### PR TITLE
workspace references v3

### DIFF
--- a/langserver/definition.go
+++ b/langserver/definition.go
@@ -24,7 +24,7 @@ func (h *LangHandler) handleDefinition(ctx context.Context, conn JSONRPC2Conn, r
 	return locs, nil
 }
 
-func (h *LangHandler) handleXDefinition(ctx context.Context, conn JSONRPC2Conn, req *jsonrpc2.Request, params lsp.TextDocumentPositionParams) ([]lspext.LocationInformation, error) {
+func (h *LangHandler) handleXDefinition(ctx context.Context, conn JSONRPC2Conn, req *jsonrpc2.Request, params lsp.TextDocumentPositionParams) ([]lspext.SymbolLocationInformation, error) {
 	rootPath := h.FilePath(h.init.RootPath)
 	bctx := h.OverlayBuildContext(ctx, h.defaultBuildContext(), !h.init.NoOSFileSystemAccess)
 
@@ -58,10 +58,10 @@ func (h *LangHandler) handleXDefinition(ctx context.Context, conn JSONRPC2Conn, 
 	if len(nodes) == 0 {
 		return nil, errors.New("definition not found")
 	}
-	locs := make([]lspext.LocationInformation, 0, len(nodes))
+	locs := make([]lspext.SymbolLocationInformation, 0, len(nodes))
 	for _, node := range nodes {
 		// Determine location information for the node.
-		l := lspext.LocationInformation{
+		l := lspext.SymbolLocationInformation{
 			Location: goRangeToLSPLocation(fset, node.Pos(), node.End()),
 		}
 		// LSP expects a range to be of the entire body, not just of the

--- a/langserver/definition.go
+++ b/langserver/definition.go
@@ -76,7 +76,7 @@ func (h *LangHandler) handleXDefinition(ctx context.Context, conn JSONRPC2Conn, 
 				// TODO: tracing
 				log.Println("refs.DefInfo:", err)
 			} else {
-				l.Symbol = append(l.Symbol, *symDesc)
+				l.Symbol = symDesc
 			}
 		} else {
 			// TODO: tracing

--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -183,6 +183,7 @@ func (h *LangHandler) Handle(ctx context.Context, conn JSONRPC2Conn, req *jsonrp
 				ReferencesProvider:           true,
 				WorkspaceSymbolProvider:      true,
 				XWorkspaceReferencesProvider: true,
+				XDefinitionProvider:          true,
 			},
 		}, nil
 

--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -960,7 +960,7 @@ func callDefinition(ctx context.Context, c *jsonrpc2.Conn, uri string, line, cha
 }
 
 func callXDefinition(ctx context.Context, c *jsonrpc2.Conn, uri string, line, char int) (string, error) {
-	var res []lspext.LocationInformation
+	var res []lspext.SymbolLocationInformation
 	err := c.Call(ctx, "textDocument/xdefinition", lsp.TextDocumentPositionParams{
 		TextDocument: lsp.TextDocumentIdentifier{URI: uri},
 		Position:     lsp.Position{Line: line, Character: char},

--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -54,10 +54,10 @@ func TestServer(t *testing.T) {
 				"b.go:1:23": "/src/test/pkg/a.go:1:17",
 			},
 			wantXDefinition: map[string]string{
-				"a.go:1:17": "/src/test/pkg/a.go:1:17 container_packageName:p name:A package_id:test/pkg package_registry:go",
-				"a.go:1:23": "/src/test/pkg/a.go:1:17 container_packageName:p name:A package_id:test/pkg package_registry:go",
-				"b.go:1:17": "/src/test/pkg/b.go:1:17 container_packageName:p name:B package_id:test/pkg package_registry:go",
-				"b.go:1:23": "/src/test/pkg/a.go:1:17 container_packageName:p name:A package_id:test/pkg package_registry:go",
+				"a.go:1:17": "/src/test/pkg/a.go:1:17 name:A package:test/pkg packageName:p",
+				"a.go:1:23": "/src/test/pkg/a.go:1:17 name:A package:test/pkg packageName:p",
+				"b.go:1:17": "/src/test/pkg/b.go:1:17 name:B package:test/pkg packageName:p",
+				"b.go:1:23": "/src/test/pkg/a.go:1:17 name:A package:test/pkg packageName:p",
 			},
 			wantReferences: map[string][]string{
 				"a.go:1:17": []string{
@@ -160,11 +160,11 @@ func TestServer(t *testing.T) {
 				"d2/b.go:1:52": "/src/test/pkg/d/d2/b.go:1:39",
 			},
 			wantXDefinition: map[string]string{
-				"a.go:1:17":    "/src/test/pkg/d/a.go:1:17 container_packageName:d name:A package_id:test/pkg/d package_registry:go",
-				"a.go:1:23":    "/src/test/pkg/d/a.go:1:17 container_packageName:d name:A package_id:test/pkg/d package_registry:go",
-				"d2/b.go:1:39": "/src/test/pkg/d/d2/b.go:1:39 container_packageName:d2 name:B package_id:test/pkg/d/d2 package_registry:go",
-				"d2/b.go:1:47": "/src/test/pkg/d/a.go:1:17 container_packageName:d name:A package_id:test/pkg/d package_registry:go",
-				"d2/b.go:1:52": "/src/test/pkg/d/d2/b.go:1:39 container_packageName:d2 name:B package_id:test/pkg/d/d2 package_registry:go",
+				"a.go:1:17":    "/src/test/pkg/d/a.go:1:17 name:A package:test/pkg/d packageName:d",
+				"a.go:1:23":    "/src/test/pkg/d/a.go:1:17 name:A package:test/pkg/d packageName:d",
+				"d2/b.go:1:39": "/src/test/pkg/d/d2/b.go:1:39 name:B package:test/pkg/d/d2 packageName:d2",
+				"d2/b.go:1:47": "/src/test/pkg/d/a.go:1:17 name:A package:test/pkg/d packageName:d",
+				"d2/b.go:1:52": "/src/test/pkg/d/d2/b.go:1:39 name:B package:test/pkg/d/d2 packageName:d2",
 			},
 			wantSymbols: map[string][]string{
 				"a.go":    []string{"/src/test/pkg/d/a.go:function:d.A:1:17"},
@@ -182,8 +182,8 @@ func TestServer(t *testing.T) {
 				"dir:d2/":     []string{"/src/test/pkg/d/d2/b.go:function:d2.B:1:39"},
 			},
 			wantWorkspaceReferences: []string{
-				"/src/test/pkg/d/d2/b.go:1:20-1:20 -> container_packageName:d package_id:test/pkg/d package_registry:go",
-				"/src/test/pkg/d/d2/b.go:1:47-1:47 -> container_packageName:d name:A package_id:test/pkg/d package_registry:go",
+				"/src/test/pkg/d/d2/b.go:1:20-1:20 -> package:test/pkg/d packageName:d",
+				"/src/test/pkg/d/d2/b.go:1:47-1:47 -> name:A package:test/pkg/d packageName:d",
 			},
 		},
 		"go multiple packages in dir": {
@@ -213,8 +213,8 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				// "main.go:3:52": "/src/test/pkg/main.go:3:39", // B() -> func B()
 			},
 			wantXDefinition: map[string]string{
-				"a.go:1:17": "/src/test/pkg/a.go:1:17 container_packageName:p name:A package_id:test/pkg package_registry:go",
-				"a.go:1:23": "/src/test/pkg/a.go:1:17 container_packageName:p name:A package_id:test/pkg package_registry:go",
+				"a.go:1:17": "/src/test/pkg/a.go:1:17 name:A package:test/pkg packageName:p",
+				"a.go:1:23": "/src/test/pkg/a.go:1:17 name:A package:test/pkg packageName:p",
 			},
 			wantSymbols: map[string][]string{
 				"a.go": []string{"/src/test/pkg/a.go:function:pkg.A:1:17"},
@@ -239,7 +239,7 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				// "a.go:1:53": "/goroot/src/builtin/builtin.go:TODO:TODO", // TODO(sqs): support builtins
 			},
 			wantXDefinition: map[string]string{
-				"a.go:1:40": "/goroot/src/fmt/print.go:1:19 container_packageName:fmt name:Println package_id:fmt package_registry:go",
+				"a.go:1:40": "/goroot/src/fmt/print.go:1:19 name:Println package:fmt packageName:fmt",
 			},
 			mountFS: map[string]map[string]string{
 				"/goroot": {
@@ -262,8 +262,8 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				"is:exported": []string{},
 			},
 			wantWorkspaceReferences: []string{
-				"/src/test/pkg/a.go:1:19-1:19 -> container_packageName:fmt package_id:fmt package_registry:go",
-				"/src/test/pkg/a.go:1:38-1:38 -> container_packageName:fmt name:Println package_id:fmt package_registry:go",
+				"/src/test/pkg/a.go:1:19-1:19 -> package:fmt packageName:fmt",
+				"/src/test/pkg/a.go:1:38-1:38 -> name:Println package:fmt packageName:fmt",
 			},
 		},
 		"gopath": {
@@ -283,8 +283,8 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				"b/b.go:1:43": "/src/test/pkg/a/a.go:1:17",
 			},
 			wantXDefinition: map[string]string{
-				"a/a.go:1:17": "/src/test/pkg/a/a.go:1:17 container_packageName:a name:A package_id:test/pkg/a package_registry:go",
-				"b/b.go:1:43": "/src/test/pkg/a/a.go:1:17 container_packageName:a name:A package_id:test/pkg/a package_registry:go",
+				"a/a.go:1:17": "/src/test/pkg/a/a.go:1:17 name:A package:test/pkg/a packageName:a",
+				"b/b.go:1:43": "/src/test/pkg/a/a.go:1:17 name:A package:test/pkg/a packageName:a",
 			},
 			wantReferences: map[string][]string{
 				"a/a.go:1:17": []string{
@@ -305,8 +305,8 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				"is:exported": []string{"/src/test/pkg/a/a.go:function:a.A:1:17"},
 			},
 			wantWorkspaceReferences: []string{
-				"/src/test/pkg/b/b.go:1:19-1:19 -> container_packageName:a package_id:test/pkg/a package_registry:go",
-				"/src/test/pkg/b/b.go:1:43-1:43 -> container_packageName:a name:A package_id:test/pkg/a package_registry:go",
+				"/src/test/pkg/b/b.go:1:19-1:19 -> package:test/pkg/a packageName:a",
+				"/src/test/pkg/b/b.go:1:43-1:43 -> name:A package:test/pkg/a packageName:a",
 			},
 		},
 		"go vendored dep": {
@@ -322,7 +322,7 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				"a.go:1:61": "/src/test/pkg/vendor/github.com/v/vendored/v.go:1:24",
 			},
 			wantXDefinition: map[string]string{
-				"a.go:1:61": "/src/test/pkg/vendor/github.com/v/vendored/v.go:1:24 container_packageName:vendored name:V package_id:test/pkg/vendor/github.com/v/vendored package_registry:go vendor:true",
+				"a.go:1:61": "/src/test/pkg/vendor/github.com/v/vendored/v.go:1:24 name:V package:test/pkg/vendor/github.com/v/vendored packageName:vendored vendor:true",
 			},
 			wantReferences: map[string][]string{
 				"vendor/github.com/v/vendored/v.go:1:24": []string{
@@ -339,8 +339,8 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				"is:exported": []string{},
 			},
 			wantWorkspaceReferences: []string{
-				"/src/test/pkg/a.go:1:19-1:19 -> container_packageName:vendored package_id:test/pkg/vendor/github.com/v/vendored package_registry:go vendor:true",
-				"/src/test/pkg/a.go:1:61-1:61 -> container_packageName:vendored name:V package_id:test/pkg/vendor/github.com/v/vendored package_registry:go vendor:true",
+				"/src/test/pkg/a.go:1:19-1:19 -> package:test/pkg/vendor/github.com/v/vendored packageName:vendored vendor:true",
+				"/src/test/pkg/a.go:1:61-1:61 -> name:V package:test/pkg/vendor/github.com/v/vendored packageName:vendored vendor:true",
 			},
 		},
 		"go vendor symbols with same name": {
@@ -392,7 +392,7 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				"a.go:1:51": "/src/github.com/d/dep/d.go:1:19",
 			},
 			wantXDefinition: map[string]string{
-				"a.go:1:51": "/src/github.com/d/dep/d.go:1:19 container_packageName:dep name:D package_id:github.com/d/dep package_registry:go",
+				"a.go:1:51": "/src/github.com/d/dep/d.go:1:19 name:D package:github.com/d/dep packageName:dep",
 			},
 			wantReferences: map[string][]string{
 				"a.go:1:51": []string{
@@ -404,9 +404,9 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				},
 			},
 			wantWorkspaceReferences: []string{
-				"/src/test/pkg/a.go:1:19-1:19 -> container_packageName:dep package_id:github.com/d/dep package_registry:go",
-				"/src/test/pkg/a.go:1:51-1:51 -> container_packageName:dep name:D package_id:github.com/d/dep package_registry:go",
-				"/src/test/pkg/a.go:1:66-1:66 -> container_packageName:dep name:D package_id:github.com/d/dep package_registry:go",
+				"/src/test/pkg/a.go:1:19-1:19 -> package:github.com/d/dep packageName:dep",
+				"/src/test/pkg/a.go:1:51-1:51 -> name:D package:github.com/d/dep packageName:dep",
+				"/src/test/pkg/a.go:1:66-1:66 -> name:D package:github.com/d/dep packageName:dep",
 			},
 			mountFS: map[string]map[string]string{
 				"/src/github.com/d/dep": {
@@ -423,12 +423,12 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				"a.go:1:55": "/src/github.com/d/dep/vendor/vendp/vp.go:1:32",
 			},
 			wantXDefinition: map[string]string{
-				"a.go:1:55": "/src/github.com/d/dep/vendor/vendp/vp.go:1:32 container_packageName:vendp container_parent:V name:F package_id:github.com/d/dep/vendor/vendp package_registry:go vendor:true",
+				"a.go:1:55": "/src/github.com/d/dep/vendor/vendp/vp.go:1:32 name:F package:github.com/d/dep/vendor/vendp packageName:vendp recv:V vendor:true",
 			},
 			wantWorkspaceReferences: []string{
-				"/src/test/pkg/a.go:1:19-1:19 -> container_packageName:dep package_id:github.com/d/dep package_registry:go",
-				"/src/test/pkg/a.go:1:55-1:55 -> container_packageName:vendp container_parent:V name:F package_id:github.com/d/dep/vendor/vendp package_registry:go vendor:true",
-				"/src/test/pkg/a.go:1:51-1:51 -> container_packageName:dep name:D package_id:github.com/d/dep package_registry:go",
+				"/src/test/pkg/a.go:1:19-1:19 -> package:github.com/d/dep packageName:dep",
+				"/src/test/pkg/a.go:1:55-1:55 -> name:F package:github.com/d/dep/vendor/vendp packageName:vendp recv:V vendor:true",
+				"/src/test/pkg/a.go:1:51-1:51 -> name:D package:github.com/d/dep packageName:dep",
 			},
 			mountFS: map[string]map[string]string{
 				"/src/github.com/d/dep": map[string]string{
@@ -449,11 +449,11 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				"a.go:1:57": "/src/github.com/d/dep/subp/d.go:1:20",
 			},
 			wantXDefinition: map[string]string{
-				"a.go:1:57": "/src/github.com/d/dep/subp/d.go:1:20 container_packageName:subp name:D package_id:github.com/d/dep/subp package_registry:go",
+				"a.go:1:57": "/src/github.com/d/dep/subp/d.go:1:20 name:D package:github.com/d/dep/subp packageName:subp",
 			},
 			wantWorkspaceReferences: []string{
-				"/src/test/pkg/a.go:1:19-1:19 -> container_packageName:subp package_id:github.com/d/dep/subp package_registry:go",
-				"/src/test/pkg/a.go:1:57-1:57 -> container_packageName:subp name:D package_id:github.com/d/dep/subp package_registry:go",
+				"/src/test/pkg/a.go:1:19-1:19 -> package:github.com/d/dep/subp packageName:subp",
+				"/src/test/pkg/a.go:1:57-1:57 -> name:D package:github.com/d/dep/subp packageName:subp",
 			},
 			mountFS: map[string]map[string]string{
 				"/src/github.com/d/dep": {
@@ -475,13 +475,13 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				"a.go:1:58": "/src/github.com/d/dep2/d2.go:1:32", // field D2
 			},
 			wantXDefinition: map[string]string{
-				"a.go:1:53": "/src/github.com/d/dep1/d1.go:1:48 container_packageName:dep1 name:D1 package_id:github.com/d/dep1 package_registry:go",
-				"a.go:1:58": "/src/github.com/d/dep2/d2.go:1:32 container_packageName:dep2 container_parent:D2 name:D2 package_id:github.com/d/dep2 package_registry:go",
+				"a.go:1:53": "/src/github.com/d/dep1/d1.go:1:48 name:D1 package:github.com/d/dep1 packageName:dep1",
+				"a.go:1:58": "/src/github.com/d/dep2/d2.go:1:32 name:D2 package:github.com/d/dep2 packageName:dep2 recv:D2",
 			},
 			wantWorkspaceReferences: []string{
-				"/src/test/pkg/a.go:1:19-1:19 -> container_packageName:dep1 package_id:github.com/d/dep1 package_registry:go",
-				"/src/test/pkg/a.go:1:58-1:58 -> container_packageName:dep2 container_parent:D2 name:D2 package_id:github.com/d/dep2 package_registry:go",
-				"/src/test/pkg/a.go:1:53-1:53 -> container_packageName:dep1 name:D1 package_id:github.com/d/dep1 package_registry:go",
+				"/src/test/pkg/a.go:1:19-1:19 -> package:github.com/d/dep1 packageName:dep1",
+				"/src/test/pkg/a.go:1:58-1:58 -> name:D2 package:github.com/d/dep2 packageName:dep2 recv:D2",
+				"/src/test/pkg/a.go:1:53-1:53 -> name:D1 package:github.com/d/dep1 packageName:dep1",
 			},
 			mountFS: map[string]map[string]string{
 				"/src/github.com/d/dep1": {
@@ -602,12 +602,12 @@ type Header struct {
 				},
 			},
 			wantWorkspaceReferences: []string{
-				"/src/test/pkg/a.go:1:19-1:19 -> container_packageName:fmt package_id:fmt package_registry:go",
-				"/src/test/pkg/a.go:1:38-1:38 -> container_packageName:fmt name:Println package_id:fmt package_registry:go",
-				"/src/test/pkg/b.go:1:19-1:19 -> container_packageName:fmt package_id:fmt package_registry:go",
-				"/src/test/pkg/b.go:1:38-1:38 -> container_packageName:fmt name:Println package_id:fmt package_registry:go",
-				"/src/test/pkg/c.go:1:19-1:19 -> container_packageName:fmt package_id:fmt package_registry:go",
-				"/src/test/pkg/c.go:1:38-1:38 -> container_packageName:fmt name:Println package_id:fmt package_registry:go",
+				"/src/test/pkg/a.go:1:19-1:19 -> package:fmt packageName:fmt",
+				"/src/test/pkg/a.go:1:38-1:38 -> name:Println package:fmt packageName:fmt",
+				"/src/test/pkg/b.go:1:19-1:19 -> package:fmt packageName:fmt",
+				"/src/test/pkg/b.go:1:38-1:38 -> name:Println package:fmt packageName:fmt",
+				"/src/test/pkg/c.go:1:19-1:19 -> package:fmt packageName:fmt",
+				"/src/test/pkg/c.go:1:38-1:38 -> name:Println package:fmt packageName:fmt",
 			},
 		},
 	}
@@ -925,10 +925,7 @@ func callXDefinition(ctx context.Context, c *jsonrpc2.Conn, uri string, line, ch
 		if i != 0 {
 			str += ", "
 		}
-		if len(loc.Symbol) > 1 {
-			return "", errors.New("expected one symbol got > 1")
-		}
-		str += fmt.Sprintf("%s:%d:%d %s", loc.Location.URI, loc.Location.Range.Start.Line+1, loc.Location.Range.Start.Character+1, loc.Symbol[0])
+		str += fmt.Sprintf("%s:%d:%d %s", loc.Location.URI, loc.Location.Range.Start.Line+1, loc.Location.Range.Start.Character+1, loc.Symbol)
 	}
 	return str, nil
 }

--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -31,7 +31,7 @@ func TestServer(t *testing.T) {
 		wantReferences          map[string][]string
 		wantSymbols             map[string][]string
 		wantWorkspaceSymbols    map[string][]string
-		wantWorkspaceReferences []string
+		wantWorkspaceReferences map[*lspext.WorkspaceReferencesParams][]string
 		mountFS                 map[string]map[string]string // mount dir -> map VFS
 	}{
 		"go basic": {
@@ -90,7 +90,7 @@ func TestServer(t *testing.T) {
 				"dir:/ A":     []string{"/src/test/pkg/a.go:function:pkg.A:1:17"},
 				"dir:/ B":     []string{"/src/test/pkg/b.go:function:pkg.B:1:17"},
 			},
-			wantWorkspaceReferences: []string{},
+			wantWorkspaceReferences: map[*lspext.WorkspaceReferencesParams][]string{},
 		},
 		"go detailed": {
 			rootPath: "file:///src/test/pkg",
@@ -111,7 +111,7 @@ func TestServer(t *testing.T) {
 				"F":           []string{}, // we don't return fields for now
 				"is:exported": []string{"/src/test/pkg/a.go:class:pkg.T:1:17"},
 			},
-			wantWorkspaceReferences: []string{},
+			wantWorkspaceReferences: map[*lspext.WorkspaceReferencesParams][]string{},
 		},
 		"exported defs unexported type": {
 			rootPath: "file:///src/test/pkg",
@@ -124,7 +124,7 @@ func TestServer(t *testing.T) {
 			wantWorkspaceSymbols: map[string][]string{
 				"is:exported": []string{},
 			},
-			wantWorkspaceReferences: []string{},
+			wantWorkspaceReferences: map[*lspext.WorkspaceReferencesParams][]string{},
 		},
 		"go xtest": {
 			rootPath: "file:///src/test/pkg",
@@ -137,7 +137,7 @@ func TestServer(t *testing.T) {
 				"a_test.go:1:40": "var X int",
 				"a_test.go:1:46": "var A int",
 			},
-			wantWorkspaceReferences: []string{},
+			wantWorkspaceReferences: map[*lspext.WorkspaceReferencesParams][]string{},
 		},
 		"go subdirectory in repo": {
 			rootPath: "file:///src/test/pkg/d",
@@ -181,9 +181,42 @@ func TestServer(t *testing.T) {
 				"dir:./d2":    []string{"/src/test/pkg/d/d2/b.go:function:d2.B:1:39"},
 				"dir:d2/":     []string{"/src/test/pkg/d/d2/b.go:function:d2.B:1:39"},
 			},
-			wantWorkspaceReferences: []string{
-				"/src/test/pkg/d/d2/b.go:1:20-1:20 -> name: package:test/pkg/d packageName:d recv: vendor:false",
-				"/src/test/pkg/d/d2/b.go:1:47-1:47 -> name:A package:test/pkg/d packageName:d recv: vendor:false",
+			wantWorkspaceReferences: map[*lspext.WorkspaceReferencesParams][]string{
+				// Non-matching name query.
+				{Query: lspext.SymbolDescriptor{"name": "nope"}}: []string{},
+
+				// Matching against invalid field name.
+				{Query: lspext.SymbolDescriptor{"nope": "A"}}: []string{},
+
+				// Matching against single field.
+				{Query: lspext.SymbolDescriptor{"package": "test/pkg/d"}}: []string{
+					"/src/test/pkg/d/d2/b.go:1:20-1:20 -> name: package:test/pkg/d packageName:d recv: vendor:false",
+					"/src/test/pkg/d/d2/b.go:1:47-1:47 -> name:A package:test/pkg/d packageName:d recv: vendor:false",
+				},
+
+				// Matching against no fields.
+				{Query: lspext.SymbolDescriptor{}}: []string{
+					"/src/test/pkg/d/d2/b.go:1:20-1:20 -> name: package:test/pkg/d packageName:d recv: vendor:false",
+					"/src/test/pkg/d/d2/b.go:1:47-1:47 -> name:A package:test/pkg/d packageName:d recv: vendor:false",
+				},
+				{
+					Query: lspext.SymbolDescriptor{
+						"name":        "",
+						"package":     "test/pkg/d",
+						"packageName": "d",
+						"recv":        "",
+						"vendor":      false,
+					},
+				}: []string{"/src/test/pkg/d/d2/b.go:1:20-1:20 -> name: package:test/pkg/d packageName:d recv: vendor:false"},
+				{
+					Query: lspext.SymbolDescriptor{
+						"name":        "A",
+						"package":     "test/pkg/d",
+						"packageName": "d",
+						"recv":        "",
+						"vendor":      false,
+					},
+				}: []string{"/src/test/pkg/d/d2/b.go:1:47-1:47 -> name:A package:test/pkg/d packageName:d recv: vendor:false"},
 			},
 		},
 		"go multiple packages in dir": {
@@ -223,7 +256,7 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				"":            []string{"/src/test/pkg/a.go:function:pkg.A:1:17"},
 				"is:exported": []string{"/src/test/pkg/a.go:function:pkg.A:1:17"},
 			},
-			wantWorkspaceReferences: []string{},
+			wantWorkspaceReferences: map[*lspext.WorkspaceReferencesParams][]string{},
 		},
 		"goroot": {
 			rootPath: "file:///src/test/pkg",
@@ -261,9 +294,11 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				},
 				"is:exported": []string{},
 			},
-			wantWorkspaceReferences: []string{
-				"/src/test/pkg/a.go:1:19-1:19 -> name: package:fmt packageName:fmt recv: vendor:false",
-				"/src/test/pkg/a.go:1:38-1:38 -> name:Println package:fmt packageName:fmt recv: vendor:false",
+			wantWorkspaceReferences: map[*lspext.WorkspaceReferencesParams][]string{
+				{Query: lspext.SymbolDescriptor{}}: []string{
+					"/src/test/pkg/a.go:1:19-1:19 -> name: package:fmt packageName:fmt recv: vendor:false",
+					"/src/test/pkg/a.go:1:38-1:38 -> name:Println package:fmt packageName:fmt recv: vendor:false",
+				},
 			},
 		},
 		"gopath": {
@@ -304,9 +339,11 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				"":            []string{"/src/test/pkg/a/a.go:function:a.A:1:17", "/src/test/pkg/b/b.go:variable:b._:1:33"},
 				"is:exported": []string{"/src/test/pkg/a/a.go:function:a.A:1:17"},
 			},
-			wantWorkspaceReferences: []string{
-				"/src/test/pkg/b/b.go:1:19-1:19 -> name: package:test/pkg/a packageName:a recv: vendor:false",
-				"/src/test/pkg/b/b.go:1:43-1:43 -> name:A package:test/pkg/a packageName:a recv: vendor:false",
+			wantWorkspaceReferences: map[*lspext.WorkspaceReferencesParams][]string{
+				{Query: lspext.SymbolDescriptor{}}: []string{
+					"/src/test/pkg/b/b.go:1:19-1:19 -> name: package:test/pkg/a packageName:a recv: vendor:false",
+					"/src/test/pkg/b/b.go:1:43-1:43 -> name:A package:test/pkg/a packageName:a recv: vendor:false",
+				},
 			},
 		},
 		"go vendored dep": {
@@ -338,9 +375,11 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				"":            []string{"/src/test/pkg/a.go:variable:pkg._:1:44", "/src/test/pkg/vendor/github.com/v/vendored/v.go:function:vendored.V:1:24"},
 				"is:exported": []string{},
 			},
-			wantWorkspaceReferences: []string{
-				"/src/test/pkg/a.go:1:19-1:19 -> name: package:test/pkg/vendor/github.com/v/vendored packageName:vendored recv: vendor:true",
-				"/src/test/pkg/a.go:1:61-1:61 -> name:V package:test/pkg/vendor/github.com/v/vendored packageName:vendored recv: vendor:true",
+			wantWorkspaceReferences: map[*lspext.WorkspaceReferencesParams][]string{
+				{Query: lspext.SymbolDescriptor{}}: []string{
+					"/src/test/pkg/a.go:1:19-1:19 -> name: package:test/pkg/vendor/github.com/v/vendored packageName:vendored recv: vendor:true",
+					"/src/test/pkg/a.go:1:61-1:61 -> name:V package:test/pkg/vendor/github.com/v/vendored packageName:vendored recv: vendor:true",
+				},
 			},
 		},
 		"go vendor symbols with same name": {
@@ -378,7 +417,7 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				},
 				"is:exported": []string{},
 			},
-			wantWorkspaceReferences: []string{},
+			wantWorkspaceReferences: map[*lspext.WorkspaceReferencesParams][]string{},
 		},
 		"go external dep": {
 			rootPath: "file:///src/test/pkg",
@@ -403,10 +442,12 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 					// workspace.
 				},
 			},
-			wantWorkspaceReferences: []string{
-				"/src/test/pkg/a.go:1:19-1:19 -> name: package:github.com/d/dep packageName:dep recv: vendor:false",
-				"/src/test/pkg/a.go:1:51-1:51 -> name:D package:github.com/d/dep packageName:dep recv: vendor:false",
-				"/src/test/pkg/a.go:1:66-1:66 -> name:D package:github.com/d/dep packageName:dep recv: vendor:false",
+			wantWorkspaceReferences: map[*lspext.WorkspaceReferencesParams][]string{
+				{Query: lspext.SymbolDescriptor{}}: []string{
+					"/src/test/pkg/a.go:1:19-1:19 -> name: package:github.com/d/dep packageName:dep recv: vendor:false",
+					"/src/test/pkg/a.go:1:51-1:51 -> name:D package:github.com/d/dep packageName:dep recv: vendor:false",
+					"/src/test/pkg/a.go:1:66-1:66 -> name:D package:github.com/d/dep packageName:dep recv: vendor:false",
+				},
 			},
 			mountFS: map[string]map[string]string{
 				"/src/github.com/d/dep": {
@@ -425,10 +466,12 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 			wantXDefinition: map[string]string{
 				"a.go:1:55": "/src/github.com/d/dep/vendor/vendp/vp.go:1:32 name:F package:github.com/d/dep/vendor/vendp packageName:vendp recv:V vendor:true",
 			},
-			wantWorkspaceReferences: []string{
-				"/src/test/pkg/a.go:1:19-1:19 -> name: package:github.com/d/dep packageName:dep recv: vendor:false",
-				"/src/test/pkg/a.go:1:55-1:55 -> name:F package:github.com/d/dep/vendor/vendp packageName:vendp recv:V vendor:true",
-				"/src/test/pkg/a.go:1:51-1:51 -> name:D package:github.com/d/dep packageName:dep recv: vendor:false",
+			wantWorkspaceReferences: map[*lspext.WorkspaceReferencesParams][]string{
+				{Query: lspext.SymbolDescriptor{}}: []string{
+					"/src/test/pkg/a.go:1:19-1:19 -> name: package:github.com/d/dep packageName:dep recv: vendor:false",
+					"/src/test/pkg/a.go:1:55-1:55 -> name:F package:github.com/d/dep/vendor/vendp packageName:vendp recv:V vendor:true",
+					"/src/test/pkg/a.go:1:51-1:51 -> name:D package:github.com/d/dep packageName:dep recv: vendor:false",
+				},
 			},
 			mountFS: map[string]map[string]string{
 				"/src/github.com/d/dep": map[string]string{
@@ -451,9 +494,11 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 			wantXDefinition: map[string]string{
 				"a.go:1:57": "/src/github.com/d/dep/subp/d.go:1:20 name:D package:github.com/d/dep/subp packageName:subp recv: vendor:false",
 			},
-			wantWorkspaceReferences: []string{
-				"/src/test/pkg/a.go:1:19-1:19 -> name: package:github.com/d/dep/subp packageName:subp recv: vendor:false",
-				"/src/test/pkg/a.go:1:57-1:57 -> name:D package:github.com/d/dep/subp packageName:subp recv: vendor:false",
+			wantWorkspaceReferences: map[*lspext.WorkspaceReferencesParams][]string{
+				{Query: lspext.SymbolDescriptor{}}: []string{
+					"/src/test/pkg/a.go:1:19-1:19 -> name: package:github.com/d/dep/subp packageName:subp recv: vendor:false",
+					"/src/test/pkg/a.go:1:57-1:57 -> name:D package:github.com/d/dep/subp packageName:subp recv: vendor:false",
+				},
 			},
 			mountFS: map[string]map[string]string{
 				"/src/github.com/d/dep": {
@@ -478,10 +523,12 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				"a.go:1:53": "/src/github.com/d/dep1/d1.go:1:48 name:D1 package:github.com/d/dep1 packageName:dep1 recv: vendor:false",
 				"a.go:1:58": "/src/github.com/d/dep2/d2.go:1:32 name:D2 package:github.com/d/dep2 packageName:dep2 recv:D2 vendor:false",
 			},
-			wantWorkspaceReferences: []string{
-				"/src/test/pkg/a.go:1:19-1:19 -> name: package:github.com/d/dep1 packageName:dep1 recv: vendor:false",
-				"/src/test/pkg/a.go:1:58-1:58 -> name:D2 package:github.com/d/dep2 packageName:dep2 recv:D2 vendor:false",
-				"/src/test/pkg/a.go:1:53-1:53 -> name:D1 package:github.com/d/dep1 packageName:dep1 recv: vendor:false",
+			wantWorkspaceReferences: map[*lspext.WorkspaceReferencesParams][]string{
+				{Query: lspext.SymbolDescriptor{}}: []string{
+					"/src/test/pkg/a.go:1:19-1:19 -> name: package:github.com/d/dep1 packageName:dep1 recv: vendor:false",
+					"/src/test/pkg/a.go:1:58-1:58 -> name:D2 package:github.com/d/dep2 packageName:dep2 recv:D2 vendor:false",
+					"/src/test/pkg/a.go:1:53-1:53 -> name:D1 package:github.com/d/dep1 packageName:dep1 recv: vendor:false",
+				},
 			},
 			mountFS: map[string]map[string]string{
 				"/src/github.com/d/dep1": {
@@ -525,7 +572,7 @@ func yza() {}
 				"bcd":         []string{"/src/test/pkg/bcd.go:method:YZA.BCD:5:14", "/src/test/pkg/bcd.go:class:pkg.YZA:3:6"},
 				"is:exported": []string{"/src/test/pkg/abc.go:method:XYZ.ABC:5:14", "/src/test/pkg/bcd.go:method:YZA.BCD:5:14", "/src/test/pkg/abc.go:class:pkg.XYZ:3:6", "/src/test/pkg/bcd.go:class:pkg.YZA:3:6"},
 			},
-			wantWorkspaceReferences: []string{},
+			wantWorkspaceReferences: map[*lspext.WorkspaceReferencesParams][]string{},
 		},
 		"go hover docs": {
 			rootPath: "file:///src/test/pkg",
@@ -601,13 +648,15 @@ type Header struct {
 					"src/builtin/builtin.go": "package builtin; type int int",
 				},
 			},
-			wantWorkspaceReferences: []string{
-				"/src/test/pkg/a.go:1:19-1:19 -> name: package:fmt packageName:fmt recv: vendor:false",
-				"/src/test/pkg/a.go:1:38-1:38 -> name:Println package:fmt packageName:fmt recv: vendor:false",
-				"/src/test/pkg/b.go:1:19-1:19 -> name: package:fmt packageName:fmt recv: vendor:false",
-				"/src/test/pkg/b.go:1:38-1:38 -> name:Println package:fmt packageName:fmt recv: vendor:false",
-				"/src/test/pkg/c.go:1:19-1:19 -> name: package:fmt packageName:fmt recv: vendor:false",
-				"/src/test/pkg/c.go:1:38-1:38 -> name:Println package:fmt packageName:fmt recv: vendor:false",
+			wantWorkspaceReferences: map[*lspext.WorkspaceReferencesParams][]string{
+				{Query: lspext.SymbolDescriptor{}}: []string{
+					"/src/test/pkg/a.go:1:19-1:19 -> name: package:fmt packageName:fmt recv: vendor:false",
+					"/src/test/pkg/a.go:1:38-1:38 -> name:Println package:fmt packageName:fmt recv: vendor:false",
+					"/src/test/pkg/b.go:1:19-1:19 -> name: package:fmt packageName:fmt recv: vendor:false",
+					"/src/test/pkg/b.go:1:38-1:38 -> name:Println package:fmt packageName:fmt recv: vendor:false",
+					"/src/test/pkg/c.go:1:19-1:19 -> name: package:fmt packageName:fmt recv: vendor:false",
+					"/src/test/pkg/c.go:1:38-1:38 -> name:Println package:fmt packageName:fmt recv: vendor:false",
+				},
 			},
 		},
 	}
@@ -690,7 +739,7 @@ func dialServer(t testing.TB, addr string) *jsonrpc2.Conn {
 }
 
 // lspTests runs all test suites for LSP functionality.
-func lspTests(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, rootPath string, wantHover, wantDefinition, wantXDefinition map[string]string, wantReferences, wantSymbols, wantWorkspaceSymbols map[string][]string, wantWorkspaceReferences []string) {
+func lspTests(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, rootPath string, wantHover, wantDefinition, wantXDefinition map[string]string, wantReferences, wantSymbols, wantWorkspaceSymbols map[string][]string, wantWorkspaceReferences map[*lspext.WorkspaceReferencesParams][]string) {
 	for pos, want := range wantHover {
 		tbRun(t, fmt.Sprintf("hover-%s", strings.Replace(pos, "/", "-", -1)), func(t testing.TB) {
 			hoverTest(t, ctx, c, rootPath, pos, want)
@@ -727,9 +776,11 @@ func lspTests(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, rootPath stri
 	}
 
 	if wantWorkspaceReferences != nil {
-		tbRun(t, "workspaceReferences", func(t testing.TB) {
-			workspaceReferencesTest(t, ctx, c, rootPath, wantWorkspaceReferences)
-		})
+		for params, want := range wantWorkspaceReferences {
+			tbRun(t, fmt.Sprintf("workspaceReferences"), func(t testing.TB) {
+				workspaceReferencesTest(t, ctx, c, rootPath, *params, want)
+			})
+		}
 	}
 }
 
@@ -834,8 +885,8 @@ func workspaceSymbolsTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, r
 	}
 }
 
-func workspaceReferencesTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, rootPath string, want []string) {
-	references, err := callWorkspaceReferences(ctx, c)
+func workspaceReferencesTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, rootPath string, params lspext.WorkspaceReferencesParams, want []string) {
+	references, err := callWorkspaceReferences(ctx, c, params)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -977,9 +1028,9 @@ func callWorkspaceSymbols(ctx context.Context, c *jsonrpc2.Conn, query string) (
 	return syms, nil
 }
 
-func callWorkspaceReferences(ctx context.Context, c *jsonrpc2.Conn) ([]string, error) {
+func callWorkspaceReferences(ctx context.Context, c *jsonrpc2.Conn, params lspext.WorkspaceReferencesParams) ([]string, error) {
 	var references []lspext.ReferenceInformation
-	err := c.Call(ctx, "workspace/xreferences", lspext.WorkspaceReferencesParams{}, &references)
+	err := c.Call(ctx, "workspace/xreferences", params, &references)
 	if err != nil {
 		return nil, err
 	}

--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -54,10 +54,10 @@ func TestServer(t *testing.T) {
 				"b.go:1:23": "/src/test/pkg/a.go:1:17",
 			},
 			wantXDefinition: map[string]string{
-				"a.go:1:17": "/src/test/pkg/a.go:1:17 name:A package:test/pkg packageName:p",
-				"a.go:1:23": "/src/test/pkg/a.go:1:17 name:A package:test/pkg packageName:p",
-				"b.go:1:17": "/src/test/pkg/b.go:1:17 name:B package:test/pkg packageName:p",
-				"b.go:1:23": "/src/test/pkg/a.go:1:17 name:A package:test/pkg packageName:p",
+				"a.go:1:17": "/src/test/pkg/a.go:1:17 name:A package:test/pkg packageName:p recv: vendor:false",
+				"a.go:1:23": "/src/test/pkg/a.go:1:17 name:A package:test/pkg packageName:p recv: vendor:false",
+				"b.go:1:17": "/src/test/pkg/b.go:1:17 name:B package:test/pkg packageName:p recv: vendor:false",
+				"b.go:1:23": "/src/test/pkg/a.go:1:17 name:A package:test/pkg packageName:p recv: vendor:false",
 			},
 			wantReferences: map[string][]string{
 				"a.go:1:17": []string{
@@ -160,11 +160,11 @@ func TestServer(t *testing.T) {
 				"d2/b.go:1:52": "/src/test/pkg/d/d2/b.go:1:39",
 			},
 			wantXDefinition: map[string]string{
-				"a.go:1:17":    "/src/test/pkg/d/a.go:1:17 name:A package:test/pkg/d packageName:d",
-				"a.go:1:23":    "/src/test/pkg/d/a.go:1:17 name:A package:test/pkg/d packageName:d",
-				"d2/b.go:1:39": "/src/test/pkg/d/d2/b.go:1:39 name:B package:test/pkg/d/d2 packageName:d2",
-				"d2/b.go:1:47": "/src/test/pkg/d/a.go:1:17 name:A package:test/pkg/d packageName:d",
-				"d2/b.go:1:52": "/src/test/pkg/d/d2/b.go:1:39 name:B package:test/pkg/d/d2 packageName:d2",
+				"a.go:1:17":    "/src/test/pkg/d/a.go:1:17 name:A package:test/pkg/d packageName:d recv: vendor:false",
+				"a.go:1:23":    "/src/test/pkg/d/a.go:1:17 name:A package:test/pkg/d packageName:d recv: vendor:false",
+				"d2/b.go:1:39": "/src/test/pkg/d/d2/b.go:1:39 name:B package:test/pkg/d/d2 packageName:d2 recv: vendor:false",
+				"d2/b.go:1:47": "/src/test/pkg/d/a.go:1:17 name:A package:test/pkg/d packageName:d recv: vendor:false",
+				"d2/b.go:1:52": "/src/test/pkg/d/d2/b.go:1:39 name:B package:test/pkg/d/d2 packageName:d2 recv: vendor:false",
 			},
 			wantSymbols: map[string][]string{
 				"a.go":    []string{"/src/test/pkg/d/a.go:function:d.A:1:17"},
@@ -182,8 +182,8 @@ func TestServer(t *testing.T) {
 				"dir:d2/":     []string{"/src/test/pkg/d/d2/b.go:function:d2.B:1:39"},
 			},
 			wantWorkspaceReferences: []string{
-				"/src/test/pkg/d/d2/b.go:1:20-1:20 -> package:test/pkg/d packageName:d",
-				"/src/test/pkg/d/d2/b.go:1:47-1:47 -> name:A package:test/pkg/d packageName:d",
+				"/src/test/pkg/d/d2/b.go:1:20-1:20 -> name: package:test/pkg/d packageName:d recv: vendor:false",
+				"/src/test/pkg/d/d2/b.go:1:47-1:47 -> name:A package:test/pkg/d packageName:d recv: vendor:false",
 			},
 		},
 		"go multiple packages in dir": {
@@ -213,8 +213,8 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				// "main.go:3:52": "/src/test/pkg/main.go:3:39", // B() -> func B()
 			},
 			wantXDefinition: map[string]string{
-				"a.go:1:17": "/src/test/pkg/a.go:1:17 name:A package:test/pkg packageName:p",
-				"a.go:1:23": "/src/test/pkg/a.go:1:17 name:A package:test/pkg packageName:p",
+				"a.go:1:17": "/src/test/pkg/a.go:1:17 name:A package:test/pkg packageName:p recv: vendor:false",
+				"a.go:1:23": "/src/test/pkg/a.go:1:17 name:A package:test/pkg packageName:p recv: vendor:false",
 			},
 			wantSymbols: map[string][]string{
 				"a.go": []string{"/src/test/pkg/a.go:function:pkg.A:1:17"},
@@ -239,7 +239,7 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				// "a.go:1:53": "/goroot/src/builtin/builtin.go:TODO:TODO", // TODO(sqs): support builtins
 			},
 			wantXDefinition: map[string]string{
-				"a.go:1:40": "/goroot/src/fmt/print.go:1:19 name:Println package:fmt packageName:fmt",
+				"a.go:1:40": "/goroot/src/fmt/print.go:1:19 name:Println package:fmt packageName:fmt recv: vendor:false",
 			},
 			mountFS: map[string]map[string]string{
 				"/goroot": {
@@ -262,8 +262,8 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				"is:exported": []string{},
 			},
 			wantWorkspaceReferences: []string{
-				"/src/test/pkg/a.go:1:19-1:19 -> package:fmt packageName:fmt",
-				"/src/test/pkg/a.go:1:38-1:38 -> name:Println package:fmt packageName:fmt",
+				"/src/test/pkg/a.go:1:19-1:19 -> name: package:fmt packageName:fmt recv: vendor:false",
+				"/src/test/pkg/a.go:1:38-1:38 -> name:Println package:fmt packageName:fmt recv: vendor:false",
 			},
 		},
 		"gopath": {
@@ -283,8 +283,8 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				"b/b.go:1:43": "/src/test/pkg/a/a.go:1:17",
 			},
 			wantXDefinition: map[string]string{
-				"a/a.go:1:17": "/src/test/pkg/a/a.go:1:17 name:A package:test/pkg/a packageName:a",
-				"b/b.go:1:43": "/src/test/pkg/a/a.go:1:17 name:A package:test/pkg/a packageName:a",
+				"a/a.go:1:17": "/src/test/pkg/a/a.go:1:17 name:A package:test/pkg/a packageName:a recv: vendor:false",
+				"b/b.go:1:43": "/src/test/pkg/a/a.go:1:17 name:A package:test/pkg/a packageName:a recv: vendor:false",
 			},
 			wantReferences: map[string][]string{
 				"a/a.go:1:17": []string{
@@ -305,8 +305,8 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				"is:exported": []string{"/src/test/pkg/a/a.go:function:a.A:1:17"},
 			},
 			wantWorkspaceReferences: []string{
-				"/src/test/pkg/b/b.go:1:19-1:19 -> package:test/pkg/a packageName:a",
-				"/src/test/pkg/b/b.go:1:43-1:43 -> name:A package:test/pkg/a packageName:a",
+				"/src/test/pkg/b/b.go:1:19-1:19 -> name: package:test/pkg/a packageName:a recv: vendor:false",
+				"/src/test/pkg/b/b.go:1:43-1:43 -> name:A package:test/pkg/a packageName:a recv: vendor:false",
 			},
 		},
 		"go vendored dep": {
@@ -322,7 +322,7 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				"a.go:1:61": "/src/test/pkg/vendor/github.com/v/vendored/v.go:1:24",
 			},
 			wantXDefinition: map[string]string{
-				"a.go:1:61": "/src/test/pkg/vendor/github.com/v/vendored/v.go:1:24 name:V package:test/pkg/vendor/github.com/v/vendored packageName:vendored vendor:true",
+				"a.go:1:61": "/src/test/pkg/vendor/github.com/v/vendored/v.go:1:24 name:V package:test/pkg/vendor/github.com/v/vendored packageName:vendored recv: vendor:true",
 			},
 			wantReferences: map[string][]string{
 				"vendor/github.com/v/vendored/v.go:1:24": []string{
@@ -339,8 +339,8 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				"is:exported": []string{},
 			},
 			wantWorkspaceReferences: []string{
-				"/src/test/pkg/a.go:1:19-1:19 -> package:test/pkg/vendor/github.com/v/vendored packageName:vendored vendor:true",
-				"/src/test/pkg/a.go:1:61-1:61 -> name:V package:test/pkg/vendor/github.com/v/vendored packageName:vendored vendor:true",
+				"/src/test/pkg/a.go:1:19-1:19 -> name: package:test/pkg/vendor/github.com/v/vendored packageName:vendored recv: vendor:true",
+				"/src/test/pkg/a.go:1:61-1:61 -> name:V package:test/pkg/vendor/github.com/v/vendored packageName:vendored recv: vendor:true",
 			},
 		},
 		"go vendor symbols with same name": {
@@ -392,7 +392,7 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				"a.go:1:51": "/src/github.com/d/dep/d.go:1:19",
 			},
 			wantXDefinition: map[string]string{
-				"a.go:1:51": "/src/github.com/d/dep/d.go:1:19 name:D package:github.com/d/dep packageName:dep",
+				"a.go:1:51": "/src/github.com/d/dep/d.go:1:19 name:D package:github.com/d/dep packageName:dep recv: vendor:false",
 			},
 			wantReferences: map[string][]string{
 				"a.go:1:51": []string{
@@ -404,9 +404,9 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				},
 			},
 			wantWorkspaceReferences: []string{
-				"/src/test/pkg/a.go:1:19-1:19 -> package:github.com/d/dep packageName:dep",
-				"/src/test/pkg/a.go:1:51-1:51 -> name:D package:github.com/d/dep packageName:dep",
-				"/src/test/pkg/a.go:1:66-1:66 -> name:D package:github.com/d/dep packageName:dep",
+				"/src/test/pkg/a.go:1:19-1:19 -> name: package:github.com/d/dep packageName:dep recv: vendor:false",
+				"/src/test/pkg/a.go:1:51-1:51 -> name:D package:github.com/d/dep packageName:dep recv: vendor:false",
+				"/src/test/pkg/a.go:1:66-1:66 -> name:D package:github.com/d/dep packageName:dep recv: vendor:false",
 			},
 			mountFS: map[string]map[string]string{
 				"/src/github.com/d/dep": {
@@ -426,9 +426,9 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				"a.go:1:55": "/src/github.com/d/dep/vendor/vendp/vp.go:1:32 name:F package:github.com/d/dep/vendor/vendp packageName:vendp recv:V vendor:true",
 			},
 			wantWorkspaceReferences: []string{
-				"/src/test/pkg/a.go:1:19-1:19 -> package:github.com/d/dep packageName:dep",
+				"/src/test/pkg/a.go:1:19-1:19 -> name: package:github.com/d/dep packageName:dep recv: vendor:false",
 				"/src/test/pkg/a.go:1:55-1:55 -> name:F package:github.com/d/dep/vendor/vendp packageName:vendp recv:V vendor:true",
-				"/src/test/pkg/a.go:1:51-1:51 -> name:D package:github.com/d/dep packageName:dep",
+				"/src/test/pkg/a.go:1:51-1:51 -> name:D package:github.com/d/dep packageName:dep recv: vendor:false",
 			},
 			mountFS: map[string]map[string]string{
 				"/src/github.com/d/dep": map[string]string{
@@ -449,11 +449,11 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				"a.go:1:57": "/src/github.com/d/dep/subp/d.go:1:20",
 			},
 			wantXDefinition: map[string]string{
-				"a.go:1:57": "/src/github.com/d/dep/subp/d.go:1:20 name:D package:github.com/d/dep/subp packageName:subp",
+				"a.go:1:57": "/src/github.com/d/dep/subp/d.go:1:20 name:D package:github.com/d/dep/subp packageName:subp recv: vendor:false",
 			},
 			wantWorkspaceReferences: []string{
-				"/src/test/pkg/a.go:1:19-1:19 -> package:github.com/d/dep/subp packageName:subp",
-				"/src/test/pkg/a.go:1:57-1:57 -> name:D package:github.com/d/dep/subp packageName:subp",
+				"/src/test/pkg/a.go:1:19-1:19 -> name: package:github.com/d/dep/subp packageName:subp recv: vendor:false",
+				"/src/test/pkg/a.go:1:57-1:57 -> name:D package:github.com/d/dep/subp packageName:subp recv: vendor:false",
 			},
 			mountFS: map[string]map[string]string{
 				"/src/github.com/d/dep": {
@@ -475,13 +475,13 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				"a.go:1:58": "/src/github.com/d/dep2/d2.go:1:32", // field D2
 			},
 			wantXDefinition: map[string]string{
-				"a.go:1:53": "/src/github.com/d/dep1/d1.go:1:48 name:D1 package:github.com/d/dep1 packageName:dep1",
-				"a.go:1:58": "/src/github.com/d/dep2/d2.go:1:32 name:D2 package:github.com/d/dep2 packageName:dep2 recv:D2",
+				"a.go:1:53": "/src/github.com/d/dep1/d1.go:1:48 name:D1 package:github.com/d/dep1 packageName:dep1 recv: vendor:false",
+				"a.go:1:58": "/src/github.com/d/dep2/d2.go:1:32 name:D2 package:github.com/d/dep2 packageName:dep2 recv:D2 vendor:false",
 			},
 			wantWorkspaceReferences: []string{
-				"/src/test/pkg/a.go:1:19-1:19 -> package:github.com/d/dep1 packageName:dep1",
-				"/src/test/pkg/a.go:1:58-1:58 -> name:D2 package:github.com/d/dep2 packageName:dep2 recv:D2",
-				"/src/test/pkg/a.go:1:53-1:53 -> name:D1 package:github.com/d/dep1 packageName:dep1",
+				"/src/test/pkg/a.go:1:19-1:19 -> name: package:github.com/d/dep1 packageName:dep1 recv: vendor:false",
+				"/src/test/pkg/a.go:1:58-1:58 -> name:D2 package:github.com/d/dep2 packageName:dep2 recv:D2 vendor:false",
+				"/src/test/pkg/a.go:1:53-1:53 -> name:D1 package:github.com/d/dep1 packageName:dep1 recv: vendor:false",
 			},
 			mountFS: map[string]map[string]string{
 				"/src/github.com/d/dep1": {
@@ -602,12 +602,12 @@ type Header struct {
 				},
 			},
 			wantWorkspaceReferences: []string{
-				"/src/test/pkg/a.go:1:19-1:19 -> package:fmt packageName:fmt",
-				"/src/test/pkg/a.go:1:38-1:38 -> name:Println package:fmt packageName:fmt",
-				"/src/test/pkg/b.go:1:19-1:19 -> package:fmt packageName:fmt",
-				"/src/test/pkg/b.go:1:38-1:38 -> name:Println package:fmt packageName:fmt",
-				"/src/test/pkg/c.go:1:19-1:19 -> package:fmt packageName:fmt",
-				"/src/test/pkg/c.go:1:38-1:38 -> name:Println package:fmt packageName:fmt",
+				"/src/test/pkg/a.go:1:19-1:19 -> name: package:fmt packageName:fmt recv: vendor:false",
+				"/src/test/pkg/a.go:1:38-1:38 -> name:Println package:fmt packageName:fmt recv: vendor:false",
+				"/src/test/pkg/b.go:1:19-1:19 -> name: package:fmt packageName:fmt recv: vendor:false",
+				"/src/test/pkg/b.go:1:38-1:38 -> name:Println package:fmt packageName:fmt recv: vendor:false",
+				"/src/test/pkg/c.go:1:19-1:19 -> name: package:fmt packageName:fmt recv: vendor:false",
+				"/src/test/pkg/c.go:1:38-1:38 -> name:Println package:fmt packageName:fmt recv: vendor:false",
 			},
 		},
 	}

--- a/langserver/workspace_refs.go
+++ b/langserver/workspace_refs.go
@@ -27,7 +27,6 @@ import (
 
 func (h *LangHandler) handleWorkspaceReferences(ctx context.Context, conn JSONRPC2Conn, req *jsonrpc2.Request, params lspext.WorkspaceReferencesParams) ([]lspext.ReferenceInformation, error) {
 	// TODO(slimsag): respect params.Files
-	// TODO(slimsag): properly handle vendor
 
 	rootPath := h.FilePath(h.init.RootPath)
 	bctx := h.OverlayBuildContext(ctx, h.defaultBuildContext(), !h.init.NoOSFileSystemAccess)

--- a/langserver/workspace_refs.go
+++ b/langserver/workspace_refs.go
@@ -226,21 +226,24 @@ func defSymbolDescriptor(bctx *build.Context, rootPath string, def refs.Def) (ls
 	}
 
 	desc := lspext.SymbolDescriptor{
+		"vendor":      IsVendorDir(defPkg.Dir),
 		"package":     defPkg.ImportPath,
 		"packageName": def.PackageName,
-	}
-
-	if IsVendorDir(defPkg.Dir) {
-		desc["vendor"] = true
+		"recv":        "",
+		"name":        "",
 	}
 
 	fields := strings.Fields(def.Path)
-	if len(fields) >= 1 {
-		desc["name"] = fields[0]
-	}
-	if len(fields) >= 2 {
+	switch {
+	case len(fields) == 0:
+		// reference to just a package
+	case len(fields) >= 2:
 		desc["recv"] = fields[0]
 		desc["name"] = fields[1]
+	case len(fields) >= 1:
+		desc["name"] = fields[0]
+	default:
+		panic("invalid def.Path response from internal/refs")
 	}
 	return desc, nil
 }

--- a/langserver/workspace_refs.go
+++ b/langserver/workspace_refs.go
@@ -26,7 +26,8 @@ import (
 )
 
 func (h *LangHandler) handleWorkspaceReferences(ctx context.Context, conn JSONRPC2Conn, req *jsonrpc2.Request, params lspext.WorkspaceReferencesParams) ([]lspext.ReferenceInformation, error) {
-	// TODO(slimsag): respect params.Files
+	// TODO(slimsag): respect params.Files which will make performance in any
+	// moderately sized repository more bearable (right now these are really bad).
 
 	rootPath := h.FilePath(h.init.RootPath)
 	bctx := h.OverlayBuildContext(ctx, h.defaultBuildContext(), !h.init.NoOSFileSystemAccess)

--- a/pkg/lsp/service.go
+++ b/pkg/lsp/service.go
@@ -58,6 +58,10 @@ type ServerCapabilities struct {
 	// XWorkspaceReferencesProvider indicates the server provides support for
 	// xworkspace/references. This is a Sourcegraph extension.
 	XWorkspaceReferencesProvider bool `json:"xworkspaceReferencesProvider,omitempty"`
+
+	// XDefinitionProvider indicates the server provides support for
+	// textDocument/xdefinition. This is a Sourcegraph extension.
+	XDefinitionProvider bool `json:"xdefinitionProvider,omitempty"`
 }
 
 type CompletionOptions struct {

--- a/pkg/lspext/lspext.go
+++ b/pkg/lspext/lspext.go
@@ -47,6 +47,18 @@ type LocationInformation struct {
 	Symbol SymbolDescriptor `json:"SymbolDescriptor"`
 }
 
+// Contains tells if this SymbolDescriptor fully contains all of the keys and
+// values in the other symbol descriptor.
+func (s SymbolDescriptor) Contains(other SymbolDescriptor) bool {
+	for k, v := range other {
+		v2, ok := s[k]
+		if !ok || v != v2 {
+			return false
+		}
+	}
+	return true
+}
+
 // String returns a consistently ordered string representation of the
 // SymbolDescriptor. It is useful for testing.
 func (s SymbolDescriptor) String() string {

--- a/pkg/lspext/lspext.go
+++ b/pkg/lspext/lspext.go
@@ -39,8 +39,8 @@ type ReferenceInformation struct {
 // guaranteed to do so.
 type SymbolDescriptor map[string]interface{}
 
-// LocationInformation is the response type for the `textDocument/xdefinition` extension.
-type LocationInformation struct {
+// SymbolLocationInformation is the response type for the `textDocument/xdefinition` extension.
+type SymbolLocationInformation struct {
 	// A concrete location at which the definition is located, if any.
 	Location lsp.Location `json:"location,omitempty"`
 	// Metadata about the definition.

--- a/pkg/lspext/lspext.go
+++ b/pkg/lspext/lspext.go
@@ -13,6 +13,11 @@ import (
 // See: https://github.com/sourcegraph/language-server-protocol/blob/master/extension-workspace-reference.md
 //
 type WorkspaceReferencesParams struct {
+	// Query represents metadata about the symbol that is being searched for.
+	Query SymbolDescriptor `json:"query"`
+
+	// Files is an optional list of files to restrict the search to.
+	Files []string `json:"files,omitempty"`
 }
 
 // ReferenceInformation represents information about a reference to programming
@@ -27,103 +32,27 @@ type ReferenceInformation struct {
 }
 
 // SymbolDescriptor represents information about a programming construct like a
-// variable, class, interface etc that has a reference to it. Effectively, it
-// contains data similar to SymbolInformation except all fields are optional.
+// variable, class, interface, etc that has a reference to it. It is up to the
+// language server to define the schema of this object.
 //
 // SymbolDescriptor usually uniquely identifies a symbol, but it is not
 // guaranteed to do so.
-type SymbolDescriptor struct {
-	// Name of this symbol (same as `SymbolInformation.name`).
-	Name string `json:"name,omitempty"`
-
-	// Kind of this symbol (same as `SymbolInformation.kind`).
-	Kind lsp.SymbolKind `json:"kind,omitempty"`
-
-	// URI of this symbol (same as `SymbolInformation.location.uri`).
-	URI string `json:"uri,omitempty"`
-
-	// Container represents the container of this symbol. It is up to the
-	// language server to define what exact data this object contains.
-	Container map[string]interface{} `json:"container,omitempty"`
-
-	// Whether or not the symbol is defined inside of "vendored" code. In Go,
-	// for example, this means that an external dependency was copied to a
-	// subdirectory named `vendor`. The exact definition of vendor depends on
-	// the language, but it is generally understood to mean "code that was
-	// copied from its original source and now lives in our project directly".
-	Vendor bool `json:"vendor,omitempty"`
-
-	// Package contains information about the package/library that this symbol
-	// is defined in.
-	Package PackageDescriptor `json:"package,omitempty"`
-
-	// Attributes describing the symbol that is being referenced. It is up to
-	// the language server to define what exact data this object contains.
-	Attributes map[string]interface{} `json:"attributes,omitempty"`
-}
-
-// PackageDescriptor represents information about a programming code unit like
-// a package, library, crate, module, etc. It uniquely identifies a package at
-// a specific version within a given registry.
-type PackageDescriptor struct {
-	// ID represents the package of code. For example, in JS this would be the
-	// NPM package name. In Go, the full import path. etc.
-	ID string `json:"id"`
-
-	// Version is the version of the package in the registry.
-	Version *VersionDescriptor `json:"version,omitempty"`
-
-	// The registry for this package. Examples:
-	//
-	//  - JS: "npm"
-	//  - Java: "maven" etc.
-	//  - Go: "go"
-	//
-	Registry string `json:"registry,omitempty"`
-}
-
-// VersionDescriptor represents a specific version. It can be either
-// language-server / build tool defined fields OR semantically version fields
-// (which are preferable). TS declaration is:
-//
-// 	type VersionDescriptor = Object | {
-// 		commitID?: string
-// 		major?: number
-// 		minor?: number
-// 		patch?: number
-// 		tag?: string
-// 	};
-//
-type VersionDescriptor map[string]interface{}
+type SymbolDescriptor map[string]interface{}
 
 // LocationInformation is the response type for the `textDocument/xdefinition` extension.
 type LocationInformation struct {
 	// A concrete location at which the definition is located, if any.
 	Location lsp.Location `json:"location,omitempty"`
 	// Metadata about the definition.
-	Symbol []SymbolDescriptor `json:"SymbolDescriptor"`
+	Symbol SymbolDescriptor `json:"SymbolDescriptor"`
 }
 
 // String returns a consistently ordered string representation of the
 // SymbolDescriptor. It is useful for testing.
 func (s SymbolDescriptor) String() string {
-	sm := newSortedMap(s.Attributes).prefix("attr")
-	sm = append(sm, newSortedMap(s.Container).prefix("container")...)
-	stdfield := func(k, v string) {
-		if v != "" {
-			sm = append(sm, mapValue{key: k, value: v})
-		}
-	}
-	stdfield("name", s.Name)
-	stdfield("kind", s.Kind.String())
-	stdfield("uri", s.URI)
-	if s.Vendor {
-		stdfield("vendor", "true")
-	}
-	stdfield("package_id", s.Package.ID)
-	stdfield("package_registry", s.Package.Registry)
-	if s.Package.Version != nil {
-		stdfield("package_version", fmt.Sprint(s.Package.Version))
+	sm := make(sortedMap, 0, len(s))
+	for k, v := range s {
+		sm = append(sm, mapValue{key: k, value: v})
 	}
 	sort.Sort(sm)
 	var str string
@@ -143,18 +72,3 @@ type sortedMap []mapValue
 func (s sortedMap) Len() int           { return len(s) }
 func (s sortedMap) Less(i, j int) bool { return s[i].key < s[j].key }
 func (s sortedMap) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
-
-func (sm sortedMap) prefix(s string) sortedMap {
-	for i, v := range sm {
-		sm[i].key = s + "_" + v.key
-	}
-	return sm
-}
-
-func newSortedMap(m map[string]interface{}) sortedMap {
-	sm := make(sortedMap, 0, len(m))
-	for k, v := range m {
-		sm = append(sm, mapValue{key: k, value: v})
-	}
-	return sm
-}


### PR DESCRIPTION
This mostly implements the `workspace/xreferences` third revision of the spec, as defined in the latest revision of https://github.com/sourcegraph/language-server-protocol/pull/8

The notable remaining piece left as a TODO here is to respect the `params.Files` parameter which would significantly reduce the amount of typechecking we would have to do. This is quite important, so I am tracking this issue separately and intend to follow-up on it ASAP. Without this improvement this will only really be functional for very small repositories (e.g. gorilla/mux will be OK, kubernetes not so much).