### PR TITLE
Fix def range

### DIFF
--- a/langserver/definition.go
+++ b/langserver/definition.go
@@ -40,5 +40,11 @@ func (h *LangHandler) handleDefinition(ctx context.Context, conn JSONRPC2Conn, r
 	if len(nodes) == 0 {
 		return nil, errors.New("definition not found")
 	}
-	return goRangesToLSPLocations(fset, nodes), nil
+	locs := goRangesToLSPLocations(fset, nodes)
+	for i := range locs {
+		// LSP expects a range to be of the entire body, not just of the
+		// identifier, so we pretend its just a position and not a range.
+		locs[i].Range.End = locs[i].Range.Start
+	}
+	return locs, nil
 }


### PR DESCRIPTION
Update def range to be a position instead of a range. This fixes a bug
where a hover tooltip would only show one line when pressing cmd/ctrl,
instead of the entire definition.

This is the behavior of the most popular Go language server.