### PR TITLE
langserver: Initial support for formatting

### DIFF
--- a/langserver/format.go
+++ b/langserver/format.go
@@ -1,0 +1,62 @@
+package langserver
+
+import (
+	"bytes"
+	"context"
+	"go/ast"
+	"go/parser"
+	"go/printer"
+	"go/token"
+	"path/filepath"
+
+	"golang.org/x/tools/go/buildutil"
+
+	"github.com/sourcegraph/go-langserver/pkg/lsp"
+	"github.com/sourcegraph/jsonrpc2"
+)
+
+func (h *LangHandler) handleTextDocumentFormatting(ctx context.Context, conn JSONRPC2Conn, req *jsonrpc2.Request, params lsp.DocumentFormattingParams) ([]lsp.TextEdit, error) {
+	filename := h.FilePath(params.TextDocument.URI)
+	bctx := h.OverlayBuildContext(ctx, h.defaultBuildContext(), !h.init.NoOSFileSystemAccess)
+	fset := token.NewFileSet()
+	file, err := buildutil.ParseFile(fset, bctx, nil, filepath.Dir(filename), filepath.Base(filename), parser.ParseComments)
+	if err != nil {
+		return nil, err
+	}
+
+	ast.SortImports(fset, file)
+
+	var buf bytes.Buffer
+	cfg := printer.Config{Mode: printer.UseSpaces | printer.TabIndent, Tabwidth: 8}
+	err = cfg.Fprint(&buf, fset, file)
+	if err != nil {
+		return nil, err
+	}
+
+	b := buf.Bytes()
+	orig, err := h.readFile(ctx, params.TextDocument.URI)
+	if err != nil {
+		return nil, err
+	}
+	if bytes.Equal(b, orig) {
+		return nil, nil
+	}
+
+	return []lsp.TextEdit{
+		{
+			Range: lsp.Range{
+				Start: lsp.Position{
+					Line:      0,
+					Character: 0,
+				},
+				End: lsp.Position{
+					Line:      bytes.Count(orig, []byte("\n")),
+					Character: len(orig) - bytes.LastIndexByte(orig, '\n') - 1,
+				},
+			},
+		},
+		{
+			NewText: string(b),
+		},
+	}, nil
+}

--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -177,6 +177,7 @@ func (h *LangHandler) Handle(ctx context.Context, conn JSONRPC2Conn, req *jsonrp
 			Capabilities: lsp.ServerCapabilities{
 				TextDocumentSync:             lsp.TDSKFull,
 				DefinitionProvider:           true,
+				DocumentFormattingProvider:   true,
 				DocumentSymbolProvider:       true,
 				HoverProvider:                true,
 				ReferencesProvider:           true,
@@ -256,6 +257,16 @@ func (h *LangHandler) Handle(ctx context.Context, conn JSONRPC2Conn, req *jsonrp
 			return nil, err
 		}
 		return h.handleTextDocumentSignatureHelp(ctx, conn, req, params)
+
+	case "textDocument/formatting":
+		if req.Params == nil {
+			return nil, &jsonrpc2.Error{Code: jsonrpc2.CodeInvalidParams}
+		}
+		var params lsp.DocumentFormattingParams
+		if err := json.Unmarshal(*req.Params, &params); err != nil {
+			return nil, err
+		}
+		return h.handleTextDocumentFormatting(ctx, conn, req, params)
 
 	case "workspace/symbol":
 		if req.Params == nil {


### PR DESCRIPTION
This returns a very sub-optimal `[]TextEdit`, but may suffice for now. The
`[]TextEdit` is either empty, or is 2 edits: delete all, insert formatted code.

Fixes #76