### PR TITLE
workspace/reference: improve testing + fix serious bug with multiple files

### DIFF
--- a/langserver/internal/refs/refs.go
+++ b/langserver/internal/refs/refs.go
@@ -30,12 +30,8 @@ type Ref struct {
 	// Def is the definition being referenced.
 	Def Def
 
-	// Position is the position of the reference.
-	Position token.Position
-}
-
-func (r *Ref) String() string {
-	return fmt.Sprintf("&Ref{Def.ImportPath: %q, Def.PackageName: %q, Def.Path: %q, Position: \"%s:%d:%d:%d\"}", r.Def.ImportPath, r.Def.PackageName, r.Def.Path, r.Position.Filename, r.Position.Line, r.Position.Column, r.Position.Offset)
+	// Pos is the position of the reference.
+	Pos token.Pos
 }
 
 type Config struct {
@@ -60,8 +56,8 @@ func (c *Config) Refs(emit func(*Ref)) error {
 			}
 		}
 		emit(&Ref{
-			Def:      *d,
-			Position: c.FileSet.Position(pos),
+			Def: *d,
+			Pos: pos,
 		})
 		return nil
 	}

--- a/langserver/internal/refs/refs_test.go
+++ b/langserver/internal/refs/refs_test.go
@@ -63,9 +63,13 @@ func TestParseFile(t *testing.T) {
 			Offset:   offs,
 		}
 	}
