### PR TITLE
langserver: Do not hold lock for FilePath

### DIFF
--- a/langserver/fs.go
+++ b/langserver/fs.go
@@ -91,8 +91,8 @@ func (h *HandlerShared) FilePath(uri string) string {
 func (h *HandlerShared) readFile(ctx context.Context, uri string) ([]byte, error) {
 	h.Mu.Lock()
 	fs := h.FS
-	path := h.FilePath(uri)
 	h.Mu.Unlock()
+	path := h.FilePath(uri)
 	contents, err := ctxvfs.ReadFile(ctx, fs, path)
 	if os.IsNotExist(err) {
 		if _, ok := err.(*os.PathError); !ok {


### PR DESCRIPTION
FilePath can currently panic, leading to deadlock since we never unlock the
mutex. We also do not need to hold the lock while using FilePath. In future, we
may make FilePath a function rather than a method since it doesn't access any
fields of h.