### PR TITLE
langserver: Correctly detect no GlobalTracer

### DIFF
--- a/langserver/handler_common.go
+++ b/langserver/handler_common.go
@@ -19,7 +19,6 @@ type HandlerCommon struct {
 	RootFSPath string     // root path of the project's files in the (possibly virtual) file system, without the "file://" prefix (typically /src/github.com/foo/bar)
 	shutdown   bool
 	tracer     opentracing.Tracer
-	tracerOK   bool
 }
 
 func (h *HandlerCommon) Reset(rootURI string) error {

--- a/langserver/tracing.go
+++ b/langserver/tracing.go
@@ -23,7 +23,8 @@ func (h *HandlerCommon) InitTracer(conn *jsonrpc2.Conn) {
 		return
 	}
 
-	if hasGlobalTracer() {
+	if _, isNoopTracer := opentracing.GlobalTracer().(opentracing.NoopTracer); !isNoopTracer {
+		// We have configured a tracer, use that instead of telemetry/event
 		h.tracer = opentracing.GlobalTracer()
 		return
 	}
@@ -82,17 +83,6 @@ func (h *HandlerCommon) SpanForRequest(ctx context.Context, buildOrLang string, 
 	}
 
 	return span, opentracing.ContextWithSpan(ctx, span), nil
-}
-
-// hasGlobalTracer checks if someone has setup a global tracer for this
-// process.
-func hasGlobalTracer() bool {
-	t := opentracing.GlobalTracer()
-	if t == nil {
-		return false
-	}
-	_, ok := t.(opentracing.NoopTracer)
-	return !ok
 }
 
 type tracer struct {

--- a/langserver/tracing.go
+++ b/langserver/tracing.go
@@ -19,13 +19,12 @@ import (
 func (h *HandlerCommon) InitTracer(conn *jsonrpc2.Conn) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	if h.tracerOK {
+	if h.tracer != nil {
 		return
 	}
 
 	if hasGlobalTracer() {
 		h.tracer = opentracing.GlobalTracer()
-		h.tracerOK = true
 		return
 	}
 
@@ -33,7 +32,6 @@ func (h *HandlerCommon) InitTracer(conn *jsonrpc2.Conn) {
 	opt := basictracer.DefaultOptions()
 	opt.Recorder = &t
 	h.tracer = basictracer.NewWithOptions(opt)
-	h.tracerOK = true
 	go func() {
 		<-conn.DisconnectNotify()
 		t.mu.Lock()

--- a/langserver/tracing.go
+++ b/langserver/tracing.go
@@ -23,8 +23,8 @@ func (h *HandlerCommon) InitTracer(conn *jsonrpc2.Conn) {
 		return
 	}
 
-	if t := opentracing.GlobalTracer(); t != nil {
-		h.tracer = t
+	if hasGlobalTracer() {
+		h.tracer = opentracing.GlobalTracer()
 		h.tracerOK = true
 		return
 	}
@@ -84,6 +84,17 @@ func (h *HandlerCommon) SpanForRequest(ctx context.Context, buildOrLang string, 
 	}
 
 	return span, opentracing.ContextWithSpan(ctx, span), nil
+}
+
+// hasGlobalTracer checks if someone has setup a global tracer for this
+// process.
+func hasGlobalTracer() bool {
+	t := opentracing.GlobalTracer()
+	if t == nil {
+		return false
+	}
+	_, ok := t.(opentracing.NoopTracer)
+	return !ok
 }
 
 type tracer struct {


### PR DESCRIPTION
`opentracing.GlobalTracer()` by default is non-nil since it is the NoopTracer.
This means currently we will never use `telemetry/event`, even if we want to.