### PR TITLE
langserver: Make it possible to use a custom FindPackage

### DIFF
--- a/langserver/handler_shared.go
+++ b/langserver/handler_shared.go
@@ -1,7 +1,9 @@
 package langserver
 
 import (
+	"context"
 	"fmt"
+	"go/build"
 	"strings"
 	"sync"
 
@@ -15,9 +17,22 @@ type HandlerShared struct {
 	Shared bool             // true if this struct is shared with a build server
 	FS     ctxvfs.NameSpace // full filesystem (mounts both deps and overlay)
 
+	// FindPackage if non-nil is used by our typechecker. See
+	// loader.Config.FindPackage. We use this in production to lazily
+	// fetch dependencies + cache lookups.
+	FindPackage FindPackageFunc
+
 	overlayFSMu      sync.Mutex        // guards overlayFS map
 	overlayFS        map[string][]byte // files to overlay
 	OverlayMountPath string            // mount point of overlay on fs (usually /src/github.com/foo/bar)
+}
+
+// FindPackageFunc matches the signature of loader.Config.FindPackage, except
+// also takes a context.Context.
+type FindPackageFunc func(ctx context.Context, bctx *build.Context, importPath, fromDir string, mode build.ImportMode) (*build.Package, error)
+
+func defaultFindPackageFunc(ctx context.Context, bctx *build.Context, importPath, fromDir string, mode build.ImportMode) (*build.Package, error) {
+	return bctx.Import(importPath, fromDir, mode)
 }
 
 func (h *HandlerShared) Reset(overlayRootURI string, useOSFS bool) error {

--- a/langserver/loader_test.go
+++ b/langserver/loader_test.go
@@ -1,6 +1,7 @@
 package langserver
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"go/build"
@@ -36,10 +37,11 @@ package main`,
 }
 
 func TestLoader(t *testing.T) {
+	ctx := context.Background()
 	for label, tc := range loaderCases {
 		t.Run(label, func(t *testing.T) {
 			fset, bctx, bpkg := setUpLoaderTest(tc.fs)
-			p, _, err := typecheck(fset, bctx, bpkg)
+			p, _, err := typecheck(ctx, fset, bctx, bpkg, nil)
 			if err != nil {
 				t.Error(err)
 			}
@@ -60,12 +62,13 @@ func TestLoader(t *testing.T) {
 //
 //   go test ./langserver -bench Loader -benchmem
 func BenchmarkLoader(b *testing.B) {
+	ctx := context.Background()
 	for label, tc := range loaderCases {
 		b.Run(label, func(b *testing.B) {
 			fset, bctx, bpkg := setUpLoaderTest(tc.fs)
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				if _, _, err := typecheck(fset, bctx, bpkg); err != nil {
+				if _, _, err := typecheck(ctx, fset, bctx, bpkg, nil); err != nil {
 					b.Error(err)
 				}
 			}
@@ -102,10 +105,11 @@ func TestLoaderDiagnostics(t *testing.T) {
 			Want: m(`{"/src/p/f.go":[{"range":{"start":{"line":0,"character":19},"end":{"line":0,"character":23}},"severity":1,"source":"go","message":"undeclared name: http"}]}`),
 		},
 	}
+	ctx := context.Background()
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
 			fset, bctx, bpkg := setUpLoaderTest(tc.FS)
-			_, diag, err := typecheck(fset, bctx, bpkg)
+			_, diag, err := typecheck(ctx, fset, bctx, bpkg, nil)
 			if err != nil {
 				t.Error(err)
 			}


### PR DESCRIPTION
From some benchmarking, it seems a significant amount of time is spent in
`FindPackage`. As such, we want to be able to use more sophisticated
implementations in production. This opens the possibility for a build server to
fetch dependencies JIT, smarter vendor checks, cache package info across
commits, etc.