### PR TITLE
Signature help provider

### DIFF
--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -184,6 +184,7 @@ func (h *LangHandler) Handle(ctx context.Context, conn JSONRPC2Conn, req *jsonrp
 				WorkspaceSymbolProvider:      true,
 				XWorkspaceReferencesProvider: true,
 				XDefinitionProvider:          true,
+				SignatureHelpProvider:        &lsp.SignatureHelpOptions{TriggerCharacters: []string{"(", ","}},
 			},
 		}, nil
 
@@ -246,6 +247,16 @@ func (h *LangHandler) Handle(ctx context.Context, conn JSONRPC2Conn, req *jsonrp
 			return nil, err
 		}
 		return h.handleTextDocumentSymbol(ctx, conn, req, params)
+
+	case "textDocument/signatureHelp":
+		if req.Params == nil {
+			return nil, &jsonrpc2.Error{Code: jsonrpc2.CodeInvalidParams}
+		}
+		var params lsp.TextDocumentPositionParams
+		if err := json.Unmarshal(*req.Params, &params); err != nil {
+			return nil, err
+		}
+		return h.handleTextDocumentSignatureHelp(ctx, conn, req, params)
 
 	case "workspace/symbol":
 		if req.Params == nil {

--- a/langserver/integration_test.go
+++ b/langserver/integration_test.go
@@ -69,7 +69,7 @@ func TestIntegration_FileSystem(t *testing.T) {
 		"b.go:1:20":    "func A()",
 		"p2/c.go:1:40": "func A()",
 	}
-	lspTests(t, ctx, conn, rootPath, wantHover, nil, nil, nil, nil, nil, nil)
+	lspTests(t, ctx, conn, rootPath, wantHover, nil, nil, nil, nil, nil, nil, nil)
 
 	// Now mimic what happens when a file is edited but not yet
 	// saved. It should re-typecheck using the unsaved file contents.
@@ -86,5 +86,5 @@ func TestIntegration_FileSystem(t *testing.T) {
 		"b.go:1:20":    "func A() int",
 		"p2/c.go:1:40": "func A() int",
 	}
-	lspTests(t, ctx, conn, rootPath, wantHover, nil, nil, nil, nil, nil, nil)
+	lspTests(t, ctx, conn, rootPath, wantHover, nil, nil, nil, nil, nil, nil, nil)
 }

--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -679,6 +679,8 @@ type Header struct {
 				"b.go:1:27": "func() 0",
 				"b.go:1:32": "func(foo int, bar func(baz int) int) int 0",
 				"b.go:1:39": "func(foo int, bar func(baz int) int) int 1",
+			},
+		},
 		"unexpected paths": {
 			// notice the : and @ symbol
 			rootPath: "file:///src/t:est/@hello/pkg",

--- a/langserver/loader.go
+++ b/langserver/loader.go
@@ -83,7 +83,7 @@ func (h *LangHandler) typecheck(ctx context.Context, conn JSONRPC2Conn, fileURI 
 			pp := fset.Position(p)
 			return fmt.Sprintf("%d:%d", pp.Line, pp.Column)
 		}
-		return nil, nil, nil, nil, nil, &invalidNodeError{
+		return fset, nil, nodes, prog, pkg, &invalidNodeError{
 			Node: nodes[0],
 			msg:  fmt.Sprintf("invalid node: %s (%s-%s)", reflect.TypeOf(nodes[0]).Elem(), lineCol(nodes[0].Pos()), lineCol(nodes[0].End())),
 		}

--- a/langserver/signature.go
+++ b/langserver/signature.go
@@ -1,0 +1,73 @@
+package langserver
+
+import (
+	"context"
+	"go/ast"
+	"go/token"
+	"go/types"
+
+	"github.com/sourcegraph/go-langserver/pkg/lsp"
+	"github.com/sourcegraph/jsonrpc2"
+)
+
+func (h *LangHandler) handleTextDocumentSignatureHelp(ctx context.Context, conn JSONRPC2Conn, req *jsonrpc2.Request, params lsp.TextDocumentPositionParams) (*lsp.SignatureHelp, error) {
+	fset, _, nodes, _, pkg, err := h.typecheck(ctx, conn, params.TextDocument.URI, params.Position)
+	if err != nil {
+		if _, ok := err.(*invalidNodeError); !ok {
+			return nil, err
+		}
+	}
+
+	call := callExpr(fset, nodes)
+	if call == nil {
+		return nil, nil
+	}
+	t := pkg.TypeOf(call.Fun)
+	signature, ok := t.(*types.Signature)
+	if !ok {
+		return nil, nil
+	}
+	info := lsp.SignatureInformation{Label: shortType(signature)}
+	sParams := signature.Params()
+	info.Parameters = make([]lsp.ParameterInformation, sParams.Len())
+	for i := 0; i < sParams.Len(); i++ {
+		info.Parameters[i] = lsp.ParameterInformation{Label: shortParam(sParams.At(i))}
+	}
+	activeParameter := len(info.Parameters)
+	if activeParameter > 0 {
+		activeParameter = activeParameter - 1
+	}
+	numArguments := len(call.Args)
+	if activeParameter > numArguments {
+		activeParameter = numArguments
+	}
+
+	return &lsp.SignatureHelp{Signatures: []lsp.SignatureInformation{info}, ActiveSignature: 0, ActiveParameter: activeParameter}, nil
+}
+
+// callExpr climbs AST tree up until call expression
+func callExpr(fset *token.FileSet, nodes []ast.Node) *ast.CallExpr {
+	for _, node := range nodes {
+		callExpr, ok := node.(*ast.CallExpr)
+		if ok {
+			return callExpr
+		}
+	}
+	return nil
+}
+
+// shortTyoe returns shorthand type notation without specifying type's import path
+func shortType(t types.Type) string {
+	return types.TypeString(t, func(*types.Package) string {
+		return ""
+	})
+}
+
+// shortParam returns shorthand parameter notation in form "name type" without specifying type's import path
+func shortParam(param *types.Var) string {
+	ret := param.Name()
+	if ret != "" {
+		ret += " "
+	}
+	return ret + shortType(param.Type())
+}

--- a/pkg/lsp/service.go
+++ b/pkg/lsp/service.go
@@ -134,14 +134,14 @@ type MarkedString struct {
 
 type SignatureHelp struct {
 	Signatures      []SignatureInformation `json:"signatures"`
-	ActiveSignature int                    `json:"activeSignature,omitempty"`
-	ActiveParameter int                    `json:"activeParameter,omitempty"`
+	ActiveSignature int                    `json:"activeSignature"`
+	ActiveParameter int                    `json:"activeParameter"`
 }
 
 type SignatureInformation struct {
 	Label         string                 `json:"label"`
 	Documentation string                 `json:"documentation,omitempty"`
-	Paramaters    []ParameterInformation `json:"paramaters,omitempty"`
+	Parameters    []ParameterInformation `json:"parameters,omitempty"`
 }
 
 type ParameterInformation struct {


### PR DESCRIPTION
Experimenting with signature help provider feature. It works but pretty slow for now when comparing with vscode-go (uses `godef`)

Recording this PR to save my changes just in case

Fixes #75 