### PR TITLE
langserver: workspace/xreferences: change Go DependencyReference.Hints dir -> dirs

### DIFF
--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -190,11 +190,17 @@ func TestServer(t *testing.T) {
 					// Matching against invalid field name.
 					{Query: lspext.SymbolDescriptor{"nope": "A"}}: []string{},
 
-					// Matching against an invalid dir hint.
-					{Query: lspext.SymbolDescriptor{"package": "test/pkg/d"}, Hints: map[string]interface{}{"dir": "file:///src/test/pkg/d/d3"}}: []string{},
+					// Matching against an invalid dirs hint.
+					{Query: lspext.SymbolDescriptor{"package": "test/pkg/d"}, Hints: map[string]interface{}{"dirs": []string{"file:///src/test/pkg/d/d3"}}}: []string{},
 
-					// Matching against a dir hint.
-					{Query: lspext.SymbolDescriptor{"package": "test/pkg/d"}, Hints: map[string]interface{}{"dir": "file:///src/test/pkg/d/d2"}}: []string{
+					// Matching against a dirs hint with multiple dirs.
+					{Query: lspext.SymbolDescriptor{"package": "test/pkg/d"}, Hints: map[string]interface{}{"dirs": []string{"file:///src/test/pkg/d/d2", "file:///src/test/pkg/d/invalid"}}}: []string{
+						"/src/test/pkg/d/d2/b.go:1:20-1:20 -> name: package:test/pkg/d packageName:d recv: vendor:false",
+						"/src/test/pkg/d/d2/b.go:1:47-1:47 -> name:A package:test/pkg/d packageName:d recv: vendor:false",
+					},
+
+					// Matching against a dirs hint.
+					{Query: lspext.SymbolDescriptor{"package": "test/pkg/d"}, Hints: map[string]interface{}{"dirs": []string{"file:///src/test/pkg/d/d2"}}}: []string{
 						"/src/test/pkg/d/d2/b.go:1:20-1:20 -> name: package:test/pkg/d packageName:d recv: vendor:false",
 						"/src/test/pkg/d/d2/b.go:1:47-1:47 -> name:A package:test/pkg/d packageName:d recv: vendor:false",
 					},

--- a/langserver/workspace_refs.go
+++ b/langserver/workspace_refs.go
@@ -73,11 +73,18 @@ func (h *LangHandler) handleWorkspaceReferences(ctx context.Context, conn JSONRP
 			continue
 		}
 
-		// If a directory hint is present, only look for references created in
-		// that directory.
-		dir, ok := params.Hints["dir"]
+		// If a dirs hint is present, only look for references created in those
+		// directories.
+		dirs, ok := params.Hints["dirs"]
 		if ok {
-			if "file://"+bpkg.Dir != dir.(string) {
+			found := false
+			for _, dir := range dirs.([]interface{}) {
+				if "file://"+bpkg.Dir == dir.(string) {
+					found = true
+					break
+				}
+			}
+			if !found {
 				continue
 			}
 		}


### PR DESCRIPTION
This will give us much less DB entries (one/dependency referenced/repo vs. one/dependency
referenced/directory/repo).

Additionally, this will help with optimizing `workspace/xreferences` to be both performant
and accurate. It will however mean that we will likely need to add a `Limit` or other
pagination options to `workspace/xreferences`.

Also update the tests accordingly.