### PR TITLE
langserver: Prevent typecheck cache invalidation race

### DIFF
--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -41,8 +41,7 @@ type LangHandler struct {
 	pkgSymCache   map[string][]lsp.SymbolInformation
 
 	// cached typechecking results
-	cacheMus map[typecheckKey]*sync.Mutex
-	cache    map[typecheckKey]typecheckResult
+	cache map[typecheckKey]*typecheckResult
 
 	// cache the reverse import graph
 	importGraphOnce sync.Once
@@ -72,8 +71,7 @@ func (h *LangHandler) resetCaches(lock bool) {
 	if lock {
 		h.mu.Lock()
 	}
-	h.cacheMus = map[typecheckKey]*sync.Mutex{}
-	h.cache = map[typecheckKey]typecheckResult{}
+	h.cache = map[typecheckKey]*typecheckResult{}
 	h.importGraphOnce = sync.Once{}
 	h.importGraph = nil
 	if lock {


### PR DESCRIPTION
If we are busy typechecking something and we receive a FS command which mutates
the overlay, we can store in the cache invalid results for future hovers. This
change does not fully prevent that behaviour. However, it does make it much less
likely. The reason it could still happen is the FS tied to the bctx could be
stale. However, the amount of time that lives is low and I will fix it in a
future commit.

This change also simplifies the logic as well as removing the mutex map we had.
This single-flighting pattern is the same as the one used in the `go/loader`
pkg.

Fixes https://github.com/sourcegraph/sourcegraph/issues/2802