### PR TITLE
langserver: Use global tracer if specified

### DIFF
--- a/langserver/tracing.go
+++ b/langserver/tracing.go
@@ -23,6 +23,12 @@ func (h *HandlerCommon) InitTracer(conn *jsonrpc2.Conn) {
 		return
 	}
 
+	if t := opentracing.GlobalTracer(); t != nil {
+		h.tracer = t
+		h.tracerOK = true
+		return
+	}
+
 	t := tracer{conn: conn}
 	opt := basictracer.DefaultOptions()
 	opt.Recorder = &t


### PR DESCRIPTION
Currently we send all telemetry events over jsonrpc. We can instead directly
send spans to our opentracing provider in production. This also helps with local
debugging/testing.