### PR TITLE
langserver: Faster package list

### DIFF
--- a/langserver/symbol.go
+++ b/langserver/symbol.go
@@ -278,8 +278,7 @@ func (h *LangHandler) handleSymbol(ctx context.Context, conn JSONRPC2Conn, req *
 		bctx := h.OverlayBuildContext(ctx, h.defaultBuildContext(), !h.init.NoOSFileSystemAccess)
 
 		par := parallel.NewRun(8)
-		pkgs := listPkgsUnderDir(bctx, rootPath)
-		for _, pkg := range pkgs {
+		for _, pkg := range listPkgsUnderDir(bctx, rootPath) {
 			// If we're restricting results to a single file or dir, ensure the
 			// package dir matches to avoid doing unnecessary work.
 			if results.Query.File != "" {

--- a/langserver/symbol.go
+++ b/langserver/symbol.go
@@ -277,18 +277,9 @@ func (h *LangHandler) handleSymbol(ctx context.Context, conn JSONRPC2Conn, req *
 		rootPath := h.FilePath(h.init.RootPath)
 		bctx := h.OverlayBuildContext(ctx, h.defaultBuildContext(), !h.init.NoOSFileSystemAccess)
 
-		var pkgPat string
-		if h.init.RootImportPath == "" {
-			// Go stdlib (empty root import path)
-			pkgPat = "..."
-		} else {
-			// All other Go packages.
-			pkgPat = h.init.RootImportPath + "/..."
-		}
-
 		par := parallel.NewRun(8)
-		pkgs := buildutil.ExpandPatterns(bctx, []string{pkgPat})
-		for pkg := range pkgs {
+		pkgs := listPkgs(bctx, rootPath)
+		for _, pkg := range pkgs {
 			// If we're restricting results to a single file or dir, ensure the
 			// package dir matches to avoid doing unnecessary work.
 			if results.Query.File != "" {
@@ -487,4 +478,92 @@ var symbolCacheTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
 
 func init() {
 	prometheus.MustRegister(symbolCacheTotal)
+}
+
+func listPkgs(ctxt *build.Context, dir string) []string {
+	ch := make(chan string)
+
+	var wg sync.WaitGroup
+	for _, root := range ctxt.SrcDirs() {
+		root := root
+		wg.Add(1)
+		go func() {
+			allPackages(ctxt, root, dir, ch)
+			wg.Done()
+		}()
+	}
+	go func() {
+		wg.Wait()
+		close(ch)
+	}()
+
+	var pkgs []string
+	for p := range ch {
+		pkgs = append(pkgs, p)
+	}
+	sort.Strings(pkgs)
+	return pkgs
+}
+
+// We use a process-wide counting semaphore to limit
+// the number of parallel calls to ReadDir.
+var ioLimit = make(chan bool, 20)
+
+// allPackages is from tools/go/buildutil. We don't use the exported method
+// since it doesn't allow searching from a directory. We need from a specific
+// directory for performance on large GOPATHs.
+func allPackages(ctxt *build.Context, root, start string, ch chan<- string) {
+	root = filepath.Clean(root) + string(os.PathSeparator)
+	start = filepath.Clean(start) + string(os.PathSeparator)
+
+	if strings.HasPrefix(root, start) {
+		// If we are a child of start, we can just start at the
+		// root. A concrete example of this happening is when
+		// root=/goroot/src and start=/goroot
+		start = root
+	}
+
+	if !strings.HasPrefix(start, root) {
+		return
+	}
+
+	var wg sync.WaitGroup
+
+	var walkDir func(dir string)
+	walkDir = func(dir string) {
+		// Avoid .foo, _foo, and testdata directory trees.
+		base := filepath.Base(dir)
+		if base == "" || base[0] == '.' || base[0] == '_' || base == "testdata" {
+			return
+		}
+
+		pkg := filepath.ToSlash(strings.TrimPrefix(dir, root))
+
+		// Prune search if we encounter any of these import paths.
+		switch pkg {
+		case "builtin":
+			return
+		}
+
+		if pkg != "" {
+			ch <- pkg
+		}
+
+		ioLimit <- true
+		files, _ := buildutil.ReadDir(ctxt, dir)
+		<-ioLimit
+		for _, fi := range files {
+			fi := fi
+			if fi.IsDir() {
+				wg.Add(1)
+				go func() {
+					walkDir(filepath.Join(dir, fi.Name()))
+					wg.Done()
+				}()
+			}
+		}
+	}
+
+	walkDir(start)
+	wg.Wait()
 }


### PR DESCRIPTION
`buildutil.ExpandPattern` would inspect every package in the `GOPATH` and `GOROOT`.
The slowness of this is not much of a factor on sourcegraph.com, but for local
`GOPATH`s which can be large (such as my own), it is really slow. This takes
symbol search on this project on my machine from half a minute to instant.

This code is essentially the `buildutil.ExpandPattern` modified for our usecase. The idea
used can probably be submitted upstream since there are TODOs hinting at wanting this
functionality.

Previously we also incorrectly relied on `h.init.RootImportPath`, which is
technically not allowed in the langserver. In the future, we should work out
ways to prevent this accidental use of it.

Test Plan: Tested on the extensive integration tests for sourcegraph.com, which
will test both golang/go and other popular pkgs.

Fixes #70 and #69