### PR TITLE
langserver: Cleanup BuildContext functions

### DIFF
--- a/langserver/definition.go
+++ b/langserver/definition.go
@@ -26,7 +26,7 @@ func (h *LangHandler) handleDefinition(ctx context.Context, conn JSONRPC2Conn, r
 
 func (h *LangHandler) handleXDefinition(ctx context.Context, conn JSONRPC2Conn, req *jsonrpc2.Request, params lsp.TextDocumentPositionParams) ([]lspext.SymbolLocationInformation, error) {
 	rootPath := h.FilePath(h.init.RootPath)
-	bctx := h.OverlayBuildContext(ctx, h.defaultBuildContext(), !h.init.NoOSFileSystemAccess)
+	bctx := h.BuildContext(ctx)
 
 	fset, node, pathEnclosingInterval, _, pkg, err := h.typecheck(ctx, conn, params.TextDocument.URI, params.Position)
 	if err != nil {

--- a/langserver/format.go
+++ b/langserver/format.go
@@ -17,7 +17,7 @@ import (
 
 func (h *LangHandler) handleTextDocumentFormatting(ctx context.Context, conn JSONRPC2Conn, req *jsonrpc2.Request, params lsp.DocumentFormattingParams) ([]lsp.TextEdit, error) {
 	filename := h.FilePath(params.TextDocument.URI)
-	bctx := h.OverlayBuildContext(ctx, h.defaultBuildContext(), !h.init.NoOSFileSystemAccess)
+	bctx := h.BuildContext(ctx)
 	fset := token.NewFileSet()
 	file, err := buildutil.ParseFile(fset, bctx, nil, filepath.Dir(filename), filepath.Base(filename), parser.ParseComments)
 	if err != nil {

--- a/langserver/loader.go
+++ b/langserver/loader.go
@@ -41,7 +41,7 @@ func (h *LangHandler) typecheck(ctx context.Context, conn JSONRPC2Conn, fileURI 
 		return nil, nil, nil, nil, nil, fmt.Errorf("invalid position: %s:%d:%d (%s)", filename, position.Line, position.Character, why)
 	}
 
-	bctx := h.OverlayBuildContext(ctx, h.defaultBuildContext(), !h.init.NoOSFileSystemAccess)
+	bctx := h.BuildContext(ctx)
 
 	bpkg, err := ContainingPackage(bctx, filename)
 	if mpErr, ok := err.(*build.MultiplePackageError); ok {

--- a/langserver/loader_test.go
+++ b/langserver/loader_test.go
@@ -136,7 +136,7 @@ func setUpLoaderTest(fs map[string]string) (*token.FileSet, *build.Context, *bui
 	for filename, contents := range fs {
 		h.addOverlayFile("file://"+filename, []byte(contents))
 	}
-	bctx := h.OverlayBuildContext(nil, &build.Default, false)
+	bctx := h.BuildContext(context.Background())
 	bctx.GOPATH = "/"
 	goFiles := make([]string, 0, len(fs))
 	for n := range fs {

--- a/langserver/references.go
+++ b/langserver/references.go
@@ -31,7 +31,7 @@ func (h *LangHandler) handleTextDocumentReferences(ctx context.Context, conn JSO
 		return nil, err
 	}
 
-	bctx := h.OverlayBuildContext(ctx, h.defaultBuildContext(), !h.init.NoOSFileSystemAccess)
+	bctx := h.BuildContext(ctx)
 	h.importGraphOnce.Do(func() {
 		// We ignore the errors since we are doing a best-effort analysis
 		_, rev, _ := importgraph.Build(bctx)

--- a/langserver/symbol.go
+++ b/langserver/symbol.go
@@ -275,7 +275,7 @@ func (h *LangHandler) handleSymbol(ctx context.Context, conn JSONRPC2Conn, req *
 	{
 		fs := token.NewFileSet()
 		rootPath := h.FilePath(h.init.RootPath)
-		bctx := h.OverlayBuildContext(ctx, h.defaultBuildContext(), !h.init.NoOSFileSystemAccess)
+		bctx := h.BuildContext(ctx)
 
 		par := parallel.NewRun(8)
 		for _, pkg := range listPkgsUnderDir(bctx, rootPath) {

--- a/langserver/workspace_refs.go
+++ b/langserver/workspace_refs.go
@@ -29,7 +29,7 @@ func (h *LangHandler) handleWorkspaceReferences(ctx context.Context, conn JSONRP
 	// moderately sized repository more bearable (right now these are really bad).
 
 	rootPath := h.FilePath(h.init.RootPath)
-	bctx := h.OverlayBuildContext(ctx, h.defaultBuildContext(), !h.init.NoOSFileSystemAccess)
+	bctx := h.BuildContext(ctx)
 
 	var parallelism int
 	if envWorkspaceReferenceParallelism != "" {


### PR DESCRIPTION
This commit contains a few fixes to how we export and use our Build Context
related functions. We can greatly simplify this due to changes like AtomicFS and
changes on sourcegraph.com's build server side.

We used to export OverlayBuildContext since at one point we would use it before
doing init on sourcegraph.com's build server. Now we use the same build context
after init, so we can combine both defaultBuildContext and OverlayBuildContext
and use that everywhere. This will require a change to sourcegraph.com's
codebase.