### PR TITLE
langserver: significantly reduce the amount of typechecking for workspace/reference

### DIFF
--- a/langserver/loader.go
+++ b/langserver/loader.go
@@ -286,20 +286,26 @@ func typecheck(fset *token.FileSet, bctx *build.Context, bpkg *build.Package) (*
 	if err != nil && prog == nil {
 		return nil, nil, err
 	}
+	diag, err := typecheckErrorDiagnostics(typeErrs)
+	if err != nil {
+		return nil, nil, err
+	}
+	return prog, diag, nil
+}
 
+func typecheckErrorDiagnostics(errs []error) (diagnostics, error) {
 	var diags diagnostics
-	for _, e := range typeErrs {
+	for _, e := range errs {
 		if diags == nil {
 			diags = diagnostics{}
 		}
 		filename, diag, err := parseLoaderError(e.Error())
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 		diags[filename] = append(diags[filename], diag)
 	}
-
-	return prog, diags, nil
+	return diags, nil
 }
 
 func clearInfoFields(info *loader.PackageInfo) {

--- a/langserver/util.go
+++ b/langserver/util.go
@@ -26,3 +26,8 @@ func PathTrimPrefix(s, prefix string) string {
 func pathEqual(a, b string) bool {
 	return PathTrimPrefix(a, b) == ""
 }
+
+// IsVendorDir tells if the specified directory is a vendor directory.
+func IsVendorDir(dir string) bool {
+	return strings.HasPrefix(dir, "vendor/") || strings.Contains(dir, "/vendor/")
+}


### PR DESCRIPTION
Prior to this change `workspace/reference` would individually typecheck each package
in the workspace that it intended to list external references for. This meant that
e.g. if a workspace had two packages `pkg/a` and `pkg/b` which both use `net/http`
that `net/http` and all of it's dependencies would have to be typechecked twice (once
for each input package, respectively).

After this change, we no longer cache typechecking results for workspace/reference
(in fact, it is not entirely useful to cache them due to workspace/reference being
a bad indicator of real direct user-initiated queries) and instead typecheck all
packages we intend to list external references of, together. This means that in the
prior example, `net/http` and it's dependencies will only be typechecked once. This
is possible because `go/loader.Config.Import` is smart enough to reuse existing
dependency typecheckign results.

The end effect is that a large repository like e.g. kubernetes has a quite large
perf gain in terms of `workspace/reference` typechecking, going from many minutes
(15+ before I killed it) to just 9-10s.