### PR TITLE
langserver: Do not panic on files with @ or :

### DIFF
--- a/langserver/fs.go
+++ b/langserver/fs.go
@@ -81,12 +81,6 @@ func (h *HandlerShared) FilePath(uri string) string {
 	if !strings.HasPrefix(path, "/") {
 		panic(fmt.Sprintf("bad uri %q (path %q MUST have leading slash; it can't be relative)", uri, path))
 	}
-	if strings.Contains(path, ":") {
-		panic(fmt.Sprintf("bad uri %q (path %q MUST NOT contain ':')", uri, path))
-	}
-	if strings.Contains(path, "@") {
-		panic(fmt.Sprintf("bad uri %q (path %q MUST NOT contain '@')", uri, path))
-	}
 	return path
 }
 

--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -668,6 +668,25 @@ type Header struct {
 				},
 			},
 		},
+		"unexpected paths": {
+			// notice the : and @ symbol
+			rootPath: "file:///src/t:est/@hello/pkg",
+			fs: map[string]string{
+				"a.go": "package p; func A() { A() }",
+			},
+			wantHover: map[string]string{
+				"a.go:1:17": "func A()",
+			},
+			wantReferences: map[string][]string{
+				"a.go:1:17": []string{
+					"/src/t:est/@hello/pkg/a.go:1:17",
+					"/src/t:est/@hello/pkg/a.go:1:23",
+				},
+			},
+			wantSymbols: map[string][]string{
+				"a.go": []string{"/src/t:est/@hello/pkg/a.go:function:pkg.A:1:17"},
+			},
+		},
 	}
 	for label, test := range tests {
 		t.Run(label, func(t *testing.T) {


### PR DESCRIPTION
This seems to be a relic of ensuring our build servers correctly translate paths
to the langserver. However, the symbols are completely valid to be in a path, so
we remove the special casing for it.

Fixes #39