### PR TITLE
symbol - score - uri case:

### DIFF
--- a/langserver/symbol.go
+++ b/langserver/symbol.go
@@ -185,7 +185,7 @@ func score(q Query, s lsp.SymbolInformation) (scor int) {
 		}
 	}
 	name, container := strings.ToLower(s.Name), strings.ToLower(s.ContainerName)
-	filename := strings.TrimPrefix(strings.ToLower(s.Location.URI), "file://")
+	filename := strings.TrimPrefix(s.Location.URI, "file://")
 	isVendor := strings.HasPrefix(filename, "vendor/") || strings.Contains(filename, "/vendor/")
 	if q.Filter == FilterExported && isVendor {
 		// is:exported excludes vendor symbols always.


### PR DESCRIPTION
hi, All,

working on `documentSymbolProvider`.

any idea why `strings.ToLower(s.Location.URI)` was being called in the `score` function? i've tracked down the empty result-set to that. 1st trace is with current code, 2nd is without transforming the uri.

ta,

---

#### with lowercase:

```sh
langserver-go: collectFromPkg - results.Collect - sym: {Name:NewHandler Kind:12 Location:{URI:file:///Users/mbana/go/src/github.com/sourcegraph/go-langserver/langserver/handler.go Range:{Start:{Line:21 Character:5} End:{Line:21 Character:14}}} ContainerName:langserver}
langserver-go: - score - name     : newhandler
langserver-go: - score - container: langserver
langserver-go: - score - filename : /users/mbana/go/src/github.com/sourcegraph/go-langserver/langserver/handler.go
langserver-go: - score - isVendor : false
langserver-go: - score - q.file      : /Users/mbana/go/src/github.com/sourcegraph/go-langserver/langserver/handler.go
langserver-go: - score - filename    : /users/mbana/go/src/github.com/sourcegraph/go-langserver/langserver/handler.go
langserver-go: - score - filesNoMatch: true
langserver-go: - results.Collect - s.query: {kind:0 filter: file:/Users/mbana/go/src/github.com/sourcegraph/go-langserver/langserver/handler.go dir: tokens:[]}
langserver-go: - results.Collect - si: {Name:NewHandler Kind:12 Location:{URI:file:///Users/mbana/go/src/github.com/sourcegraph/go-langserver/langserver/handler.go Range:{Start:{Line:21 Character:5} End:{Line:21 Character:14}}} ContainerName:langserver}
langserver-go: - results.Collect - score: 0
...
nerName:langserver}
langserver-go: collectFromPkg - results.results: 0
langserver-go: handleSymbol - results.results: 0
<-- result #1: textDocument/documentSymbol: []
^C
 ```

#### no lowercase

```sh
langserver-go: collectFromPkg - results.results: 6
langserver-go: handleSymbol - results.results: 6
<-- result #2: textDocument/documentSymbol: [{"name":"Handle","kind":6,"location":{"uri":"file:///Users/mbana/go/src/github.com/sourcegraph/go-langserver/langserver/handler.go","range":{"start":{"line":89,"character":22},"end":{"line":89,"character":27}}},"containerName":"LangHandler"},{"name":"handle","kind":6,"location":{"uri":"file:///Users/mbana/go/src/github.com/sourcegraph/go-langserver/langserver/handler.go","range":{"start":{"line":82,"character":22},"end":{"line":82,"character":27}}},"containerName":"LangHandler"},{"name":"reset","kind":6,"location":{"uri":"file:///Users/mbana/go/src/github.com/sourcegraph/go-langserver/langserver/handler.go","range":{"start":{"line":44,"character":22},"end":{"line":44,"character":26}}},"containerName":"LangHandler"},{"name":"resetCaches","kind":6,"location":{"uri":"file:///Users/mbana/go/src/github.com/sourcegraph/go-langserver/langserver/handler.go","range":{"start":{"line":62,"character":22},"end":{"line":62,"character":32}}},"containerName":"LangHandler"},{"name":"LangHandler","kind":5,"location":{"uri":"file:///Users/mbana/go/src/github.com/sourcegraph/go-langserver/langserver/handler.go","range":{"start":{"line":28,"character":5},"end":{"line":28,"character":15}}},"containerName":"langserver"},{"name":"NewHandler","kind":12,"location":{"uri":"file:///Users/mbana/go/src/github.com/sourcegraph/go-langserver/langserver/handler.go","range":{"start":{"line":21,"character":5},"end":{"line":21,"character":14}}},"containerName":"langserver"}]
```