### PR TITLE
langserver: Prevent panic when BuildContext is not set

### DIFF
--- a/langserver/symbol.go
+++ b/langserver/symbol.go
@@ -293,7 +293,6 @@ func (h *LangHandler) handleSymbol(ctx context.Context, conn JSONRPC2Conn, req *
 			// package dir matches to avoid doing unnecessary work.
 			if results.Query.File != "" {
 				filePkgPath := path.Dir(results.Query.File)
-				bctx := h.defaultBuildContext()
 				if PathHasPrefix(filePkgPath, bctx.GOROOT) {
 					filePkgPath = PathTrimPrefix(filePkgPath, bctx.GOROOT)
 				} else {

--- a/langserver/symbol.go
+++ b/langserver/symbol.go
@@ -293,10 +293,11 @@ func (h *LangHandler) handleSymbol(ctx context.Context, conn JSONRPC2Conn, req *
 			// package dir matches to avoid doing unnecessary work.
 			if results.Query.File != "" {
 				filePkgPath := path.Dir(results.Query.File)
-				if PathHasPrefix(filePkgPath, h.init.BuildContext.GOROOT) {
-					filePkgPath = PathTrimPrefix(filePkgPath, h.init.BuildContext.GOROOT)
+				bctx := h.defaultBuildContext()
+				if PathHasPrefix(filePkgPath, bctx.GOROOT) {
+					filePkgPath = PathTrimPrefix(filePkgPath, bctx.GOROOT)
 				} else {
-					filePkgPath = PathTrimPrefix(filePkgPath, h.init.BuildContext.GOPATH)
+					filePkgPath = PathTrimPrefix(filePkgPath, bctx.GOPATH)
 				}
 				filePkgPath = PathTrimPrefix(filePkgPath, "src")
 				if !pathEqual(pkg, filePkgPath) {


### PR DESCRIPTION
workspace symbol can panic if BuildContext is not set. On sourcegraph.com this
is always set, so is not an issue. However, when used as an extension this is
not set.

Fixes #70 and #69