### PR TITLE
handleSymbol BuildContext:

### DIFF
--- a/langserver/symbol.go
+++ b/langserver/symbol.go
@@ -293,10 +293,10 @@ func (h *LangHandler) handleSymbol(ctx context.Context, conn JSONRPC2Conn, req *
 			// package dir matches to avoid doing unnecessary work.
 			if results.Query.File != "" {
 				filePkgPath := path.Dir(results.Query.File)
-				if PathHasPrefix(filePkgPath, h.init.BuildContext.GOROOT) {
-					filePkgPath = PathTrimPrefix(filePkgPath, h.init.BuildContext.GOROOT)
+				if PathHasPrefix(filePkgPath, bctx.GOROOT) {
+					filePkgPath = PathTrimPrefix(filePkgPath, bctx.GOROOT)
 				} else {
-					filePkgPath = PathTrimPrefix(filePkgPath, h.init.BuildContext.GOPATH)
+					filePkgPath = PathTrimPrefix(filePkgPath, bctx.GOPATH)
 				}
 				filePkgPath = PathTrimPrefix(filePkgPath, "src")
 				if !pathEqual(pkg, filePkgPath) {


### PR DESCRIPTION
i could be doing something wrong here, so pls fire way.

it looks like `h.init.*` is not defined so it errs.

---

```sh
--> request #1: textDocument/documentSymbol: {"textDocument":{"uri":"file:///Users/mbana/go/src/github.com/sourcegraph/go-langserver/langserver/handler.go"}}
langserver-go: handleSymbol - bctx: &{GOARCH:amd64 GOOS:darwin GOROOT:/usr/local/opt/go/libexec GOPATH:/Users/mbana/go CgoEnabled:true UseAllFiles:false Compiler:gc BuildTags:[] ReleaseTags:[go1.1 go1.2 go1.3 go1.4 go1.5 go1.6 go1.7] InstallSuffix: JoinPath:<nil> SplitPathList:<nil> IsAbsPath:<nil> IsDir:0xdcf20 HasSubdir:0xdcfc0 ReadDir:0xdd0c0 OpenFile:0xdce40}
langserver-go: handleSymbol - h.init: &{InitializeParams:{ProcessID:0 RootPath:file:///Users/mbana/go/src/github.com/sourcegraph/go-langserver/langserver InitializationOptions:0xc4201311d0 Capabilities:{XFilesProvider:false XContentProvider:false}} NoOSFileSystemAccess:false BuildContext:<nil> RootImportPath:github.com/sourcegraph/go-langserver/langserver}
langserver-go: Handle err - ctx: 0xc4201098e0 conn: 0xc4201098f0, req: 0xc420106820, err: unexpected panic: runtime error: invalid memory address or nil pointer dereference
panic serving textDocument/documentSymbol: runtime error: invalid memory address or nil pointer dereference
goroutine 21 [running]:
github.com/sourcegraph/go-langserver/langserver.(*LangHandler).Handle.func1(0xc4200499e0, 0xc4201098e0, 0xc4201098f0, 0xc420106820)
	/Users/mbana/go/src/github.com/sourcegraph/go-langserver/langserver/handler.go:112 +0x20e
panic(0x49cd40, 0xc4200120b0)
	/usr/local/opt/go/libexec/src/runtime/panic.go:458 +0x243
github.com/sourcegraph/go-langserver/langserver.(*LangHandler).handleSymbol(0xc420140120, 0x738940, 0xc420158690, 0x7312c0, 0xc420137490, 0xc420106820, 0x0, 0x0, 0x0, 0xc42011acc7, ...)
	/Users/mbana/go/src/github.com/sourcegraph/go-langserver/langserver/symbol.go:302 +0xa09
github.com/sourcegraph/go-langserver/langserver.(*LangHandler).handleTextDocumentSymbol(0xc420140120, 0x738940, 0xc420158690, 0x7312c0, 0xc420137490, 0xc420106820, 0xc42011acc0, 0x55, 0x774850, 0x738940, ...)
	/Users/mbana/go/src/github.com/sourcegraph/go-langserver/langserver/symbol.go:263 +0x128
github.com/sourcegraph/go-langserver/langserver.(*LangHandler).Handle(0xc420140120, 0x7388c0, 0xc4200122b0, 0x7312c0, 0xc420137490, 0xc420106820, 0x0, 0x0, 0x730f00, 0xc42019a110)
	/Users/mbana/go/src/github.com/sourcegraph/go-langserver/langserver/handler.go:275 +0x2237
github.com/sourcegraph/go-langserver/langserver.(*LangHandler).handle(0xc420140120, 0x7388c0, 0xc4200122b0, 0xc420137490, 0xc420106820, 0x70, 0x0, 0xc420112340, 0x563b60)
	/Users/mbana/go/src/github.com/sourcegraph/go-langserver/langserver/handler.go:94 +0x66
github.com/sourcegraph/go-langserver/langserver.(*LangHandler).(github.com/sourcegraph/go-langserver/langserver.handle)-fm(0x7388c0, 0xc4200122b0, 0xc420137490, 0xc420106820, 0xc420049b08, 0x49e400, 0xc420109760, 0x16)
	/Users/mbana/go/src/github.com/sourcegraph/go-langserver/langserver/handler.go:29 +0x52
github.com/sourcegraph/jsonrpc2.HandlerWithError.Handle(0xc420108700, 0x7388c0, 0xc4200122b0, 0xc420137490, 0xc420106820)
	/Users/mbana/go/src/github.com/sourcegraph/jsonrpc2/handler_with_error.go:15 +0x6f
github.com/sourcegraph/jsonrpc2.(*Conn).readMessages(0xc420137490, 0x7388c0, 0xc4200122b0, 0xc42011ac00)
	/Users/mbana/go/src/github.com/sourcegraph/jsonrpc2/jsonrpc2.go:473 +0x81b
github.com/sourcegraph/jsonrpc2.NewConn(0x7388c0, 0xc4200122b0, 0x738100, 0xc4201584b0, 0x732d80, 0xc420108700, 0xc42010c040, 0x1, 0x1, 0xc420137340)
	/Users/mbana/go/src/github.com/sourcegraph/jsonrpc2/jsonrpc2.go:295 +0x2e6
github.com/sourcegraph/go-langserver/langserver/modes.webSocketHandler(0x737cc0, 0xc420114750, 0xc42014a000, 0xc420138240, 0xc42010c040, 0x1, 0x1)
	/Users/mbana/go/src/github.com/sourcegraph/go-langserver/langserver/modes/websocket.go:71 +0x253
created by github.com/sourcegraph/go-langserver/langserver/modes.WebSocket.func1
	/Users/mbana/go/src/github.com/sourcegraph/go-langserver/langserver/modes/websocket.go:42 +0x343
<-- error #1: textDocument/documentSymbol: {"code":0,"message":"unexpected panic: runtime error: invalid memory address or nil pointer dereference","data":null}
--> request #2: textDocument/hover: {"textDocument":{"uri":"file:///Users/mbana/go/src/github.com/sourcegraph/go-langserver/langserver/handler.go"},"position":{"line":32,"character":29}}
<-- result #2: textDocument/hover: {}
warning: failed to send diagnostics: jsonrpc2: connection is closed.
^C
```