### PR TITLE
refs: Order results by shared directories of query

### DIFF
--- a/langserver/references.go
+++ b/langserver/references.go
@@ -8,6 +8,7 @@ import (
 	"go/parser"
 	"go/token"
 	"go/types"
+	"path"
 	"sort"
 	"strings"
 	"sync"
@@ -158,7 +159,7 @@ func (h *LangHandler) handleTextDocumentReferences(ctx context.Context, conn JSO
 	}
 
 	locs := goRangesToLSPLocations(fset, refs)
-	sort.Sort(locationList(locs))
+	sortBySharedDirWithURI(params.TextDocument.URI, locs)
 	return locs, nil
 }
 
@@ -240,21 +241,54 @@ func sameObj(x, y types.Object) bool {
 	return false
 }
 
-type locationList []lsp.Location
+func sortBySharedDirWithURI(uri string, locs []lsp.Location) {
+	l := locationList{
+		L: locs,
+		D: make([]int, len(locs)),
+	}
+	// l.D[i] = number of shared directories between uri and l.L[i].URI
+	for i := range l.L {
+		u := l.L[i].URI
+		var d int
+		for i := 0; i < len(uri) && i < len(u) && uri[i] == u[i]; i++ {
+			if u[i] == '/' {
+				d++
+			}
+		}
+		if u == uri {
+			// Boost matches in the same uri
+			d++
+		}
+		l.D[i] = d
+	}
+	sort.Sort(l)
+}
+
+type locationList struct {
+	L []lsp.Location
+	D []int
+}
 
 func (l locationList) Less(a, b int) bool {
-	if l[a].URI != l[b].URI {
-		return l[a].URI < l[b].URI
+	if l.D[a] != l.D[b] {
+		return l.D[a] > l.D[b]
 	}
-	if l[a].Range.Start.Line != l[b].Range.Start.Line {
-		return l[a].Range.Start.Line < l[b].Range.Start.Line
+	if x, y := path.Dir(l.L[a].URI), path.Dir(l.L[b].URI); x != y {
+		return x < y
 	}
-	return l[a].Range.Start.Character < l[b].Range.Start.Character
+	if l.L[a].URI != l.L[b].URI {
+		return l.L[a].URI < l.L[b].URI
+	}
+	if l.L[a].Range.Start.Line != l.L[b].Range.Start.Line {
+		return l.L[a].Range.Start.Line < l.L[b].Range.Start.Line
+	}
+	return l.L[a].Range.Start.Character < l.L[b].Range.Start.Character
 }
 
 func (l locationList) Swap(a, b int) {
-	l[a], l[b] = l[b], l[a]
+	l.L[a], l.L[b] = l.L[b], l.L[a]
+	l.D[a], l.D[b] = l.D[b], l.D[a]
 }
 func (l locationList) Len() int {
-	return len(l)
+	return len(l.L)
 }

--- a/langserver/references_test.go
+++ b/langserver/references_test.go
@@ -1,0 +1,55 @@
+package langserver
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/sourcegraph/go-langserver/pkg/lsp"
+)
+
+func TestSortBySharedDirWithURI(t *testing.T) {
+	got := []lsp.Location{
+		lsp.Location{URI: "file:///a.go"},
+		lsp.Location{URI: "file:///a/a.go"},
+		lsp.Location{URI: "file:///a/a/a.go"},
+		lsp.Location{URI: "file:///a/a/z.go"},
+		lsp.Location{URI: "file:///a/z.go"},
+		lsp.Location{URI: "file:///a/z/a.go"},
+		lsp.Location{URI: "file:///a/z/z.go"},
+		lsp.Location{URI: "file:///z.go"},
+		lsp.Location{URI: "file:///z/a.go"},
+		lsp.Location{URI: "file:///z/a/a.go"},
+		lsp.Location{URI: "file:///z/a/z.go"},
+		lsp.Location{URI: "file:///z/z.go"},
+		lsp.Location{URI: "file:///z/z/a.go"},
+		lsp.Location{URI: "file:///z/z/z.go"},
+	}
+	uri := "file:///z/m.go"
+	want := []lsp.Location{
+		lsp.Location{URI: "file:///z/a.go"},
+		lsp.Location{URI: "file:///z/z.go"},
+		lsp.Location{URI: "file:///z/a/a.go"},
+		lsp.Location{URI: "file:///z/a/z.go"},
+		lsp.Location{URI: "file:///z/z/a.go"},
+		lsp.Location{URI: "file:///z/z/z.go"},
+		lsp.Location{URI: "file:///a.go"},
+		lsp.Location{URI: "file:///z.go"},
+		lsp.Location{URI: "file:///a/a.go"},
+		lsp.Location{URI: "file:///a/z.go"},
+		lsp.Location{URI: "file:///a/a/a.go"},
+		lsp.Location{URI: "file:///a/a/z.go"},
+		lsp.Location{URI: "file:///a/z/a.go"},
+		lsp.Location{URI: "file:///a/z/z.go"},
+	}
+	sortBySharedDirWithURI(uri, got)
+	if !reflect.DeepEqual(got, want) {
+		var gotURI, wantURI []string
+		for _, l := range got {
+			gotURI = append(gotURI, l.URI)
+		}
+		for _, l := range want {
+			wantURI = append(wantURI, l.URI)
+		}
+		t.Fatalf("got != want.\nwant: %v\ngot:  %v", wantURI, gotURI)
+	}
+}


### PR DESCRIPTION
Now references in the same package will be listed first, followed by
subpackages, then other packages. For other packages, if they share more
directories with the input than another package, it will be listed before. See
the test case for a concrete example.

Part of #11