### PR TITLE
langserver: RootPath is always a file://

### DIFF
--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -151,8 +151,9 @@ func (h *LangHandler) Handle(ctx context.Context, conn JSONRPC2Conn, req *jsonrp
 			return nil, err
 		}
 
-		// Assume it's a file path if no the URI has no scheme.
-		if strings.HasPrefix(params.RootPath, "/") {
+		// HACK: RootPath is not a URI, but historically we treated it
+		// as such. Convert it to a file URI
+		if !strings.HasPrefix(params.RootPath, "file://") {
 			params.RootPath = "file://" + params.RootPath
 		}
 

--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -35,7 +35,7 @@ func TestServer(t *testing.T) {
 		mountFS                 map[string]map[string]string // mount dir -> map VFS
 	}{
 		"go basic": {
-			rootPath: "file:///src/test/pkg",
+			rootPath: "/src/test/pkg",
 			fs: map[string]string{
 				"a.go": "package p; func A() { A() }",
 				"b.go": "package p; func B() { A() }",


### PR DESCRIPTION
We incorrectly use `RootPath` as a URI. Before this change we converted unix style
absolute paths to URIs, but windows style paths would not be picked up properly.
This change should allow us to receive windows file paths.

Note: `RootPath` is deprecated in LSP 3.0 so this change is mostly to keep us working with existing systems. Once we update to LSP 3.0 (See #72) we can instead use `RootURI`, which is in fact a URI and avoid this sort of hack.