### PR TITLE
references: Cache the reverse import graph

### DIFF
--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"sync"
 
+	"golang.org/x/tools/refactor/importgraph"
+
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 
@@ -39,6 +41,10 @@ type LangHandler struct {
 	// cached typechecking results
 	cacheMus map[typecheckKey]*sync.Mutex
 	cache    map[typecheckKey]typecheckResult
+
+	// cache the reverse import graph
+	importGraphOnce sync.Once
+	importGraph     importgraph.Graph
 }
 
 // reset clears all internal state in h.


### PR DESCRIPTION
We compute this every time we answer a references query and for large workspaces
it dominates the time. However, it is static W.R.T. the workspace. In the future
when we start doing cache invalidation, this will need to be updated.

On my machine it takes subsequent references queries from 20s to 3s.

Part of #11