### PR TITLE
lsp: Match InitializeParams spec

### DIFF
--- a/pkg/lsp/service.go
+++ b/pkg/lsp/service.go
@@ -9,7 +9,18 @@ type InitializeParams struct {
 	Capabilities          ClientCapabilities `json:"capabilities"`
 }
 
-type ClientCapabilities struct{}
+type ClientCapabilities struct {
+	// Below are Sourcegraph extensions. They do not live in lspext since
+	// they are extending the field InitializeParams.Capabilities
+
+	// XFilesProvider indicates the client provides support for
+	// workspace/xfiles. This is a Sourcegraph extension.
+	XFilesProvider bool `json:"xfilesProvider,omitempty"`
+
+	// XContentProvider indicates the client provides support for
+	// textDocument/xcontent. This is a Sourcegraph extension.
+	XContentProvider bool `json:"xcontentProvider,omitempty"`
+}
 
 type InitializeResult struct {
 	Capabilities ServerCapabilities `json:"capabilities,omitempty"`

--- a/pkg/lsp/service.go
+++ b/pkg/lsp/service.go
@@ -3,9 +3,10 @@ package lsp
 type None struct{}
 
 type InitializeParams struct {
-	ProcessID    int                 `json:"processId,omitempty"`
-	RootPath     string              `json:"rootPath"`
-	Capabilities *ClientCapabilities `json:"capabilities,omitempty"`
+	ProcessID             int                `json:"processId,omitempty"`
+	RootPath              string             `json:"rootPath,omitempty"`
+	InitializationOptions interface{}        `json:"initializationOptions,omitempty"`
+	Capabilities          ClientCapabilities `json:"capabilities"`
 }
 
 type ClientCapabilities struct{}


### PR DESCRIPTION
We also update ClientCapabilities to include the capabilities introduced in our extensions to the spec.