### PR TITLE
Don't return hover info builtins

### DIFF
--- a/langserver/hover.go
+++ b/langserver/hover.go
@@ -27,10 +27,6 @@ func (h *LangHandler) handleHover(ctx context.Context, conn JSONRPC2Conn, req *j
 
 	o := pkg.ObjectOf(node)
 	t := pkg.TypeOf(node)
-	if !o.Pos().IsValid() {
-		// Only builtins have invalid position, and don't have useful info.
-		return nil, nil
-	}
 	if o == nil && t == nil {
 		comments := packageDoc(pkg.Files, node.Name)
 
@@ -43,7 +39,10 @@ func (h *LangHandler) handleHover(ctx context.Context, conn JSONRPC2Conn, req *j
 		}
 		return nil, fmt.Errorf("type/object not found at %+v", params.Position)
 	}
-
+	if o != nil && !o.Pos().IsValid() {
+		// Only builtins have invalid position, and don't have useful info.
+		return nil, nil
+	}
 	// Don't package-qualify the string output.
 	qf := func(*types.Package) string { return "" }
 
@@ -61,6 +60,7 @@ func (h *LangHandler) handleHover(ctx context.Context, conn JSONRPC2Conn, req *j
 		if s == "" {
 			s = types.ObjectString(o, qf)
 		}
+
 	} else if t != nil {
 		s = types.TypeString(t, qf)
 	}

--- a/langserver/hover.go
+++ b/langserver/hover.go
@@ -27,6 +27,10 @@ func (h *LangHandler) handleHover(ctx context.Context, conn JSONRPC2Conn, req *j
 
 	o := pkg.ObjectOf(node)
 	t := pkg.TypeOf(node)
+	if !o.Pos().IsValid() {
+		// Only builtins have invalid position, and don't have useful info.
+		return nil, nil
+	}
 	if o == nil && t == nil {
 		comments := packageDoc(pkg.Files, node.Name)
 

--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -211,7 +211,7 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 			},
 			wantHover: map[string]string{
 				"a.go:1:40": "func Println(a ...interface{}) (n int, err error)",
-				"a.go:1:53": "type int int",
+				// "a.go:1:53": "type int int",
 			},
 			wantDefinition: map[string]string{
 				"a.go:1:40": "/goroot/src/fmt/print.go:1:19",


### PR DESCRIPTION
Currently, hover returns information for builtins.

This isn't the way the TypeScript language server works. It's also not useful, it simply says eg `type bool bool`. Also jump to def doesn't work on them, and neither does find references.