### PR TITLE
langserver: Use h.FindPackage for refs loader.Config

### DIFF
--- a/langserver/definition.go
+++ b/langserver/definition.go
@@ -58,6 +58,7 @@ func (h *LangHandler) handleXDefinition(ctx context.Context, conn JSONRPC2Conn, 
 	if len(nodes) == 0 {
 		return nil, errors.New("definition not found")
 	}
+	findPackage := h.getFindPackageFunc()
 	locs := make([]lspext.SymbolLocationInformation, 0, len(nodes))
 	for _, node := range nodes {
 		// Determine location information for the node.
@@ -71,7 +72,7 @@ func (h *LangHandler) handleXDefinition(ctx context.Context, conn JSONRPC2Conn, 
 		// Determine metadata information for the node.
 
 		if def, err := refs.DefInfo(pkg.Pkg, &pkg.Info, pathEnclosingInterval, node.Pos()); err == nil {
-			symDesc, err := defSymbolDescriptor(bctx, rootPath, *def)
+			symDesc, err := defSymbolDescriptor(ctx, bctx, rootPath, *def, findPackage)
 			if err != nil {
 				// TODO: tracing
 				log.Println("refs.DefInfo:", err)

--- a/langserver/handler_shared.go
+++ b/langserver/handler_shared.go
@@ -35,6 +35,14 @@ func defaultFindPackageFunc(ctx context.Context, bctx *build.Context, importPath
 	return bctx.Import(importPath, fromDir, mode)
 }
 
+// getFindPackageFunc is a helper which returns h.FindPackage if non-nil, otherwise defaultFindPackageFunc
+func (h *HandlerShared) getFindPackageFunc() FindPackageFunc {
+	if h.FindPackage != nil {
+		return h.FindPackage
+	}
+	return defaultFindPackageFunc
+}
+
 func (h *HandlerShared) Reset(overlayRootURI string, useOSFS bool) error {
 	h.Mu.Lock()
 	defer h.Mu.Unlock()

--- a/langserver/loader.go
+++ b/langserver/loader.go
@@ -216,17 +216,13 @@ func (h *LangHandler) cachedTypecheck(ctx context.Context, bctx *build.Context, 
 	} else {
 		typecheckCacheTotal.WithLabelValues("miss").Inc()
 		res.fset = token.NewFileSet()
-		res.prog, diags, res.err = typecheck(ctx, res.fset, bctx, bpkg, h.FindPackage)
+		res.prog, diags, res.err = typecheck(ctx, res.fset, bctx, bpkg, h.getFindPackageFunc())
 	}
 	return res.fset, res.prog, diags, res.err
 }
 
 // TODO(sqs): allow typechecking just a specific file not in a package, too
 func typecheck(ctx context.Context, fset *token.FileSet, bctx *build.Context, bpkg *build.Package, findPackage FindPackageFunc) (*loader.Program, diagnostics, error) {
-	if findPackage == nil {
-		findPackage = defaultFindPackageFunc
-	}
-
 	var typeErrs []error
 	conf := loader.Config{
 		Fset: fset,

--- a/langserver/loader_test.go
+++ b/langserver/loader_test.go
@@ -41,7 +41,7 @@ func TestLoader(t *testing.T) {
 	for label, tc := range loaderCases {
 		t.Run(label, func(t *testing.T) {
 			fset, bctx, bpkg := setUpLoaderTest(tc.fs)
-			p, _, err := typecheck(ctx, fset, bctx, bpkg, nil)
+			p, _, err := typecheck(ctx, fset, bctx, bpkg, defaultFindPackageFunc)
 			if err != nil {
 				t.Error(err)
 			}
@@ -68,7 +68,7 @@ func BenchmarkLoader(b *testing.B) {
 			fset, bctx, bpkg := setUpLoaderTest(tc.fs)
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				if _, _, err := typecheck(ctx, fset, bctx, bpkg, nil); err != nil {
+				if _, _, err := typecheck(ctx, fset, bctx, bpkg, defaultFindPackageFunc); err != nil {
 					b.Error(err)
 				}
 			}
@@ -109,7 +109,7 @@ func TestLoaderDiagnostics(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
 			fset, bctx, bpkg := setUpLoaderTest(tc.FS)
-			_, diag, err := typecheck(ctx, fset, bctx, bpkg, nil)
+			_, diag, err := typecheck(ctx, fset, bctx, bpkg, defaultFindPackageFunc)
 			if err != nil {
 				t.Error(err)
 			}

--- a/langserver/symbol.go
+++ b/langserver/symbol.go
@@ -313,7 +313,7 @@ func (h *LangHandler) handleSymbol(ctx context.Context, conn JSONRPC2Conn, req *
 						return
 					}
 				}()
-				h.collectFromPkg(bctx, fs, pkg, rootPath, &results)
+				h.collectFromPkg(ctx, bctx, fs, pkg, rootPath, &results)
 			}(pkg)
 		}
 		_ = par.Wait()
@@ -353,10 +353,11 @@ func (h *LangHandler) setPkgSyms(pkg string, syms []lsp.SymbolInformation) {
 // collectFromPkg collects all the symbols from the specified package
 // into the results. It uses LangHandler's package symbol cache to
 // speed up repeated calls.
-func (h *LangHandler) collectFromPkg(bctx *build.Context, fs *token.FileSet, pkg string, rootPath string, results *resultSorter) {
+func (h *LangHandler) collectFromPkg(ctx context.Context, bctx *build.Context, fs *token.FileSet, pkg string, rootPath string, results *resultSorter) {
 	pkgSyms := h.getPkgSyms(pkg)
 	if pkgSyms == nil {
-		buildPkg, err := bctx.Import(pkg, rootPath, 0)
+		findPackage := h.getFindPackageFunc()
+		buildPkg, err := findPackage(ctx, bctx, pkg, rootPath, 0)
 		if err != nil {
 			maybeLogImportError(pkg, err)
 			return

--- a/langserver/workspace_refs.go
+++ b/langserver/workspace_refs.go
@@ -130,6 +130,11 @@ func (h *LangHandler) workspaceRefsTypecheck(ctx context.Context, bctx *build.Co
 		span.Finish()
 	}()
 
+	findPackage := h.FindPackage
+	if findPackage == nil {
+		findPackage = defaultFindPackageFunc
+	}
+
 	// Configure the loader.
 	var typeErrs []error
 	conf := loader.Config{
@@ -149,7 +154,7 @@ func (h *LangHandler) workspaceRefsTypecheck(ctx context.Context, bctx *build.Co
 			// MultipleGoErrors. This occurs, e.g., when you have a
 			// main.go with "// +build ignore" that imports the
 			// non-main package in the same dir.
-			bpkg, err := bctx.Import(importPath, fromDir, mode)
+			bpkg, err := findPackage(ctx, bctx, importPath, fromDir, mode)
 			if err != nil && !isMultiplePackageError(err) {
 				return bpkg, err
 			}

--- a/langserver/workspace_refs.go
+++ b/langserver/workspace_refs.go
@@ -130,12 +130,8 @@ func (h *LangHandler) workspaceRefsTypecheck(ctx context.Context, bctx *build.Co
 		span.Finish()
 	}()
 
-	findPackage := h.FindPackage
-	if findPackage == nil {
-		findPackage = defaultFindPackageFunc
-	}
-
 	// Configure the loader.
+	findPackage := h.getFindPackageFunc()
 	var typeErrs []error
 	conf := loader.Config{
 		Fset: fset,


### PR DESCRIPTION
This allows us to also use the same FindPackage used by our typechecker.