+	type posRef struct {
+		Def      Def
+		Position token.Position
+	}
 	cases := []struct {
 		Filename string
-		Want     []*Ref
+		Want     []*posRef
 	}{
 		{
 			Filename: "testdata/empty.go",
@@ -73,57 +77,57 @@ func TestParseFile(t *testing.T) {
 		},
 		{
 			Filename: "testdata/imports.go",
-			Want: []*Ref{
-				&Ref{Def: Def{ImportPath: "net/http", PackageName: "http", Path: ""}, Position: pos("testdata/imports.go:3:8 (offset 21)")},
+			Want: []*posRef{
+				&posRef{Def: Def{ImportPath: "net/http", PackageName: "http", Path: ""}, Position: pos("testdata/imports.go:3:8 (offset 21)")},
 			},
 		},
 		{
 			Filename: "testdata/unmatching-imports.go",
-			Want: []*Ref{
-				&Ref{Def: Def{ImportPath: "gopkg.in/inconshreveable/log15.v2", PackageName: "log15", Path: ""}, Position: pos("testdata/unmatching-imports.go:3:8 (offset 21)")},
-				&Ref{Def: Def{ImportPath: "gopkg.in/inconshreveable/log15.v2", PackageName: "log15", Path: "Crit"}, Position: pos("testdata/unmatching-imports.go:6:8 (offset 124)")},
+			Want: []*posRef{
+				&posRef{Def: Def{ImportPath: "gopkg.in/inconshreveable/log15.v2", PackageName: "log15", Path: ""}, Position: pos("testdata/unmatching-imports.go:3:8 (offset 21)")},
+				&posRef{Def: Def{ImportPath: "gopkg.in/inconshreveable/log15.v2", PackageName: "log15", Path: "Crit"}, Position: pos("testdata/unmatching-imports.go:6:8 (offset 124)")},
 			},
 		},
 		{
 			Filename: "testdata/http-request-headers.go",
-			Want: []*Ref{
-				&Ref{Def: Def{ImportPath: "net/http", PackageName: "http", Path: ""}, Position: pos("testdata/http-request-headers.go:4:2 (offset 24)")},
-				&Ref{Def: Def{ImportPath: "net/http", PackageName: "http", Path: "Request"}, Position: pos("testdata/http-request-headers.go:8:13 (offset 78)")},
-				&Ref{Def: Def{ImportPath: "net/http", PackageName: "http", Path: "Request Header"}, Position: pos("testdata/http-request-headers.go:9:4 (offset 113)")},
-				&Ref{Def: Def{ImportPath: "net/http", PackageName: "http", Path: "Request Header"}, Position: pos("testdata/http-request-headers.go:11:4 (offset 172)")},
+			Want: []*posRef{
+				&posRef{Def: Def{ImportPath: "net/http", PackageName: "http", Path: ""}, Position: pos("testdata/http-request-headers.go:4:2 (offset 24)")},
+				&posRef{Def: Def{ImportPath: "net/http", PackageName: "http", Path: "Request"}, Position: pos("testdata/http-request-headers.go:8:13 (offset 78)")},
+				&posRef{Def: Def{ImportPath: "net/http", PackageName: "http", Path: "Request Header"}, Position: pos("testdata/http-request-headers.go:9:4 (offset 113)")},
+				&posRef{Def: Def{ImportPath: "net/http", PackageName: "http", Path: "Request Header"}, Position: pos("testdata/http-request-headers.go:11:4 (offset 172)")},
 			},
 		},
 		{
 			Filename: "testdata/convoluted.go",
-			Want: []*Ref{
-				&Ref{Def: Def{ImportPath: "net/http", PackageName: "http", Path: ""}, Position: pos("testdata/convoluted.go:3:8 (offset 21)")},
-				&Ref{Def: Def{ImportPath: "net/http", PackageName: "http", Path: "Client"}, Position: pos("testdata/convoluted.go:6:10 (offset 84)")},
-				&Ref{Def: Def{ImportPath: "net/http", PackageName: "http", Path: "RoundTripper RoundTrip"}, Position: pos("testdata/convoluted.go:15:14 (offset 188)")},
-				&Ref{Def: Def{ImportPath: "net/http", PackageName: "http", Path: "Client Transport"}, Position: pos("testdata/convoluted.go:15:4 (offset 178)")},
-				&Ref{Def: Def{ImportPath: "net/http", PackageName: "http", Path: "RoundTripper RoundTrip"}, Position: pos("testdata/convoluted.go:19:25 (offset 310)")},
-				&Ref{Def: Def{ImportPath: "net/http", PackageName: "http", Path: "Client Transport"}, Position: pos("testdata/convoluted.go:19:15 (offset 300)")},
+			Want: []*posRef{
+				&posRef{Def: Def{ImportPath: "net/http", PackageName: "http", Path: ""}, Position: pos("testdata/convoluted.go:3:8 (offset 21)")},
+				&posRef{Def: Def{ImportPath: "net/http", PackageName: "http", Path: "Client"}, Position: pos("testdata/convoluted.go:6:10 (offset 84)")},
+				&posRef{Def: Def{ImportPath: "net/http", PackageName: "http", Path: "RoundTripper RoundTrip"}, Position: pos("testdata/convoluted.go:15:14 (offset 188)")},
+				&posRef{Def: Def{ImportPath: "net/http", PackageName: "http", Path: "Client Transport"}, Position: pos("testdata/convoluted.go:15:4 (offset 178)")},
+				&posRef{Def: Def{ImportPath: "net/http", PackageName: "http", Path: "RoundTripper RoundTrip"}, Position: pos("testdata/convoluted.go:19:25 (offset 310)")},
+				&posRef{Def: Def{ImportPath: "net/http", PackageName: "http", Path: "Client Transport"}, Position: pos("testdata/convoluted.go:19:15 (offset 300)")},
 			},
 		},
 		{
 			Filename: "testdata/defs.go",
-			Want: []*Ref{
-				&Ref{Def: Def{ImportPath: "net/http", PackageName: "http", Path: ""}, Position: pos("testdata/defs.go:3:8 (offset 21)")},
-				&Ref{Def: Def{ImportPath: "net/http", PackageName: "http", Path: "Client"}, Position: pos("testdata/defs.go:6:10 (offset 78)")},
-				&Ref{Def: Def{ImportPath: "net/http", PackageName: "http", Path: "RoundTripper"}, Position: pos("testdata/defs.go:7:9 (offset 119)")},
-				&Ref{Def: Def{ImportPath: "net/http", PackageName: "http", Path: "Client"}, Position: pos("testdata/defs.go:10:21 (offset 182)")},
-				&Ref{Def: Def{ImportPath: "net/http", PackageName: "http", Path: "Client"}, Position: pos("testdata/defs.go:12:12 (offset 246)")},
-				&Ref{Def: Def{ImportPath: "net/http", PackageName: "http", Path: "RoundTripper"}, Position: pos("testdata/defs.go:13:11 (offset 295)")},
-				&Ref{Def: Def{ImportPath: "net/http", PackageName: "http", Path: "Client"}, Position: pos("testdata/defs.go:20:13 (offset 392)")},
+			Want: []*posRef{
+				&posRef{Def: Def{ImportPath: "net/http", PackageName: "http", Path: ""}, Position: pos("testdata/defs.go:3:8 (offset 21)")},
+				&posRef{Def: Def{ImportPath: "net/http", PackageName: "http", Path: "Client"}, Position: pos("testdata/defs.go:6:10 (offset 78)")},
+				&posRef{Def: Def{ImportPath: "net/http", PackageName: "http", Path: "RoundTripper"}, Position: pos("testdata/defs.go:7:9 (offset 119)")},
+				&posRef{Def: Def{ImportPath: "net/http", PackageName: "http", Path: "Client"}, Position: pos("testdata/defs.go:10:21 (offset 182)")},
+				&posRef{Def: Def{ImportPath: "net/http", PackageName: "http", Path: "Client"}, Position: pos("testdata/defs.go:12:12 (offset 246)")},
+				&posRef{Def: Def{ImportPath: "net/http", PackageName: "http", Path: "RoundTripper"}, Position: pos("testdata/defs.go:13:11 (offset 295)")},
+				&posRef{Def: Def{ImportPath: "net/http", PackageName: "http", Path: "Client"}, Position: pos("testdata/defs.go:20:13 (offset 392)")},
 			},
 		},
 		{
 			Filename: "testdata/vars.go",
-			Want: []*Ref{
-				&Ref{Def: Def{ImportPath: "net/http", PackageName: "http", Path: ""}, Position: pos("testdata/vars.go:3:8 (offset 21)")},
-				&Ref{Def: Def{ImportPath: "net/http", PackageName: "http", Path: "Client"}, Position: pos("testdata/vars.go:6:14 (offset 74)")},
-				&Ref{Def: Def{ImportPath: "net/http", PackageName: "http", Path: "RoundTripper"}, Position: pos("testdata/vars.go:8:12 (offset 124)")},
-				&Ref{Def: Def{ImportPath: "net/http", PackageName: "http", Path: "Client Transport"}, Position: pos("testdata/vars.go:12:3 (offset 225)")},
-				&Ref{Def: Def{ImportPath: "net/http", PackageName: "http", Path: "Client"}, Position: pos("testdata/vars.go:11:12 (offset 194)")},
+			Want: []*posRef{
+				&posRef{Def: Def{ImportPath: "net/http", PackageName: "http", Path: ""}, Position: pos("testdata/vars.go:3:8 (offset 21)")},
+				&posRef{Def: Def{ImportPath: "net/http", PackageName: "http", Path: "Client"}, Position: pos("testdata/vars.go:6:14 (offset 74)")},
+				&posRef{Def: Def{ImportPath: "net/http", PackageName: "http", Path: "RoundTripper"}, Position: pos("testdata/vars.go:8:12 (offset 124)")},
+				&posRef{Def: Def{ImportPath: "net/http", PackageName: "http", Path: "Client Transport"}, Position: pos("testdata/vars.go:12:3 (offset 225)")},
+				&posRef{Def: Def{ImportPath: "net/http", PackageName: "http", Path: "Client"}, Position: pos("testdata/vars.go:11:12 (offset 194)")},
 			},
 		},
 	}
@@ -139,9 +143,12 @@ func TestParseFile(t *testing.T) {
 				t.Fatal(err)
 			}
 			cfg := testConfig(fs, "refstest", []*ast.File{astFile})
-			var allRefs []*Ref
+			var allRefs []*posRef
 			err = cfg.Refs(func(r *Ref) {
-				allRefs = append(allRefs, r)
+				allRefs = append(allRefs, &posRef{
+					Def:      r.Def,
+					Position: fs.Position(r.Pos),
+				})
 			})
 			if err != nil {
 				t.Fatal(err)

--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -748,7 +748,7 @@ func workspaceReferencesTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn
 		t.Fatal(err)
 	}
 	if !reflect.DeepEqual(references, want) {
-		t.Errorf("got %#v, want %q", references, want)
+		t.Errorf("\ngot  %q\nwant %q", references, want)
 	}
 }
 

--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -239,8 +239,8 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 			},
 			wantWorkspaceReferences: []string{
 				// TODO: bug: our end locations are invalid (the commented lines are correct).
-				"/src/test/pkg/a.go:1:18-1:17 -> /goroot/src/fmt fmt/<none>",
-				"/src/test/pkg/a.go:1:37-1:43 -> /goroot/src/fmt fmt/Println",
+				"/src/test/pkg/a.go:1:19-1:17 -> /goroot/src/fmt fmt/<none>",
+				"/src/test/pkg/a.go:1:38-1:43 -> /goroot/src/fmt fmt/Println",
 			},
 		},
 		"gopath": {
@@ -366,9 +366,9 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 			},
 			wantWorkspaceReferences: []string{
 				// TODO: bug: our end locations are invalid (the commented lines are correct).
-				"/src/test/pkg/a.go:1:18-1:17 -> /src/github.com/d/dep dep/<none>",
-				"/src/test/pkg/a.go:1:50-1:50 -> /src/github.com/d/dep dep/D",
-				"/src/test/pkg/a.go:1:65-1:65 -> /src/github.com/d/dep dep/D",
+				"/src/test/pkg/a.go:1:19-1:17 -> /src/github.com/d/dep dep/<none>",
+				"/src/test/pkg/a.go:1:51-1:50 -> /src/github.com/d/dep dep/D",
+				"/src/test/pkg/a.go:1:66-1:65 -> /src/github.com/d/dep dep/D",
 			},
 			mountFS: map[string]map[string]string{
 				"/src/github.com/d/dep": {
@@ -386,9 +386,9 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 			},
 			wantWorkspaceReferences: []string{
 				// TODO: bug: our end locations are invalid (the commented lines are correct).
-				"/src/test/pkg/a.go:1:18-1:17 -> /src/github.com/d/dep dep/<none>",
-				"/src/test/pkg/a.go:1:54-1:54 -> /src/github.com/d/dep/vendor/vendp F/V",
-				"/src/test/pkg/a.go:1:50-1:50 -> /src/github.com/d/dep dep/D",
+				"/src/test/pkg/a.go:1:19-1:17 -> /src/github.com/d/dep dep/<none>",
+				"/src/test/pkg/a.go:1:55-1:54 -> /src/github.com/d/dep/vendor/vendp F/V",
+				"/src/test/pkg/a.go:1:51-1:50 -> /src/github.com/d/dep dep/D",
 			},
 			mountFS: map[string]map[string]string{
 				"/src/github.com/d/dep": map[string]string{
@@ -410,8 +410,8 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 			},
 			wantWorkspaceReferences: []string{
 				// TODO: bug: our end locations are invalid (the commented lines are correct).
-				"/src/test/pkg/a.go:1:18-1:17 -> /src/github.com/d/dep/subp subp/<none>",
-				"/src/test/pkg/a.go:1:56-1:56 -> /src/github.com/d/dep/subp subp/D",
+				"/src/test/pkg/a.go:1:19-1:17 -> /src/github.com/d/dep/subp subp/<none>",
+				"/src/test/pkg/a.go:1:57-1:56 -> /src/github.com/d/dep/subp subp/D",
 			},
 			mountFS: map[string]map[string]string{
 				"/src/github.com/d/dep": {
@@ -434,9 +434,9 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 			},
 			wantWorkspaceReferences: []string{
 				// TODO: bug: our end locations are invalid (the commented lines are correct).
-				"/src/test/pkg/a.go:1:18-1:17 -> /src/github.com/d/dep1 dep1/<none>",
-				"/src/test/pkg/a.go:1:57-1:58 -> /src/github.com/d/dep2 D2/D2",
-				"/src/test/pkg/a.go:1:52-1:53 -> /src/github.com/d/dep1 dep1/D1",
+				"/src/test/pkg/a.go:1:19-1:17 -> /src/github.com/d/dep1 dep1/<none>",
+				"/src/test/pkg/a.go:1:58-1:58 -> /src/github.com/d/dep2 D2/D2",
+				"/src/test/pkg/a.go:1:53-1:53 -> /src/github.com/d/dep1 dep1/D1",
 			},
 			mountFS: map[string]map[string]string{
 				"/src/github.com/d/dep1": {

--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -238,8 +238,9 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				"is:exported": []string{},
 			},
 			wantWorkspaceReferences: []string{
-				"/src/test/pkg/a.go:1:18 -> /goroot/src/fmt fmt/<none>",
-				"/src/test/pkg/a.go:1:37 -> /goroot/src/fmt fmt/Println",
+				// TODO: bug: our end locations are invalid (the commented lines are correct).
+				"/src/test/pkg/a.go:1:18-1:17 -> /goroot/src/fmt fmt/<none>",
+				"/src/test/pkg/a.go:1:37-1:43 -> /goroot/src/fmt fmt/Println",
 			},
 		},
 		"gopath": {
@@ -364,9 +365,10 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				},
 			},
 			wantWorkspaceReferences: []string{
-				"/src/test/pkg/a.go:1:18 -> /src/github.com/d/dep dep/<none>",
-				"/src/test/pkg/a.go:1:50 -> /src/github.com/d/dep dep/D",
-				"/src/test/pkg/a.go:1:65 -> /src/github.com/d/dep dep/D",
+				// TODO: bug: our end locations are invalid (the commented lines are correct).
+				"/src/test/pkg/a.go:1:18-1:17 -> /src/github.com/d/dep dep/<none>",
+				"/src/test/pkg/a.go:1:50-1:50 -> /src/github.com/d/dep dep/D",
+				"/src/test/pkg/a.go:1:65-1:65 -> /src/github.com/d/dep dep/D",
 			},
 			mountFS: map[string]map[string]string{
 				"/src/github.com/d/dep": {
@@ -383,9 +385,10 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				"a.go:1:55": "/src/github.com/d/dep/vendor/vendp/vp.go:1:32",
 			},
 			wantWorkspaceReferences: []string{
-				"/src/test/pkg/a.go:1:18 -> /src/github.com/d/dep dep/<none>",
-				"/src/test/pkg/a.go:1:54 -> /src/github.com/d/dep/vendor/vendp F/V",
-				"/src/test/pkg/a.go:1:50 -> /src/github.com/d/dep dep/D",
+				// TODO: bug: our end locations are invalid (the commented lines are correct).
+				"/src/test/pkg/a.go:1:18-1:17 -> /src/github.com/d/dep dep/<none>",
+				"/src/test/pkg/a.go:1:54-1:54 -> /src/github.com/d/dep/vendor/vendp F/V",
+				"/src/test/pkg/a.go:1:50-1:50 -> /src/github.com/d/dep dep/D",
 			},
 			mountFS: map[string]map[string]string{
 				"/src/github.com/d/dep": map[string]string{
@@ -406,8 +409,9 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				"a.go:1:57": "/src/github.com/d/dep/subp/d.go:1:20",
 			},
 			wantWorkspaceReferences: []string{
-				"/src/test/pkg/a.go:1:18 -> /src/github.com/d/dep/subp subp/<none>",
-				"/src/test/pkg/a.go:1:56 -> /src/github.com/d/dep/subp subp/D",
+				// TODO: bug: our end locations are invalid (the commented lines are correct).
+				"/src/test/pkg/a.go:1:18-1:17 -> /src/github.com/d/dep/subp subp/<none>",
+				"/src/test/pkg/a.go:1:56-1:56 -> /src/github.com/d/dep/subp subp/D",
 			},
 			mountFS: map[string]map[string]string{
 				"/src/github.com/d/dep": {
@@ -429,9 +433,10 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				"a.go:1:58": "/src/github.com/d/dep2/d2.go:1:32", // field D2
 			},
 			wantWorkspaceReferences: []string{
-				"/src/test/pkg/a.go:1:18 -> /src/github.com/d/dep1 dep1/<none>",
-				"/src/test/pkg/a.go:1:57 -> /src/github.com/d/dep2 D2/D2",
-				"/src/test/pkg/a.go:1:52 -> /src/github.com/d/dep1 dep1/D1",
+				// TODO: bug: our end locations are invalid (the commented lines are correct).
+				"/src/test/pkg/a.go:1:18-1:17 -> /src/github.com/d/dep1 dep1/<none>",
+				"/src/test/pkg/a.go:1:57-1:58 -> /src/github.com/d/dep2 D2/D2",
+				"/src/test/pkg/a.go:1:52-1:53 -> /src/github.com/d/dep1 dep1/D1",
 			},
 			mountFS: map[string]map[string]string{
 				"/src/github.com/d/dep1": {
@@ -893,6 +898,7 @@ func callWorkspaceReferences(ctx context.Context, c *jsonrpc2.Conn) ([]string, e
 	refs := make([]string, len(references))
 	for i, r := range references {
 		start := r.Location.Range.Start
+		end := r.Location.Range.End
 		if r.ContainerName == "" {
 			r.ContainerName = "<none>"
 		}
@@ -902,7 +908,7 @@ func callWorkspaceReferences(ctx context.Context, c *jsonrpc2.Conn) ([]string, e
 		path := strings.Join([]string{r.ContainerName, r.Name}, "/")
 		locationURI := strings.TrimPrefix(r.Location.URI, "file://")
 		uri := strings.TrimPrefix(r.URI, "file://")
-		refs[i] = fmt.Sprintf("%s:%d:%d -> %s %s", locationURI, start.Line+1, start.Character+1, uri, path)
+		refs[i] = fmt.Sprintf("%s:%d:%d-%d:%d -> %s %s", locationURI, start.Line+1, start.Character+1, end.Line+1, end.Character+1, uri, path)
 	}
 	return refs, nil
 }

--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -543,6 +543,29 @@ type Header struct {
 				"a.go:24:5":  "var Foo string; Foo is the best string. \n\n",
 			},
 		},
+		"workspace references multiple files": {
+			rootPath: "file:///src/test/pkg",
+			fs: map[string]string{
+				"a.go": `package p; import "fmt"; var _ = fmt.Println; var x int`,
+				"b.go": `package p; import "fmt"; var _ = fmt.Println; var y int`,
+				"c.go": `package p; import "fmt"; var _ = fmt.Println; var z int`,
+			},
+			mountFS: map[string]map[string]string{
+				"/goroot": {
+					"src/fmt/print.go":       "package fmt; func Println(a ...interface{}) (n int, err error) { return }",
+					"src/builtin/builtin.go": "package builtin; type int int",
+				},
+			},
+			wantWorkspaceReferences: []string{
+				// TODO: bug: our end locations are invalid (the commented lines are correct).
+				"/src/test/pkg/a.go:1:19-1:17 -> /goroot/src/fmt fmt/<none>",
+				"/src/test/pkg/a.go:1:38-1:43 -> /goroot/src/fmt fmt/Println",
+				"/src/test/pkg/b.go:1:19-1:17 -> /goroot/src/fmt fmt/<none>",
+				"/src/test/pkg/b.go:1:38-1:43 -> /goroot/src/fmt fmt/Println",
+				"/src/test/pkg/c.go:1:19-1:17 -> /goroot/src/fmt fmt/<none>",
+				"/src/test/pkg/c.go:1:38-1:43 -> /goroot/src/fmt fmt/Println",
+			},
+		},
 	}
 	for label, test := range tests {
 		t.Run(label, func(t *testing.T) {

--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -238,9 +238,8 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				"is:exported": []string{},
 			},
 			wantWorkspaceReferences: []string{
-				// TODO: bug: our end locations are invalid (the commented lines are correct).
-				"/src/test/pkg/a.go:1:19-1:17 -> /goroot/src/fmt fmt/<none>",
-				"/src/test/pkg/a.go:1:38-1:43 -> /goroot/src/fmt fmt/Println",
+				"/src/test/pkg/a.go:1:19-1:19 -> /goroot/src/fmt fmt/<none>", // TODO: valid end location
+				"/src/test/pkg/a.go:1:38-1:38 -> /goroot/src/fmt fmt/Println",
 			},
 		},
 		"gopath": {
@@ -365,10 +364,9 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				},
 			},
 			wantWorkspaceReferences: []string{
-				// TODO: bug: our end locations are invalid (the commented lines are correct).
-				"/src/test/pkg/a.go:1:19-1:17 -> /src/github.com/d/dep dep/<none>",
-				"/src/test/pkg/a.go:1:51-1:50 -> /src/github.com/d/dep dep/D",
-				"/src/test/pkg/a.go:1:66-1:65 -> /src/github.com/d/dep dep/D",
+				"/src/test/pkg/a.go:1:19-1:19 -> /src/github.com/d/dep dep/<none>", // TODO: valid end location
+				"/src/test/pkg/a.go:1:51-1:51 -> /src/github.com/d/dep dep/D",
+				"/src/test/pkg/a.go:1:66-1:66 -> /src/github.com/d/dep dep/D",
 			},
 			mountFS: map[string]map[string]string{
 				"/src/github.com/d/dep": {
@@ -385,10 +383,10 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				"a.go:1:55": "/src/github.com/d/dep/vendor/vendp/vp.go:1:32",
 			},
 			wantWorkspaceReferences: []string{
-				// TODO: bug: our end locations are invalid (the commented lines are correct).
-				"/src/test/pkg/a.go:1:19-1:17 -> /src/github.com/d/dep dep/<none>",
-				"/src/test/pkg/a.go:1:55-1:54 -> /src/github.com/d/dep/vendor/vendp F/V",
-				"/src/test/pkg/a.go:1:51-1:50 -> /src/github.com/d/dep dep/D",
+				// TODO: valid end location
+				"/src/test/pkg/a.go:1:19-1:19 -> /src/github.com/d/dep dep/<none>",
+				"/src/test/pkg/a.go:1:55-1:55 -> /src/github.com/d/dep/vendor/vendp F/V",
+				"/src/test/pkg/a.go:1:51-1:51 -> /src/github.com/d/dep dep/D",
 			},
 			mountFS: map[string]map[string]string{
 				"/src/github.com/d/dep": map[string]string{
@@ -409,9 +407,9 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				"a.go:1:57": "/src/github.com/d/dep/subp/d.go:1:20",
 			},
 			wantWorkspaceReferences: []string{
-				// TODO: bug: our end locations are invalid (the commented lines are correct).
-				"/src/test/pkg/a.go:1:19-1:17 -> /src/github.com/d/dep/subp subp/<none>",
-				"/src/test/pkg/a.go:1:57-1:56 -> /src/github.com/d/dep/subp subp/D",
+				// TODO: valid end location
+				"/src/test/pkg/a.go:1:19-1:19 -> /src/github.com/d/dep/subp subp/<none>",
+				"/src/test/pkg/a.go:1:57-1:57 -> /src/github.com/d/dep/subp subp/D",
 			},
 			mountFS: map[string]map[string]string{
 				"/src/github.com/d/dep": {
@@ -433,8 +431,8 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				"a.go:1:58": "/src/github.com/d/dep2/d2.go:1:32", // field D2
 			},
 			wantWorkspaceReferences: []string{
-				// TODO: bug: our end locations are invalid (the commented lines are correct).
-				"/src/test/pkg/a.go:1:19-1:17 -> /src/github.com/d/dep1 dep1/<none>",
+				// TODO: valid end location
+				"/src/test/pkg/a.go:1:19-1:19 -> /src/github.com/d/dep1 dep1/<none>",
 				"/src/test/pkg/a.go:1:58-1:58 -> /src/github.com/d/dep2 D2/D2",
 				"/src/test/pkg/a.go:1:53-1:53 -> /src/github.com/d/dep1 dep1/D1",
 			},
@@ -558,12 +556,12 @@ type Header struct {
 			},
 			wantWorkspaceReferences: []string{
 				// TODO: bug: our end locations are invalid (the commented lines are correct).
-				"/src/test/pkg/a.go:1:19-1:17 -> /goroot/src/fmt fmt/<none>",
-				"/src/test/pkg/a.go:1:38-1:43 -> /goroot/src/fmt fmt/Println",
-				"/src/test/pkg/b.go:1:19-1:17 -> /goroot/src/fmt fmt/<none>",
-				"/src/test/pkg/b.go:1:38-1:43 -> /goroot/src/fmt fmt/Println",
-				"/src/test/pkg/c.go:1:19-1:17 -> /goroot/src/fmt fmt/<none>",
-				"/src/test/pkg/c.go:1:38-1:43 -> /goroot/src/fmt fmt/Println",
+				"/src/test/pkg/a.go:1:19-1:19 -> /goroot/src/fmt fmt/<none>",
+				"/src/test/pkg/a.go:1:38-1:38 -> /goroot/src/fmt fmt/Println",
+				"/src/test/pkg/b.go:1:19-1:19 -> /goroot/src/fmt fmt/<none>",
+				"/src/test/pkg/b.go:1:38-1:38 -> /goroot/src/fmt fmt/Println",
+				"/src/test/pkg/c.go:1:19-1:19 -> /goroot/src/fmt fmt/<none>",
+				"/src/test/pkg/c.go:1:38-1:38 -> /goroot/src/fmt fmt/Println",
 			},
 		},
 	}

--- a/langserver/workspace_refs.go
+++ b/langserver/workspace_refs.go
@@ -234,7 +234,8 @@ func (h *LangHandler) externalRefsFromPkg(ctx context.Context, bctx *build.Conte
 			Name:          defName,
 			ContainerName: defContainerName,
 			URI:           "file://" + defPkg.Dir,
-			Location:      goRangeToLSPLocation(fs, token.Pos(r.Position.Offset), token.Pos(r.Position.Offset+len(defName)-1)),
+			// TODO: This code is EXTREMELY invalid!
+			Location: goRangeToLSPLocation(fs, token.Pos(r.Position.Offset)+1, token.Pos(r.Position.Offset+len(defName)-1)),
 		})
 		results.resultsMu.Unlock()
 	})

--- a/langserver/workspace_refs.go
+++ b/langserver/workspace_refs.go
@@ -234,8 +234,7 @@ func (h *LangHandler) externalRefsFromPkg(ctx context.Context, bctx *build.Conte
 			Name:          defName,
 			ContainerName: defContainerName,
 			URI:           "file://" + defPkg.Dir,
-			// TODO: This code is EXTREMELY invalid!
-			Location: goRangeToLSPLocation(fs, token.Pos(r.Position.Offset)+1, token.Pos(r.Position.Offset+len(defName)-1)),
+			Location:      goRangeToLSPLocation(fs, r.Pos, r.Pos), // TODO: internal/refs doesn't generate end positions
 		})
 		results.resultsMu.Unlock()
 	})


### PR DESCRIPTION
- Improve testing of `workspace/reference` generally.
- Do not emit `End` ranges that are bizarrely off or broken. Instead, emit `Start == End` and leave it as a future TODO (we do not need them right now).
- Fix an off-by-one error in the resulting `start`/`end` characters of the ranges.
- Fix a serious bug that causes the emitted filename/position for references to be VeryWrong™ / random (and add a test case).
