### PR TITLE
update to reflect latest workspace/xreferences spec

### DIFF
--- a/langserver/definition.go
+++ b/langserver/definition.go
@@ -76,7 +76,7 @@ func (h *LangHandler) handleXDefinition(ctx context.Context, conn JSONRPC2Conn, 
 				// TODO: tracing
 				log.Println("refs.DefInfo:", err)
 			} else {
-				l.Symbol = *symDesc
+				l.Symbol = append(l.Symbol, *symDesc)
 			}
 		} else {
 			// TODO: tracing

--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -54,10 +54,10 @@ func TestServer(t *testing.T) {
 				"b.go:1:23": "/src/test/pkg/a.go:1:17",
 			},
 			wantXDefinition: map[string]string{
-				"a.go:1:17": "/src/test/pkg/a.go:1:17 attr_package:test/pkg attr_packageName:p name:A",
-				"a.go:1:23": "/src/test/pkg/a.go:1:17 attr_package:test/pkg attr_packageName:p name:A",
-				"b.go:1:17": "/src/test/pkg/b.go:1:17 attr_package:test/pkg attr_packageName:p name:B",
-				"b.go:1:23": "/src/test/pkg/a.go:1:17 attr_package:test/pkg attr_packageName:p name:A",
+				"a.go:1:17": "/src/test/pkg/a.go:1:17 container_packageName:p name:A package_id:test/pkg package_registry:go",
+				"a.go:1:23": "/src/test/pkg/a.go:1:17 container_packageName:p name:A package_id:test/pkg package_registry:go",
+				"b.go:1:17": "/src/test/pkg/b.go:1:17 container_packageName:p name:B package_id:test/pkg package_registry:go",
+				"b.go:1:23": "/src/test/pkg/a.go:1:17 container_packageName:p name:A package_id:test/pkg package_registry:go",
 			},
 			wantReferences: map[string][]string{
 				"a.go:1:17": []string{
@@ -160,11 +160,11 @@ func TestServer(t *testing.T) {
 				"d2/b.go:1:52": "/src/test/pkg/d/d2/b.go:1:39",
 			},
 			wantXDefinition: map[string]string{
-				"a.go:1:17":    "/src/test/pkg/d/a.go:1:17 attr_package:test/pkg/d attr_packageName:d name:A",
-				"a.go:1:23":    "/src/test/pkg/d/a.go:1:17 attr_package:test/pkg/d attr_packageName:d name:A",
-				"d2/b.go:1:39": "/src/test/pkg/d/d2/b.go:1:39 attr_package:test/pkg/d/d2 attr_packageName:d2 name:B",
-				"d2/b.go:1:47": "/src/test/pkg/d/a.go:1:17 attr_package:test/pkg/d attr_packageName:d name:A",
-				"d2/b.go:1:52": "/src/test/pkg/d/d2/b.go:1:39 attr_package:test/pkg/d/d2 attr_packageName:d2 name:B",
+				"a.go:1:17":    "/src/test/pkg/d/a.go:1:17 container_packageName:d name:A package_id:test/pkg/d package_registry:go",
+				"a.go:1:23":    "/src/test/pkg/d/a.go:1:17 container_packageName:d name:A package_id:test/pkg/d package_registry:go",
+				"d2/b.go:1:39": "/src/test/pkg/d/d2/b.go:1:39 container_packageName:d2 name:B package_id:test/pkg/d/d2 package_registry:go",
+				"d2/b.go:1:47": "/src/test/pkg/d/a.go:1:17 container_packageName:d name:A package_id:test/pkg/d package_registry:go",
+				"d2/b.go:1:52": "/src/test/pkg/d/d2/b.go:1:39 container_packageName:d2 name:B package_id:test/pkg/d/d2 package_registry:go",
 			},
 			wantSymbols: map[string][]string{
 				"a.go":    []string{"/src/test/pkg/d/a.go:function:d.A:1:17"},
@@ -182,8 +182,8 @@ func TestServer(t *testing.T) {
 				"dir:d2/":     []string{"/src/test/pkg/d/d2/b.go:function:d2.B:1:39"},
 			},
 			wantWorkspaceReferences: []string{
-				"/src/test/pkg/d/d2/b.go:1:20-1:20 -> attr_package:test/pkg/d attr_packageName:d",
-				"/src/test/pkg/d/d2/b.go:1:47-1:47 -> attr_package:test/pkg/d attr_packageName:d name:A",
+				"/src/test/pkg/d/d2/b.go:1:20-1:20 -> container_packageName:d package_id:test/pkg/d package_registry:go",
+				"/src/test/pkg/d/d2/b.go:1:47-1:47 -> container_packageName:d name:A package_id:test/pkg/d package_registry:go",
 			},
 		},
 		"go multiple packages in dir": {
@@ -213,8 +213,8 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				// "main.go:3:52": "/src/test/pkg/main.go:3:39", // B() -> func B()
 			},
 			wantXDefinition: map[string]string{
-				"a.go:1:17": "/src/test/pkg/a.go:1:17 attr_package:test/pkg attr_packageName:p name:A",
-				"a.go:1:23": "/src/test/pkg/a.go:1:17 attr_package:test/pkg attr_packageName:p name:A",
+				"a.go:1:17": "/src/test/pkg/a.go:1:17 container_packageName:p name:A package_id:test/pkg package_registry:go",
+				"a.go:1:23": "/src/test/pkg/a.go:1:17 container_packageName:p name:A package_id:test/pkg package_registry:go",
 			},
 			wantSymbols: map[string][]string{
 				"a.go": []string{"/src/test/pkg/a.go:function:pkg.A:1:17"},
@@ -239,8 +239,7 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				// "a.go:1:53": "/goroot/src/builtin/builtin.go:TODO:TODO", // TODO(sqs): support builtins
 			},
 			wantXDefinition: map[string]string{
-				"a.go:1:40": "/goroot/src/fmt/print.go:1:19 attr_package:fmt attr_packageName:fmt name:Println",
-				// "a.go:1:53": "/goroot/src/builtin/builtin.go:TODO:TODO", // TODO(sqs): support builtins
+				"a.go:1:40": "/goroot/src/fmt/print.go:1:19 container_packageName:fmt name:Println package_id:fmt package_registry:go",
 			},
 			mountFS: map[string]map[string]string{
 				"/goroot": {
@@ -263,8 +262,8 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				"is:exported": []string{},
 			},
 			wantWorkspaceReferences: []string{
-				"/src/test/pkg/a.go:1:19-1:19 -> attr_package:fmt attr_packageName:fmt",
-				"/src/test/pkg/a.go:1:38-1:38 -> attr_package:fmt attr_packageName:fmt name:Println",
+				"/src/test/pkg/a.go:1:19-1:19 -> container_packageName:fmt package_id:fmt package_registry:go",
+				"/src/test/pkg/a.go:1:38-1:38 -> container_packageName:fmt name:Println package_id:fmt package_registry:go",
 			},
 		},
 		"gopath": {
@@ -284,8 +283,8 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				"b/b.go:1:43": "/src/test/pkg/a/a.go:1:17",
 			},
 			wantXDefinition: map[string]string{
-				"a/a.go:1:17": "/src/test/pkg/a/a.go:1:17 attr_package:test/pkg/a attr_packageName:a name:A",
-				"b/b.go:1:43": "/src/test/pkg/a/a.go:1:17 attr_package:test/pkg/a attr_packageName:a name:A",
+				"a/a.go:1:17": "/src/test/pkg/a/a.go:1:17 container_packageName:a name:A package_id:test/pkg/a package_registry:go",
+				"b/b.go:1:43": "/src/test/pkg/a/a.go:1:17 container_packageName:a name:A package_id:test/pkg/a package_registry:go",
 			},
 			wantReferences: map[string][]string{
 				"a/a.go:1:17": []string{
@@ -306,8 +305,8 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				"is:exported": []string{"/src/test/pkg/a/a.go:function:a.A:1:17"},
 			},
 			wantWorkspaceReferences: []string{
-				"/src/test/pkg/b/b.go:1:19-1:19 -> attr_package:test/pkg/a attr_packageName:a",
-				"/src/test/pkg/b/b.go:1:43-1:43 -> attr_package:test/pkg/a attr_packageName:a name:A",
+				"/src/test/pkg/b/b.go:1:19-1:19 -> container_packageName:a package_id:test/pkg/a package_registry:go",
+				"/src/test/pkg/b/b.go:1:43-1:43 -> container_packageName:a name:A package_id:test/pkg/a package_registry:go",
 			},
 		},
 		"go vendored dep": {
@@ -323,7 +322,7 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				"a.go:1:61": "/src/test/pkg/vendor/github.com/v/vendored/v.go:1:24",
 			},
 			wantXDefinition: map[string]string{
-				"a.go:1:61": "/src/test/pkg/vendor/github.com/v/vendored/v.go:1:24 attr_package:test/pkg/vendor/github.com/v/vendored attr_packageName:vendored name:V vendor:true",
+				"a.go:1:61": "/src/test/pkg/vendor/github.com/v/vendored/v.go:1:24 container_packageName:vendored name:V package_id:test/pkg/vendor/github.com/v/vendored package_registry:go vendor:true",
 			},
 			wantReferences: map[string][]string{
 				"vendor/github.com/v/vendored/v.go:1:24": []string{
@@ -340,8 +339,8 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				"is:exported": []string{},
 			},
 			wantWorkspaceReferences: []string{
-				"/src/test/pkg/a.go:1:19-1:19 -> attr_package:test/pkg/vendor/github.com/v/vendored attr_packageName:vendored vendor:true",
-				"/src/test/pkg/a.go:1:61-1:61 -> attr_package:test/pkg/vendor/github.com/v/vendored attr_packageName:vendored name:V vendor:true",
+				"/src/test/pkg/a.go:1:19-1:19 -> container_packageName:vendored package_id:test/pkg/vendor/github.com/v/vendored package_registry:go vendor:true",
+				"/src/test/pkg/a.go:1:61-1:61 -> container_packageName:vendored name:V package_id:test/pkg/vendor/github.com/v/vendored package_registry:go vendor:true",
 			},
 		},
 		"go vendor symbols with same name": {
@@ -393,7 +392,7 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				"a.go:1:51": "/src/github.com/d/dep/d.go:1:19",
 			},
 			wantXDefinition: map[string]string{
-				"a.go:1:51": "/src/github.com/d/dep/d.go:1:19 attr_package:github.com/d/dep attr_packageName:dep name:D",
+				"a.go:1:51": "/src/github.com/d/dep/d.go:1:19 container_packageName:dep name:D package_id:github.com/d/dep package_registry:go",
 			},
 			wantReferences: map[string][]string{
 				"a.go:1:51": []string{
@@ -405,9 +404,9 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				},
 			},
 			wantWorkspaceReferences: []string{
-				"/src/test/pkg/a.go:1:19-1:19 -> attr_package:github.com/d/dep attr_packageName:dep",
-				"/src/test/pkg/a.go:1:51-1:51 -> attr_package:github.com/d/dep attr_packageName:dep name:D",
-				"/src/test/pkg/a.go:1:66-1:66 -> attr_package:github.com/d/dep attr_packageName:dep name:D",
+				"/src/test/pkg/a.go:1:19-1:19 -> container_packageName:dep package_id:github.com/d/dep package_registry:go",
+				"/src/test/pkg/a.go:1:51-1:51 -> container_packageName:dep name:D package_id:github.com/d/dep package_registry:go",
+				"/src/test/pkg/a.go:1:66-1:66 -> container_packageName:dep name:D package_id:github.com/d/dep package_registry:go",
 			},
 			mountFS: map[string]map[string]string{
 				"/src/github.com/d/dep": {
@@ -424,12 +423,12 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				"a.go:1:55": "/src/github.com/d/dep/vendor/vendp/vp.go:1:32",
 			},
 			wantXDefinition: map[string]string{
-				"a.go:1:55": "/src/github.com/d/dep/vendor/vendp/vp.go:1:32 attr_package:github.com/d/dep/vendor/vendp attr_packageName:vendp attr_parent:V name:F vendor:true",
+				"a.go:1:55": "/src/github.com/d/dep/vendor/vendp/vp.go:1:32 container_packageName:vendp container_parent:V name:F package_id:github.com/d/dep/vendor/vendp package_registry:go vendor:true",
 			},
 			wantWorkspaceReferences: []string{
-				"/src/test/pkg/a.go:1:19-1:19 -> attr_package:github.com/d/dep attr_packageName:dep",
-				"/src/test/pkg/a.go:1:55-1:55 -> attr_package:github.com/d/dep/vendor/vendp attr_packageName:vendp attr_parent:V name:F vendor:true",
-				"/src/test/pkg/a.go:1:51-1:51 -> attr_package:github.com/d/dep attr_packageName:dep name:D",
+				"/src/test/pkg/a.go:1:19-1:19 -> container_packageName:dep package_id:github.com/d/dep package_registry:go",
+				"/src/test/pkg/a.go:1:55-1:55 -> container_packageName:vendp container_parent:V name:F package_id:github.com/d/dep/vendor/vendp package_registry:go vendor:true",
+				"/src/test/pkg/a.go:1:51-1:51 -> container_packageName:dep name:D package_id:github.com/d/dep package_registry:go",
 			},
 			mountFS: map[string]map[string]string{
 				"/src/github.com/d/dep": map[string]string{
@@ -450,11 +449,11 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				"a.go:1:57": "/src/github.com/d/dep/subp/d.go:1:20",
 			},
 			wantXDefinition: map[string]string{
-				"a.go:1:57": "/src/github.com/d/dep/subp/d.go:1:20 attr_package:github.com/d/dep/subp attr_packageName:subp name:D",
+				"a.go:1:57": "/src/github.com/d/dep/subp/d.go:1:20 container_packageName:subp name:D package_id:github.com/d/dep/subp package_registry:go",
 			},
 			wantWorkspaceReferences: []string{
-				"/src/test/pkg/a.go:1:19-1:19 -> attr_package:github.com/d/dep/subp attr_packageName:subp",
-				"/src/test/pkg/a.go:1:57-1:57 -> attr_package:github.com/d/dep/subp attr_packageName:subp name:D",
+				"/src/test/pkg/a.go:1:19-1:19 -> container_packageName:subp package_id:github.com/d/dep/subp package_registry:go",
+				"/src/test/pkg/a.go:1:57-1:57 -> container_packageName:subp name:D package_id:github.com/d/dep/subp package_registry:go",
 			},
 			mountFS: map[string]map[string]string{
 				"/src/github.com/d/dep": {
@@ -476,13 +475,13 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				"a.go:1:58": "/src/github.com/d/dep2/d2.go:1:32", // field D2
 			},
 			wantXDefinition: map[string]string{
-				"a.go:1:53": "/src/github.com/d/dep1/d1.go:1:48 attr_package:github.com/d/dep1 attr_packageName:dep1 name:D1",
-				"a.go:1:58": "/src/github.com/d/dep2/d2.go:1:32 attr_package:github.com/d/dep2 attr_packageName:dep2 attr_parent:D2 name:D2",
+				"a.go:1:53": "/src/github.com/d/dep1/d1.go:1:48 container_packageName:dep1 name:D1 package_id:github.com/d/dep1 package_registry:go",
+				"a.go:1:58": "/src/github.com/d/dep2/d2.go:1:32 container_packageName:dep2 container_parent:D2 name:D2 package_id:github.com/d/dep2 package_registry:go",
 			},
 			wantWorkspaceReferences: []string{
-				"/src/test/pkg/a.go:1:19-1:19 -> attr_package:github.com/d/dep1 attr_packageName:dep1",
-				"/src/test/pkg/a.go:1:58-1:58 -> attr_package:github.com/d/dep2 attr_packageName:dep2 attr_parent:D2 name:D2",
-				"/src/test/pkg/a.go:1:53-1:53 -> attr_package:github.com/d/dep1 attr_packageName:dep1 name:D1",
+				"/src/test/pkg/a.go:1:19-1:19 -> container_packageName:dep1 package_id:github.com/d/dep1 package_registry:go",
+				"/src/test/pkg/a.go:1:58-1:58 -> container_packageName:dep2 container_parent:D2 name:D2 package_id:github.com/d/dep2 package_registry:go",
+				"/src/test/pkg/a.go:1:53-1:53 -> container_packageName:dep1 name:D1 package_id:github.com/d/dep1 package_registry:go",
 			},
 			mountFS: map[string]map[string]string{
 				"/src/github.com/d/dep1": {
@@ -603,12 +602,12 @@ type Header struct {
 				},
 			},
 			wantWorkspaceReferences: []string{
-				"/src/test/pkg/a.go:1:19-1:19 -> attr_package:fmt attr_packageName:fmt",
-				"/src/test/pkg/a.go:1:38-1:38 -> attr_package:fmt attr_packageName:fmt name:Println",
-				"/src/test/pkg/b.go:1:19-1:19 -> attr_package:fmt attr_packageName:fmt",
-				"/src/test/pkg/b.go:1:38-1:38 -> attr_package:fmt attr_packageName:fmt name:Println",
-				"/src/test/pkg/c.go:1:19-1:19 -> attr_package:fmt attr_packageName:fmt",
-				"/src/test/pkg/c.go:1:38-1:38 -> attr_package:fmt attr_packageName:fmt name:Println",
+				"/src/test/pkg/a.go:1:19-1:19 -> container_packageName:fmt package_id:fmt package_registry:go",
+				"/src/test/pkg/a.go:1:38-1:38 -> container_packageName:fmt name:Println package_id:fmt package_registry:go",
+				"/src/test/pkg/b.go:1:19-1:19 -> container_packageName:fmt package_id:fmt package_registry:go",
+				"/src/test/pkg/b.go:1:38-1:38 -> container_packageName:fmt name:Println package_id:fmt package_registry:go",
+				"/src/test/pkg/c.go:1:19-1:19 -> container_packageName:fmt package_id:fmt package_registry:go",
+				"/src/test/pkg/c.go:1:38-1:38 -> container_packageName:fmt name:Println package_id:fmt package_registry:go",
 			},
 		},
 	}
@@ -786,7 +785,7 @@ func xdefinitionTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, rootPa
 	}
 	xdefinition = strings.TrimPrefix(xdefinition, "file://")
 	if xdefinition != want {
-		t.Errorf("got %q, want %q", xdefinition, want)
+		t.Errorf("\ngot  %q\nwant %q", xdefinition, want)
 	}
 }
 
@@ -926,7 +925,10 @@ func callXDefinition(ctx context.Context, c *jsonrpc2.Conn, uri string, line, ch
 		if i != 0 {
 			str += ", "
 		}
-		str += fmt.Sprintf("%s:%d:%d %s", loc.Location.URI, loc.Location.Range.Start.Line+1, loc.Location.Range.Start.Character+1, loc.Symbol)
+		if len(loc.Symbol) > 1 {
+			return "", errors.New("expected one symbol got > 1")
+		}
+		str += fmt.Sprintf("%s:%d:%d %s", loc.Location.URI, loc.Location.Range.Start.Line+1, loc.Location.Range.Start.Character+1, loc.Symbol[0])
 	}
 	return str, nil
 }

--- a/langserver/workspace_refs.go
+++ b/langserver/workspace_refs.go
@@ -222,8 +222,7 @@ func defSymbolDescriptor(bctx *build.Context, rootPath string, def refs.Def) (*l
 		return nil, err
 	}
 
-	attributes := map[string]interface{}{
-		"package":     defPkg.ImportPath,
+	container := map[string]interface{}{
 		"packageName": def.PackageName,
 	}
 
@@ -233,14 +232,18 @@ func defSymbolDescriptor(bctx *build.Context, rootPath string, def refs.Def) (*l
 		defName = fields[0]
 	}
 	if len(fields) >= 2 {
-		attributes["parent"] = fields[0]
+		container["parent"] = fields[0]
 		defName = fields[1]
 	}
 
 	return &lspext.SymbolDescriptor{
-		Name:       defName,
-		Vendor:     IsVendorDir(defPkg.Dir),
-		Attributes: attributes,
+		Name:      defName,
+		Vendor:    IsVendorDir(defPkg.Dir),
+		Container: container,
+		Package: lspext.PackageDescriptor{
+			ID:       defPkg.ImportPath,
+			Registry: "go",
+		},
 		// TODO: be nice and emit Kind, File and Repo fields too. They
 		// are optional, though, so let's punt on it for now and see
 		// how well it works.

--- a/pkg/lspext/lspext.go
+++ b/pkg/lspext/lspext.go
@@ -42,37 +42,73 @@ type SymbolDescriptor struct {
 	// URI of this symbol (same as `SymbolInformation.location.uri`).
 	URI string `json:"uri,omitempty"`
 
-	// ContainerName represents the name of the symbol containing this symbol
-	// (same as `SymbolInformation.containerName`).
-	ContainerName string `json:"containerName,omitempty"`
+	// Container represents the container of this symbol. It is up to the
+	// language server to define what exact data this object contains.
+	Container map[string]interface{} `json:"container,omitempty"`
 
-	// Whether or not the symbol is defined inside of "vendored" code. In Go, for
-	// example, this means that an external dependency was copied to a subdirectory
-	// named `vendor`. The exact definition of vendor depends on the language,
-	// but it is generally understood to mean "code that was copied from its
-	// original source and now lives in our project directly".
+	// Whether or not the symbol is defined inside of "vendored" code. In Go,
+	// for example, this means that an external dependency was copied to a
+	// subdirectory named `vendor`. The exact definition of vendor depends on
+	// the language, but it is generally understood to mean "code that was
+	// copied from its original source and now lives in our project directly".
 	Vendor bool `json:"vendor,omitempty"`
+
+	// Package contains information about the package/library that this symbol
+	// is defined in.
+	Package PackageDescriptor `json:"package,omitempty"`
 
 	// Attributes describing the symbol that is being referenced. It is up to
 	// the language server to define what exact data this object contains.
 	Attributes map[string]interface{} `json:"attributes,omitempty"`
 }
 
+// PackageDescriptor represents information about a programming code unit like
+// a package, library, crate, module, etc. It uniquely identifies a package at
+// a specific version within a given registry.
+type PackageDescriptor struct {
+	// ID represents the package of code. For example, in JS this would be the
+	// NPM package name. In Go, the full import path. etc.
+	ID string `json:"id"`
+
+	// Version is the version of the package in the registry.
+	Version *VersionDescriptor `json:"version,omitempty"`
+
+	// The registry for this package. Examples:
+	//
+	//  - JS: "npm"
+	//  - Java: "maven" etc.
+	//  - Go: "go"
+	//
+	Registry string `json:"registry,omitempty"`
+}
+
+// VersionDescriptor represents a specific version. It can be either
+// language-server / build tool defined fields OR semantically version fields
+// (which are preferable). TS declaration is:
+//
+// 	type VersionDescriptor = Object | {
+// 		commitID?: string
+// 		major?: number
+// 		minor?: number
+// 		patch?: number
+// 		tag?: string
+// 	};
+//
+type VersionDescriptor map[string]interface{}
+
 // LocationInformation is the response type for the `textDocument/xdefinition` extension.
 type LocationInformation struct {
 	// A concrete location at which the definition is located, if any.
 	Location lsp.Location `json:"location,omitempty"`
 	// Metadata about the definition.
-	Symbol SymbolDescriptor `json:"SymbolDescriptor"`
+	Symbol []SymbolDescriptor `json:"SymbolDescriptor"`
 }
 
 // String returns a consistently ordered string representation of the
 // SymbolDescriptor. It is useful for testing.
 func (s SymbolDescriptor) String() string {
-	sm := make(sortedMap, 0, len(s.Attributes))
-	for k, v := range s.Attributes {
-		sm = append(sm, mapValue{key: "attr_" + k, value: v})
-	}
+	sm := newSortedMap(s.Attributes).prefix("attr")
+	sm = append(sm, newSortedMap(s.Container).prefix("container")...)
 	stdfield := func(k, v string) {
 		if v != "" {
 			sm = append(sm, mapValue{key: k, value: v})
@@ -81,9 +117,13 @@ func (s SymbolDescriptor) String() string {
 	stdfield("name", s.Name)
 	stdfield("kind", s.Kind.String())
 	stdfield("uri", s.URI)
-	stdfield("containerName", s.ContainerName)
 	if s.Vendor {
 		stdfield("vendor", "true")
+	}
+	stdfield("package_id", s.Package.ID)
+	stdfield("package_registry", s.Package.Registry)
+	if s.Package.Version != nil {
+		stdfield("package_version", fmt.Sprint(s.Package.Version))
 	}
 	sort.Sort(sm)
 	var str string
@@ -103,3 +143,18 @@ type sortedMap []mapValue
 func (s sortedMap) Len() int           { return len(s) }
 func (s sortedMap) Less(i, j int) bool { return s[i].key < s[j].key }
 func (s sortedMap) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+
+func (sm sortedMap) prefix(s string) sortedMap {
+	for i, v := range sm {
+		sm[i].key = s + "_" + v.key
+	}
+	return sm
+}
+
+func newSortedMap(m map[string]interface{}) sortedMap {
+	sm := make(sortedMap, 0, len(m))
+	for k, v := range m {
+		sm = append(sm, mapValue{key: k, value: v})
+	}
+	return sm
+}


### PR DESCRIPTION
Not much change, just update the LS to reflect the latest spec @ https://github.com/sourcegraph/language-server-protocol/pull/8/files which is about to be merged.

Aside from bugs, and known vendor issues (looking tomorrow), this is very close to the final implementation.