### PR TITLE
RFC: Cache extension

### DIFF
--- a/pkg/lsp/service.go
+++ b/pkg/lsp/service.go
@@ -21,8 +21,8 @@ type ClientCapabilities struct {
 	// textDocument/xcontent. This is a Sourcegraph extension.
 	XContentProvider bool `json:"xcontentProvider,omitempty"`
 
-	// XCacheProvider indicates the client provides support for cache/xget
-	// and cache/xset. This is a Sourcegraph extension.
+	// XCacheProvider indicates the client provides support for cache/get
+	// and cache/set. This is a Sourcegraph extension.
 	XCacheProvider bool `json:"xcacheProvider,omitempty"`
 }
 

--- a/pkg/lsp/service.go
+++ b/pkg/lsp/service.go
@@ -21,8 +21,8 @@ type ClientCapabilities struct {
 	// textDocument/xcontent. This is a Sourcegraph extension.
 	XContentProvider bool `json:"xcontentProvider,omitempty"`
 
-	// XCacheProvider indicates the client provides support for cache/get
-	// and cache/set. This is a Sourcegraph extension.
+	// XCacheProvider indicates the client provides support for xcache/get
+	// and xcache/set. This is a Sourcegraph extension.
 	XCacheProvider bool `json:"xcacheProvider,omitempty"`
 }
 

--- a/pkg/lsp/service.go
+++ b/pkg/lsp/service.go
@@ -20,6 +20,10 @@ type ClientCapabilities struct {
 	// XContentProvider indicates the client provides support for
 	// textDocument/xcontent. This is a Sourcegraph extension.
 	XContentProvider bool `json:"xcontentProvider,omitempty"`
+
+	// XCacheProvider indicates the client provides support for cache/xget
+	// and cache/xset. This is a Sourcegraph extension.
+	XCacheProvider bool `json:"xcacheProvider,omitempty"`
 }
 
 type InitializeResult struct {

--- a/pkg/lspext/cacheext.go
+++ b/pkg/lspext/cacheext.go
@@ -2,14 +2,14 @@ package lspext
 
 import "encoding/json"
 
-// CacheGetParams is the input for 'cache/get'. The response is a
+// CacheGetParams is the input for 'xcache/get'. The response is a
 // 'CacheItem'. This cache is global to a language server. IE it is shared
 // amongst workspaces, but not amongst different language server types.
 type CacheGetParams struct {
 	Key string `json:"key"`
 }
 
-// CacheItem is the response for 'cache/get'.
+// CacheItem is the response for 'xcache/get'.
 type CacheItem struct {
 	// Value is the value stored in the cache. It is a *json.RawMessage
 	// since the type in the spec is `any`. It is nil if the value is not
@@ -17,7 +17,7 @@ type CacheItem struct {
 	Value *json.RawMessage `json:"value,omitempty"`
 }
 
-// CacheSetParams is the input for 'cache/set'. It is a notify method, so
+// CacheSetParams is the input for 'xcache/set'. It is a notify method, so
 // does not have a response.
 type CacheSetParams struct {
 	Key string `json:"key"`

--- a/pkg/lspext/cacheext.go
+++ b/pkg/lspext/cacheext.go
@@ -1,23 +1,27 @@
 package lspext
 
-// CacheGetParams is the input for 'cache/xget'. The response is a
+import "encoding/json"
+
+// CacheGetParams is the input for 'cache/get'. The response is a
 // 'CacheItem'. This cache is global to a language server. IE it is shared
 // amongst workspaces, but not amongst different language server types.
 type CacheGetParams struct {
 	Key string `json:"key"`
 }
 
-// CacheItem is the response for 'cache/xget'.
+// CacheItem is the response for 'cache/get'.
 type CacheItem struct {
-	// Ok is true if the item was successfuly retrieved from the cache.
-	Ok bool `json:"ok"`
-	// Value is the value stored in the cache. It is present if Ok is true.
-	Value string `json:"value,omitempty"`
+	// Value is the value stored in the cache. It is a *json.RawMessage
+	// since the type in the spec is `any`. It is nil if the value is not
+	// in the cache.
+	Value *json.RawMessage `json:"value,omitempty"`
 }
 
-// CacheSetParams is the input for 'cache/xset'. It is a notify method, so
+// CacheSetParams is the input for 'cache/set'. It is a notify method, so
 // does not have a response.
 type CacheSetParams struct {
-	Key   string `json:"key"`
-	Value string `json:"value"`
+	Key string `json:"key"`
+	// Value is the same as CacheItem.Value. Note when setting Value
+	// cannot be nil.
+	Value *json.RawMessage `json:"value"`
 }

--- a/pkg/lspext/cacheext.go
+++ b/pkg/lspext/cacheext.go
@@ -1,0 +1,23 @@
+package lspext
+
+// CacheGetParams is the input for 'cache/xget'. The response is a
+// 'CacheItem'. This cache is global to a language server. IE it is shared
+// amongst workspaces, but not amongst different language server types.
+type CacheGetParams struct {
+	Key string `json:"key"`
+}
+
+// CacheItem is the response for 'cache/xget'.
+type CacheItem struct {
+	// Ok is true if the item was successfuly retrieved from the cache.
+	Ok bool `json:"ok"`
+	// Value is the value stored in the cache. It is present if Ok is true.
+	Value string `json:"value,omitempty"`
+}
+
+// CacheSetParams is the input for 'cache/xset'. It is a notify method, so
+// does not have a response.
+type CacheSetParams struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}


### PR DESCRIPTION
This is intended to kick of the discussion of what the cache extension will look like, which we want to use for future golang/php improvements.

This is a very simplistic cache interface, which doesn't take into account a bunch of properties a more complex implementation would have. It also does not specify any constraints on value/key sizes, which we may want to indicate somehow since the backing cache store will have constraints.