### PR TITLE
Use build.Default's ReleaseTags if we override

### DIFF
--- a/langserver/build_context.go
+++ b/langserver/build_context.go
@@ -26,6 +26,10 @@ func (h *LangHandler) defaultBuildContext() *build.Context {
 			UseAllFiles: override.UseAllFiles,
 			Compiler:    override.Compiler,
 			BuildTags:   override.BuildTags,
+
+			// Enable analysis of all go version build tags that
+			// our compiler should understand.
+			ReleaseTags: build.Default.ReleaseTags,
 		}
 	}
 	return bctx


### PR DESCRIPTION
It doesn't really make sense to override the release tags, and adding them in
allows us to analyse files with go version build tags. An example of a hover
that failed is at
https://sourcegraph.com/github.com/sourcegraph/go-langserver@08f9683e4a0dbacf97baaa6f4c0db1c685d7d86b/-/blob/langserver/loader.go#L232:2
It failed since loader.Config is behind a build tag. After this change it works.

Fixes https://github.com/sourcegraph/sourcegraph/issues/2036