### PR TITLE
langserver: properly make workspace/symbol `dir:` filter operate on directory

### DIFF
--- a/langserver/symbol.go
+++ b/langserver/symbol.go
@@ -23,18 +23,18 @@ import (
 	"github.com/sourcegraph/jsonrpc2"
 )
 
-// query is a structured representation that is parsed from the user's
+// Query is a structured representation that is parsed from the user's
 // raw query string.
-type query struct {
-	kind      lsp.SymbolKind
-	filter    filterType
-	file, dir string
-	tokens    []string
+type Query struct {
+	Kind      lsp.SymbolKind
+	Filter    FilterType
+	File, Dir string
+	Tokens    []string
 }
 
-// parseQuery parses a user's raw query string and returns a
+// ParseQuery parses a user's raw query string and returns a
 // structured representation of the query.
-func parseQuery(q string) (qu query) {
+func ParseQuery(q string) (qu Query) {
 	// All queries are case insensitive.
 	q = strings.ToLower(q)
 
@@ -42,12 +42,12 @@ func parseQuery(q string) (qu query) {
 	for _, field := range strings.Fields(q) {
 		// Check if the field is a filter like `is:exported`.
 		if strings.HasPrefix(field, "dir:") {
-			qu.filter = filterDir
-			qu.dir = strings.TrimPrefix(field, "dir:")
+			qu.Filter = FilterDir
+			qu.Dir = strings.TrimPrefix(field, "dir:")
 			continue
 		}
 		if field == "is:exported" {
-			qu.filter = filterExported
+			qu.Filter = FilterExported
 			continue
 		}
 
@@ -57,20 +57,20 @@ func parseQuery(q string) (qu query) {
 		})
 		for _, tok := range tokens {
 			if kind, isKeyword := keywords[tok]; isKeyword {
-				qu.kind = kind
+				qu.Kind = kind
 				continue
 			}
-			qu.tokens = append(qu.tokens, tok)
+			qu.Tokens = append(qu.Tokens, tok)
 		}
 	}
 	return qu
 }
 
-type filterType string
+type FilterType string
 
 const (
-	filterExported filterType = "exported"
-	filterDir      filterType = "dir"
+	FilterExported FilterType = "exported"
+	FilterDir      FilterType = "dir"
 )
 
 // keywords are keyword tokens that will be interpreted as symbol kind
@@ -88,7 +88,7 @@ var keywords = map[string]lsp.SymbolKind{
 // resultSorter is a utility struct for collecting, filtering, and
 // sorting symbol results.
 type resultSorter struct {
-	query
+	Query
 	results   []scoredSymbol
 	resultsMu sync.Mutex
 }
@@ -125,7 +125,7 @@ func (s *resultSorter) Swap(i, j int) {
 // symbol in the list of results if its score > 0.
 func (s *resultSorter) Collect(si lsp.SymbolInformation) {
 	s.resultsMu.Lock()
-	score := score(s.query, si)
+	score := score(s.Query, si)
 	if score > 0 {
 		sc := scoredSymbol{score, si}
 		s.results = append(s.results, sc)
@@ -144,31 +144,31 @@ func (s *resultSorter) Results() []lsp.SymbolInformation {
 
 // score returns 0 for results that aren't matches. Results that are matches are assigned
 // a positive score, which should be used for ranking purposes.
-func score(q query, s lsp.SymbolInformation) (scor int) {
-	if q.kind != 0 {
-		if q.kind != s.Kind {
+func score(q Query, s lsp.SymbolInformation) (scor int) {
+	if q.Kind != 0 {
+		if q.Kind != s.Kind {
 			return 0
 		}
 	}
 	name, container := strings.ToLower(s.Name), strings.ToLower(s.ContainerName)
 	filename := strings.TrimPrefix(strings.ToLower(s.Location.URI), "file://")
 	isVendor := strings.HasPrefix(filename, "vendor/") || strings.Contains(filename, "/vendor/")
-	if q.filter == filterExported && isVendor {
+	if q.Filter == FilterExported && isVendor {
 		// is:exported excludes vendor symbols always.
 		return 0
 	}
-	if q.file != "" && filename != q.file {
+	if q.File != "" && filename != q.File {
 		// We're restricting results to a single file, and this isn't it.
 		return 0
 	}
-	if len(q.tokens) == 0 { // early return if empty query
+	if len(q.Tokens) == 0 { // early return if empty query
 		if isVendor {
 			return 1 // lower score for vendor symbols
 		} else {
 			return 2
 		}
 	}
-	for i, tok := range q.tokens {
+	for i, tok := range q.Tokens {
 		tok := strings.ToLower(tok)
 		if strings.HasPrefix(container, tok) {
 			scor += 2
@@ -183,7 +183,7 @@ func score(q query, s lsp.SymbolInformation) (scor int) {
 			scor += 2
 		}
 		if tok == name {
-			if i == len(q.tokens)-1 {
+			if i == len(q.Tokens)-1 {
 				scor += 50
 			} else {
 				scor += 5
@@ -223,21 +223,21 @@ func toSym(name, container string, kind lsp.SymbolKind, fs *token.FileSet, pos t
 // the Go language server.
 func (h *LangHandler) handleTextDocumentSymbol(ctx context.Context, conn JSONRPC2Conn, req *jsonrpc2.Request, params lsp.DocumentSymbolParams) ([]lsp.SymbolInformation, error) {
 	f := strings.TrimPrefix(params.TextDocument.URI, "file://")
-	return h.handleSymbol(ctx, conn, req, query{file: f}, 0)
+	return h.handleSymbol(ctx, conn, req, Query{File: f}, 0)
 }
 
 // handleSymbol handles `workspace/symbol` requests for the Go
 // language server.
 func (h *LangHandler) handleWorkspaceSymbol(ctx context.Context, conn JSONRPC2Conn, req *jsonrpc2.Request, params lsp.WorkspaceSymbolParams) ([]lsp.SymbolInformation, error) {
-	q := parseQuery(params.Query)
-	if q.filter == filterDir {
-		q.dir = path.Join(h.init.RootImportPath, q.dir)
+	q := ParseQuery(params.Query)
+	if q.Filter == FilterDir {
+		q.Dir = path.Join(h.init.RootImportPath, q.Dir)
 	}
 	return h.handleSymbol(ctx, conn, req, q, params.Limit)
 }
 
-func (h *LangHandler) handleSymbol(ctx context.Context, conn JSONRPC2Conn, req *jsonrpc2.Request, query query, limit int) ([]lsp.SymbolInformation, error) {
-	results := resultSorter{query: query, results: make([]scoredSymbol, 0)}
+func (h *LangHandler) handleSymbol(ctx context.Context, conn JSONRPC2Conn, req *jsonrpc2.Request, query Query, limit int) ([]lsp.SymbolInformation, error) {
+	results := resultSorter{Query: query, results: make([]scoredSymbol, 0)}
 	{
 		fs := token.NewFileSet()
 		rootPath := h.FilePath(h.init.RootPath)
@@ -257,8 +257,8 @@ func (h *LangHandler) handleSymbol(ctx context.Context, conn JSONRPC2Conn, req *
 		for pkg := range pkgs {
 			// If we're restricting results to a single file or dir, ensure the
 			// package dir matches to avoid doing unnecessary work.
-			if results.query.file != "" {
-				filePkgPath := path.Dir(results.query.file)
+			if results.Query.File != "" {
+				filePkgPath := path.Dir(results.Query.File)
 				if PathHasPrefix(filePkgPath, h.init.BuildContext.GOROOT) {
 					filePkgPath = PathTrimPrefix(filePkgPath, h.init.BuildContext.GOROOT)
 				} else {
@@ -269,7 +269,7 @@ func (h *LangHandler) handleSymbol(ctx context.Context, conn JSONRPC2Conn, req *
 					continue
 				}
 			}
-			if results.query.filter == filterDir && !pathEqual(pkg, results.query.dir) {
+			if results.Query.Filter == FilterDir && !pathEqual(pkg, results.Query.Dir) {
 				continue
 			}
 
@@ -359,7 +359,7 @@ func (h *LangHandler) collectFromPkg(bctx *build.Context, fs *token.FileSet, pkg
 				pkgSyms = append(pkgSyms, toSym(v.Name, buildPkg.ImportPath, lsp.SKFunction, fs, v.Decl.Name.NamePos))
 			}
 			for _, v := range t.Methods {
-				if results.query.filter == filterExported && (!ast.IsExported(v.Name) || !ast.IsExported(t.Name)) {
+				if results.Query.Filter == FilterExported && (!ast.IsExported(v.Name) || !ast.IsExported(t.Name)) {
 					continue
 				}
 				pkgSyms = append(pkgSyms, toSym(v.Name, buildPkg.ImportPath+" "+t.Name, lsp.SKMethod, fs, v.Decl.Name.NamePos))
@@ -392,7 +392,7 @@ func (h *LangHandler) collectFromPkg(bctx *build.Context, fs *token.FileSet, pkg
 	}
 
 	for _, sym := range pkgSyms {
-		if results.query.filter == filterExported && !ast.IsExported(sym.Name) {
+		if results.Query.Filter == FilterExported && !ast.IsExported(sym.Name) {
 			continue
 		}
 		results.Collect(sym)

--- a/langserver/symbol.go
+++ b/langserver/symbol.go
@@ -328,9 +328,7 @@ func (h *LangHandler) collectFromPkg(bctx *build.Context, fs *token.FileSet, pkg
 	if pkgSyms == nil {
 		buildPkg, err := bctx.Import(pkg, rootPath, 0)
 		if err != nil {
-			if !(strings.Contains(err.Error(), "no buildable Go source files") || strings.Contains(err.Error(), "found packages") || strings.HasPrefix(pkg, "github.com/golang/go/test/")) {
-				log.Printf("skipping possible package %s: %s", pkg, err)
-			}
+			maybeLogImportError(pkg, err)
 			return
 		}
 
@@ -431,4 +429,11 @@ func parseDir(fset *token.FileSet, bctx *build.Context, path string, filter func
 	}
 
 	return
+}
+
+func maybeLogImportError(pkg string, err error) {
+	_, isNoGoError := err.(*build.NoGoError)
+	if !(isNoGoError || !isMultiplePackageError(err) || strings.HasPrefix(pkg, "github.com/golang/go/test/")) {
+		log.Printf("skipping possible package %s: %s", pkg, err)
+	}
 }

--- a/langserver/symbol_test.go
+++ b/langserver/symbol_test.go
@@ -125,3 +125,33 @@ func Test_resultSorter(t *testing.T) {
 		}
 	}
 }
+
+func TestQueryString(t *testing.T) {
+	tests := []struct {
+		input, expect string
+	}{
+		// Basic queries.
+		{input: "foo bar", expect: "foo bar"},
+		{input: "func bar", expect: "func bar"},
+		{input: "is:exported", expect: "is:exported"},
+		{input: "dir:foo", expect: "dir:foo"},
+		{input: "is:exported bar", expect: "is:exported bar"},
+		{input: "dir:foo bar", expect: "dir:foo bar"},
+		{input: "is:exported bar baz", expect: "is:exported bar baz"},
+		{input: "dir:foo bar baz", expect: "dir:foo bar baz"},
+
+		// Test guarantee of byte-wise ordering (hint: we only guarantee logical
+		// equivalence, not byte-wise equality).
+		{input: "bar baz is:exported", expect: "is:exported bar baz"},
+		{input: "bar baz dir:foo", expect: "dir:foo bar baz"},
+		{input: "func baz dir:foo", expect: "dir:foo func baz"},
+	}
+	for _, test := range tests {
+		t.Run(test.input, func(t *testing.T) {
+			got := ParseQuery(test.input).String()
+			if got != test.expect {
+				t.Errorf("got %q, expect %q", got, test.expect)
+			}
+		})
+	}
+}

--- a/langserver/symbol_test.go
+++ b/langserver/symbol_test.go
@@ -115,7 +115,7 @@ func Test_resultSorter(t *testing.T) {
 	}}
 
 	for _, test := range tests {
-		results := resultSorter{query: parseQuery(test.rawQuery)}
+		results := resultSorter{Query: ParseQuery(test.rawQuery)}
 		for _, s := range test.allSymbols {
 			results.Collect(s)
 		}


### PR DESCRIPTION
https://github.com/sourcegraph/go-langserver/pull/28 incorrectly tried to apply a fix that would make `workspace/symbol` with `dir:src/net/http` for github.com/golang/go work. The reason it was incorrect, was that it was special casing handling of that repository (effectively) inside the language server, here. This became apparent as I tried to add a proper test for this case.

The more correct fix is to handle this in our build server layer. This PR includes minor code cleanup, and exposing our workspace/symbol query parsing mechanisms in order to support fixing this in our build server by rewriting the `dir:` filter portion of queries.