### PR TITLE
Implement textDocument/documentSymbol

### DIFF
--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -201,6 +201,16 @@ func (h *LangHandler) Handle(ctx context.Context, conn JSONRPC2Conn, req *jsonrp
 		}
 		return h.handleTextDocumentReferences(ctx, conn, req, params)
 
+	case "textDocument/documentSymbol":
+		if req.Params == nil {
+			return nil, &jsonrpc2.Error{Code: jsonrpc2.CodeInvalidParams}
+		}
+		var params lsp.DocumentSymbolParams
+		if err := json.Unmarshal(*req.Params, &params); err != nil {
+			return nil, err
+		}
+		return h.handleTextDocumentSymbol(ctx, conn, req, params)
+
 	case "workspace/symbol":
 		if req.Params == nil {
 			return nil, &jsonrpc2.Error{Code: jsonrpc2.CodeInvalidParams}
@@ -209,7 +219,7 @@ func (h *LangHandler) Handle(ctx context.Context, conn JSONRPC2Conn, req *jsonrp
 		if err := json.Unmarshal(*req.Params, &params); err != nil {
 			return nil, err
 		}
-		return h.handleSymbol(ctx, conn, req, params)
+		return h.handleWorkspaceSymbol(ctx, conn, req, params)
 
 	case "workspace/reference":
 		if req.Params == nil {

--- a/langserver/integration_test.go
+++ b/langserver/integration_test.go
@@ -69,7 +69,7 @@ func TestIntegration_FileSystem(t *testing.T) {
 		"b.go:1:20":    "func A()",
 		"p2/c.go:1:40": "func A()",
 	}
-	lspTests(t, ctx, conn, rootPath, wantHover, nil, nil, nil, nil)
+	lspTests(t, ctx, conn, rootPath, wantHover, nil, nil, nil, nil, nil)
 
 	// Now mimic what happens when a file is edited but not yet
 	// saved. It should re-typecheck using the unsaved file contents.
@@ -86,5 +86,5 @@ func TestIntegration_FileSystem(t *testing.T) {
 		"b.go:1:20":    "func A() int",
 		"p2/c.go:1:40": "func A() int",
 	}
-	lspTests(t, ctx, conn, rootPath, wantHover, nil, nil, nil, nil)
+	lspTests(t, ctx, conn, rootPath, wantHover, nil, nil, nil, nil, nil)
 }

--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -28,6 +28,7 @@ func TestServer(t *testing.T) {
 		wantHover               map[string]string
 		wantDefinition          map[string]string
 		wantReferences          map[string][]string
+		wantSymbols             map[string][]string
 		wantWorkspaceSymbols    map[string][]string
 		wantWorkspaceReferences []string
 		mountFS                 map[string]map[string]string // mount dir -> map VFS
@@ -69,6 +70,10 @@ func TestServer(t *testing.T) {
 					"/src/test/pkg/b.go:1:23",
 				},
 			},
+			wantSymbols: map[string][]string{
+				"a.go": []string{"/src/test/pkg/a.go:function:pkg.A:1:17"},
+				"b.go": []string{"/src/test/pkg/b.go:function:pkg.B:1:17"},
+			},
 			wantWorkspaceSymbols: map[string][]string{
 				"":            []string{"/src/test/pkg/a.go:function:pkg.A:1:17", "/src/test/pkg/b.go:function:pkg.B:1:17"},
 				"A":           []string{"/src/test/pkg/a.go:function:pkg.A:1:17"},
@@ -87,6 +92,9 @@ func TestServer(t *testing.T) {
 				"a.go:1:28": "struct field F string",
 				"a.go:1:17": "type T struct",
 			},
+			wantSymbols: map[string][]string{
+				"a.go": []string{"/src/test/pkg/a.go:class:pkg.T:1:17"},
+			},
 			wantWorkspaceSymbols: map[string][]string{
 				"":            []string{"/src/test/pkg/a.go:class:pkg.T:1:17"},
 				"T":           []string{"/src/test/pkg/a.go:class:pkg.T:1:17"},
@@ -99,6 +107,9 @@ func TestServer(t *testing.T) {
 			rootPath: "file:///src/test/pkg",
 			fs: map[string]string{
 				"a.go": "package p; type t struct { F string }",
+			},
+			wantSymbols: map[string][]string{
+				"a.go": []string{"/src/test/pkg/a.go:class:pkg.t:1:17"},
 			},
 			wantWorkspaceSymbols: map[string][]string{
 				"is:exported": []string{},
@@ -138,6 +149,10 @@ func TestServer(t *testing.T) {
 				"d2/b.go:1:47": "/src/test/pkg/d/a.go:1:17",
 				"d2/b.go:1:52": "/src/test/pkg/d/d2/b.go:1:39",
 			},
+			wantSymbols: map[string][]string{
+				"a.go":    []string{"/src/test/pkg/d/a.go:function:d.A:1:17"},
+				"d2/b.go": []string{"/src/test/pkg/d/d2/b.go:function:d2.B:1:39"},
+			},
 			wantWorkspaceSymbols: map[string][]string{
 				"":            []string{"/src/test/pkg/d/a.go:function:d.A:1:17", "/src/test/pkg/d/d2/b.go:function:d2.B:1:39"},
 				"is:exported": []string{"/src/test/pkg/d/a.go:function:d.A:1:17", "/src/test/pkg/d/d2/b.go:function:d2.B:1:39"},
@@ -170,6 +185,9 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				// "main.go:3:47": "/src/test/pkg/a.go:1:17",    // p.A() -> a.go func A()
 				// "main.go:3:52": "/src/test/pkg/main.go:3:39", // B() -> func B()
 			},
+			wantSymbols: map[string][]string{
+				"a.go": []string{"/src/test/pkg/a.go:function:pkg.A:1:17"},
+			},
 			wantWorkspaceSymbols: map[string][]string{
 				"":            []string{"/src/test/pkg/a.go:function:pkg.A:1:17"},
 				"is:exported": []string{"/src/test/pkg/a.go:function:pkg.A:1:17"},
@@ -194,6 +212,13 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 					"src/fmt/print.go":       "package fmt; func Println(a ...interface{}) (n int, err error) { return }",
 					"src/builtin/builtin.go": "package builtin; type int int",
 				},
+			},
+			wantSymbols: map[string][]string{
+				"a.go": []string{
+					"/src/test/pkg/a.go:variable:pkg._:1:26",
+					"/src/test/pkg/a.go:variable:pkg.x:1:47",
+				},
+				"": []string{},
 			},
 			wantWorkspaceSymbols: map[string][]string{
 				"": []string{
@@ -233,6 +258,10 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 					"/src/test/pkg/b/b.go:1:43",
 				},
 			},
+			wantSymbols: map[string][]string{
+				"a/a.go": []string{"/src/test/pkg/a/a.go:function:a.A:1:17"},
+				"b/b.go": []string{"/src/test/pkg/b/b.go:variable:b._:1:33"},
+			},
 			wantWorkspaceSymbols: map[string][]string{
 				"":            []string{"/src/test/pkg/a/a.go:function:a.A:1:17", "/src/test/pkg/b/b.go:variable:b._:1:33"},
 				"is:exported": []string{"/src/test/pkg/a/a.go:function:a.A:1:17"},
@@ -257,6 +286,10 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 					"/src/test/pkg/a.go:1:61",
 				},
 			},
+			wantSymbols: map[string][]string{
+				"a.go": []string{"/src/test/pkg/a.go:variable:pkg._:1:44"},
+				"vendor/github.com/v/vendored/v.go": []string{"/src/test/pkg/vendor/github.com/v/vendored/v.go:function:vendored.V:1:24"},
+			},
 			wantWorkspaceSymbols: map[string][]string{
 				"":            []string{"/src/test/pkg/a.go:variable:pkg._:1:44", "/src/test/pkg/vendor/github.com/v/vendored/v.go:function:vendored.V:1:24"},
 				"is:exported": []string{},
@@ -269,6 +302,11 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				"z.go": `package pkg; func x() bool { return true }`,
 				"vendor/github.com/a/pkg2/x.go": `package pkg2; func x() bool { return true }`,
 				"vendor/github.com/x/pkg3/x.go": `package pkg3; func x() bool { return true }`,
+			},
+			wantSymbols: map[string][]string{
+				"z.go": []string{"/src/test/pkg/z.go:function:pkg.x:1:19"},
+				"vendor/github.com/a/pkg2/x.go": []string{"/src/test/pkg/vendor/github.com/a/pkg2/x.go:function:pkg2.x:1:20"},
+				"vendor/github.com/x/pkg3/x.go": []string{"/src/test/pkg/vendor/github.com/x/pkg3/x.go:function:pkg3.x:1:20"},
 			},
 			wantWorkspaceSymbols: map[string][]string{
 				"": []string{
@@ -414,6 +452,11 @@ func (y YZA) BCD() {}
 func yza() {}
 `,
 			},
+			wantSymbols: map[string][]string{
+				"abc.go": []string{"/src/test/pkg/abc.go:method:XYZ.ABC:5:14", "/src/test/pkg/abc.go:class:pkg.XYZ:3:6"},
+				"bcd.go": []string{"/src/test/pkg/bcd.go:method:YZA.BCD:5:14", "/src/test/pkg/bcd.go:class:pkg.YZA:3:6"},
+				"xyz.go": []string{"/src/test/pkg/xyz.go:function:pkg.yza:3:6"},
+			},
 			wantWorkspaceSymbols: map[string][]string{
 				"":            []string{"/src/test/pkg/abc.go:method:XYZ.ABC:5:14", "/src/test/pkg/bcd.go:method:YZA.BCD:5:14", "/src/test/pkg/abc.go:class:pkg.XYZ:3:6", "/src/test/pkg/bcd.go:class:pkg.YZA:3:6", "/src/test/pkg/xyz.go:function:pkg.yza:3:6"},
 				"xyz":         []string{"/src/test/pkg/abc.go:class:pkg.XYZ:3:6", "/src/test/pkg/abc.go:method:XYZ.ABC:5:14", "/src/test/pkg/xyz.go:function:pkg.yza:3:6"},
@@ -523,7 +566,7 @@ type Header struct {
 				h.FS.Bind(mountDir, mapFS(fs), "/", ctxvfs.BindAfter)
 			}
 
-			lspTests(t, ctx, conn, rootFSPath, test.wantHover, test.wantDefinition, test.wantReferences, test.wantWorkspaceSymbols, test.wantWorkspaceReferences)
+			lspTests(t, ctx, conn, rootFSPath, test.wantHover, test.wantDefinition, test.wantReferences, test.wantSymbols, test.wantWorkspaceSymbols, test.wantWorkspaceReferences)
 		})
 	}
 }
@@ -563,7 +606,7 @@ func dialServer(t testing.TB, addr string) *jsonrpc2.Conn {
 }
 
 // lspTests runs all test suites for LSP functionality.
-func lspTests(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, rootPath string, wantHover, wantDefinition map[string]string, wantReferences, wantWorkspaceSymbols map[string][]string, wantWorkspaceReferences []string) {
+func lspTests(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, rootPath string, wantHover, wantDefinition map[string]string, wantReferences, wantSymbols, wantWorkspaceSymbols map[string][]string, wantWorkspaceReferences []string) {
 	for pos, want := range wantHover {
 		tbRun(t, fmt.Sprintf("hover-%s", strings.Replace(pos, "/", "-", -1)), func(t testing.TB) {
 			hoverTest(t, ctx, c, rootPath, pos, want)
@@ -579,6 +622,12 @@ func lspTests(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, rootPath stri
 	for pos, want := range wantReferences {
 		tbRun(t, fmt.Sprintf("references-%s", pos), func(t testing.TB) {
 			referencesTest(t, ctx, c, rootPath, pos, want)
+		})
+	}
+
+	for file, want := range wantSymbols {
+		tbRun(t, fmt.Sprintf("symbols-%s", file), func(t testing.TB) {
+			symbolsTest(t, ctx, c, rootPath, file, want)
 		})
 	}
 
@@ -652,6 +701,19 @@ func referencesTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, rootPat
 	sort.Strings(want)
 	if !reflect.DeepEqual(references, want) {
 		t.Errorf("got %q, want %q", references, want)
+	}
+}
+
+func symbolsTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, rootPath string, file string, want []string) {
+	symbols, err := callSymbols(ctx, c, "file://"+path.Join(rootPath, file))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := range symbols {
+		symbols[i] = strings.TrimPrefix(symbols[i], "file://")
+	}
+	if !reflect.DeepEqual(symbols, want) {
+		t.Errorf("got %q, want %q", symbols, want)
 	}
 }
 
@@ -780,6 +842,21 @@ var symbolKindName = map[lsp.SymbolKind]string{
 	lsp.SKNumber:      "number",
 	lsp.SKBoolean:     "boolean",
 	lsp.SKArray:       "array",
+}
+
+func callSymbols(ctx context.Context, c *jsonrpc2.Conn, uri string) ([]string, error) {
+	var symbols []lsp.SymbolInformation
+	err := c.Call(ctx, "textDocument/documentSymbol", lsp.DocumentSymbolParams{
+		TextDocument: lsp.TextDocumentIdentifier{URI: uri},
+	}, &symbols)
+	if err != nil {
+		return nil, err
+	}
+	syms := make([]string, len(symbols))
+	for i, s := range symbols {
+		syms[i] = fmt.Sprintf("%s:%s:%s.%s:%d:%d", s.Location.URI, symbolKindName[s.Kind], s.ContainerName, s.Name, s.Location.Range.Start.Line+1, s.Location.Range.Start.Character+1)
+	}
+	return syms, nil
 }
 
 func callWorkspaceSymbols(ctx context.Context, c *jsonrpc2.Conn, query string) ([]string, error) {

--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -28,7 +28,7 @@ func TestServer(t *testing.T) {
 		wantHover               map[string]string
 		wantDefinition          map[string]string
 		wantReferences          map[string][]string
-		wantSymbols             map[string][]string
+		wantWorkspaceSymbols    map[string][]string
 		wantWorkspaceReferences []string
 		mountFS                 map[string]map[string]string // mount dir -> map VFS
 	}{
@@ -69,7 +69,7 @@ func TestServer(t *testing.T) {
 					"/src/test/pkg/b.go:1:23",
 				},
 			},
-			wantSymbols: map[string][]string{
+			wantWorkspaceSymbols: map[string][]string{
 				"":            []string{"/src/test/pkg/a.go:function:pkg.A:1:17", "/src/test/pkg/b.go:function:pkg.B:1:17"},
 				"A":           []string{"/src/test/pkg/a.go:function:pkg.A:1:17"},
 				"B":           []string{"/src/test/pkg/b.go:function:pkg.B:1:17"},
@@ -87,7 +87,7 @@ func TestServer(t *testing.T) {
 				"a.go:1:28": "struct field F string",
 				"a.go:1:17": "type T struct",
 			},
-			wantSymbols: map[string][]string{
+			wantWorkspaceSymbols: map[string][]string{
 				"":            []string{"/src/test/pkg/a.go:class:pkg.T:1:17"},
 				"T":           []string{"/src/test/pkg/a.go:class:pkg.T:1:17"},
 				"F":           []string{}, // we don't return fields for now
@@ -100,7 +100,7 @@ func TestServer(t *testing.T) {
 			fs: map[string]string{
 				"a.go": "package p; type t struct { F string }",
 			},
-			wantSymbols: map[string][]string{
+			wantWorkspaceSymbols: map[string][]string{
 				"is:exported": []string{},
 			},
 			wantWorkspaceReferences: []string{},
@@ -138,7 +138,7 @@ func TestServer(t *testing.T) {
 				"d2/b.go:1:47": "/src/test/pkg/d/a.go:1:17",
 				"d2/b.go:1:52": "/src/test/pkg/d/d2/b.go:1:39",
 			},
-			wantSymbols: map[string][]string{
+			wantWorkspaceSymbols: map[string][]string{
 				"":            []string{"/src/test/pkg/d/a.go:function:d.A:1:17", "/src/test/pkg/d/d2/b.go:function:d2.B:1:39"},
 				"is:exported": []string{"/src/test/pkg/d/a.go:function:d.A:1:17", "/src/test/pkg/d/d2/b.go:function:d2.B:1:39"},
 			},
@@ -170,7 +170,7 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				// "main.go:3:47": "/src/test/pkg/a.go:1:17",    // p.A() -> a.go func A()
 				// "main.go:3:52": "/src/test/pkg/main.go:3:39", // B() -> func B()
 			},
-			wantSymbols: map[string][]string{
+			wantWorkspaceSymbols: map[string][]string{
 				"":            []string{"/src/test/pkg/a.go:function:pkg.A:1:17"},
 				"is:exported": []string{"/src/test/pkg/a.go:function:pkg.A:1:17"},
 			},
@@ -195,7 +195,7 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 					"src/builtin/builtin.go": "package builtin; type int int",
 				},
 			},
-			wantSymbols: map[string][]string{
+			wantWorkspaceSymbols: map[string][]string{
 				"": []string{
 					"/src/test/pkg/a.go:variable:pkg._:1:26",
 					"/src/test/pkg/a.go:variable:pkg.x:1:47",
@@ -233,7 +233,7 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 					"/src/test/pkg/b/b.go:1:43",
 				},
 			},
-			wantSymbols: map[string][]string{
+			wantWorkspaceSymbols: map[string][]string{
 				"":            []string{"/src/test/pkg/a/a.go:function:a.A:1:17", "/src/test/pkg/b/b.go:variable:b._:1:33"},
 				"is:exported": []string{"/src/test/pkg/a/a.go:function:a.A:1:17"},
 			},
@@ -257,7 +257,7 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 					"/src/test/pkg/a.go:1:61",
 				},
 			},
-			wantSymbols: map[string][]string{
+			wantWorkspaceSymbols: map[string][]string{
 				"":            []string{"/src/test/pkg/a.go:variable:pkg._:1:44", "/src/test/pkg/vendor/github.com/v/vendored/v.go:function:vendored.V:1:24"},
 				"is:exported": []string{},
 			},
@@ -270,7 +270,7 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				"vendor/github.com/a/pkg2/x.go": `package pkg2; func x() bool { return true }`,
 				"vendor/github.com/x/pkg3/x.go": `package pkg3; func x() bool { return true }`,
 			},
-			wantSymbols: map[string][]string{
+			wantWorkspaceSymbols: map[string][]string{
 				"": []string{
 					"/src/test/pkg/z.go:function:pkg.x:1:19",
 					"/src/test/pkg/vendor/github.com/a/pkg2/x.go:function:pkg2.x:1:20",
@@ -414,7 +414,7 @@ func (y YZA) BCD() {}
 func yza() {}
 `,
 			},
-			wantSymbols: map[string][]string{
+			wantWorkspaceSymbols: map[string][]string{
 				"":            []string{"/src/test/pkg/abc.go:method:XYZ.ABC:5:14", "/src/test/pkg/bcd.go:method:YZA.BCD:5:14", "/src/test/pkg/abc.go:class:pkg.XYZ:3:6", "/src/test/pkg/bcd.go:class:pkg.YZA:3:6", "/src/test/pkg/xyz.go:function:pkg.yza:3:6"},
 				"xyz":         []string{"/src/test/pkg/abc.go:class:pkg.XYZ:3:6", "/src/test/pkg/abc.go:method:XYZ.ABC:5:14", "/src/test/pkg/xyz.go:function:pkg.yza:3:6"},
 				"yza":         []string{"/src/test/pkg/bcd.go:class:pkg.YZA:3:6", "/src/test/pkg/xyz.go:function:pkg.yza:3:6", "/src/test/pkg/bcd.go:method:YZA.BCD:5:14"},
@@ -523,7 +523,7 @@ type Header struct {
 				h.FS.Bind(mountDir, mapFS(fs), "/", ctxvfs.BindAfter)
 			}
 
-			lspTests(t, ctx, conn, rootFSPath, test.wantHover, test.wantDefinition, test.wantReferences, test.wantSymbols, test.wantWorkspaceReferences)
+			lspTests(t, ctx, conn, rootFSPath, test.wantHover, test.wantDefinition, test.wantReferences, test.wantWorkspaceSymbols, test.wantWorkspaceReferences)
 		})
 	}
 }
@@ -563,7 +563,7 @@ func dialServer(t testing.TB, addr string) *jsonrpc2.Conn {
 }
 
 // lspTests runs all test suites for LSP functionality.
-func lspTests(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, rootPath string, wantHover, wantDefinition map[string]string, wantReferences, wantSymbols map[string][]string, wantWorkspaceReferences []string) {
+func lspTests(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, rootPath string, wantHover, wantDefinition map[string]string, wantReferences, wantWorkspaceSymbols map[string][]string, wantWorkspaceReferences []string) {
 	for pos, want := range wantHover {
 		tbRun(t, fmt.Sprintf("hover-%s", strings.Replace(pos, "/", "-", -1)), func(t testing.TB) {
 			hoverTest(t, ctx, c, rootPath, pos, want)
@@ -582,9 +582,9 @@ func lspTests(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, rootPath stri
 		})
 	}
 
-	for query, want := range wantSymbols {
-		tbRun(t, fmt.Sprintf("symbols(q=%q)", query), func(t testing.TB) {
-			symbolsTest(t, ctx, c, rootPath, query, want)
+	for query, want := range wantWorkspaceSymbols {
+		tbRun(t, fmt.Sprintf("workspaceSymbols(q=%q)", query), func(t testing.TB) {
+			workspaceSymbolsTest(t, ctx, c, rootPath, query, want)
 		})
 	}
 
@@ -655,8 +655,8 @@ func referencesTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, rootPat
 	}
 }
 
-func symbolsTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, rootPath string, query string, want []string) {
-	symbols, err := callSymbols(ctx, c, query)
+func workspaceSymbolsTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, rootPath string, query string, want []string) {
+	symbols, err := callWorkspaceSymbols(ctx, c, query)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -782,7 +782,7 @@ var symbolKindName = map[lsp.SymbolKind]string{
 	lsp.SKArray:       "array",
 }
 
-func callSymbols(ctx context.Context, c *jsonrpc2.Conn, query string) ([]string, error) {
+func callWorkspaceSymbols(ctx context.Context, c *jsonrpc2.Conn, query string) ([]string, error) {
 	var symbols []lsp.SymbolInformation
 	err := c.Call(ctx, "workspace/symbol", lsp.WorkspaceSymbolParams{Query: query}, &symbols)
 	if err != nil {


### PR DESCRIPTION
`textDocument/documentSymbol` is a part of the LSP (https://github.com/sourcegraph/language-server-protocol/blob/master/protocol.md#document-symbols-request).

In particular, it is useful to us because of its similarity to `workspace/symbol` except restricted to a single file ('document'). This means that e.g. when redirecting from a code file's position -> def landing page we only have to ask for a single file's symbols in order to find the symbol's `Name, ContainerName` pair which identify it instead of every symbol in the workspace (in our case, repository). It's worth adding because, for large workspaces, it can change the time taken from ~15s -> 1s or so to perform this operation.