### PR TITLE
langserver: ctxvfs.NameSpace that is safe for concurrent read/writes

### DIFF
--- a/langserver/build_context.go
+++ b/langserver/build_context.go
@@ -36,17 +36,9 @@ func (h *LangHandler) defaultBuildContext() *build.Context {
 }
 
 func (h *HandlerShared) OverlayBuildContext(ctx context.Context, orig *build.Context, useOSFileSystem bool) *build.Context {
-	// Copy to avoid a race condition if concurrent goroutines
-	// bind new mountpoints to the ctxvfs.NameSpace. This lets us lock
-	// once here, instead of once per call to any ctxvfs.FileSystem
-	// method.
 	h.Mu.Lock()
-	fs := make(ctxvfs.NameSpace, len(h.FS))
-	for path, mounts := range h.FS {
-		fs[path] = mounts
-	}
+	fs := h.FS
 	h.Mu.Unlock()
-
 	return fsBuildContext(ctx, orig, fs)
 }
 

--- a/langserver/handler_shared.go
+++ b/langserver/handler_shared.go
@@ -11,9 +11,9 @@ import (
 // HandlerShared contains data structures that a build server and its
 // wrapped lang server may share in memory.
 type HandlerShared struct {
-	Mu     sync.Mutex       // guards all fields
-	Shared bool             // true if this struct is shared with a build server
-	FS     ctxvfs.NameSpace // full filesystem (mounts both deps and overlay)
+	Mu     sync.Mutex // guards all fields
+	Shared bool       // true if this struct is shared with a build server
+	FS     *AtomicFS  // full filesystem (mounts both deps and overlay)
 
 	overlayFSMu      sync.Mutex        // guards overlayFS map
 	overlayFS        map[string][]byte // files to overlay
@@ -26,7 +26,7 @@ func (h *HandlerShared) Reset(overlayRootURI string, useOSFS bool) error {
 	h.overlayFSMu.Lock()
 	defer h.overlayFSMu.Unlock()
 	h.overlayFS = map[string][]byte{}
-	h.FS = ctxvfs.NameSpace{}
+	h.FS = NewAtomicFS()
 
 	if !strings.HasPrefix(overlayRootURI, "file:///") {
 		return fmt.Errorf("invalid overlay root URI %q: must be file:///", overlayRootURI)


### PR DESCRIPTION
ctxvfs.NameSpace is not safe to use for concurrent read/writes (were a write is
a call to .Bind). As such we create a copy every time we want to use it in a
build.Context + it actually had some race conditions outside of that code. As
part of the perf work I am doing, I want to be able to bind to the NameSpace and
have it instantly appear to all BuildContexts. So this commit introduces
AtomicFS, a wrapper around NameSpace optimized for reads (since Bind calls are
relatively rare). The implementation avoids creating a copy every time we want a
BuildContext (common operation in our build server) + is completely safe for
concurrent access.