### PR TITLE
langserver: Make caches bounded at the process level

### DIFF
--- a/langserver/cache.go
+++ b/langserver/cache.go
@@ -2,8 +2,23 @@ package langserver
 
 import (
 	"sync"
+	"sync/atomic"
 
 	lru "github.com/hashicorp/golang-lru"
+)
+
+var (
+	// typecheckCache is a process level cache for storing typechecked
+	// values. Do not directly use this, instead use newTypecheckCache()
+	typecheckCache = newARC(1000)
+
+	// symbolCache is a process level cache for storing symbols found. Do
+	// not directly use this, instead use newSymbolCache()
+	symbolCache = newARC(1000)
+
+	// cacheID is used to prevent key conflicts between different
+	// LangHandlers in the same process.
+	cacheID int64
 )
 
 type cache interface {
@@ -12,25 +27,22 @@ type cache interface {
 }
 
 func newTypecheckCache() *boundedCache {
-	c, err := lru.NewARC(1000)
-	if err != nil {
-		// This should never happen since our size is always > 0
-		panic(err)
-	}
 	return &boundedCache{
-		c: c,
+		id: nextCacheID(),
+		c:  typecheckCache,
 	}
 }
 
 func newSymbolCache() *boundedCache {
-	c, err := lru.NewARC(1000)
-	if err != nil {
-		// This should never happen since our size is always > 0
-		panic(err)
-	}
 	return &boundedCache{
-		c: c,
+		id: nextCacheID(),
+		c:  symbolCache,
 	}
+}
+
+type cacheKey struct {
+	id int64
+	k  interface{}
 }
 
 type cacheValue struct {
@@ -40,13 +52,15 @@ type cacheValue struct {
 
 type boundedCache struct {
 	mu sync.Mutex
+	id int64
 	c  *lru.ARCCache
 }
 
 func (c *boundedCache) Get(k interface{}, fill func() interface{}) interface{} {
 	c.mu.Lock()
+	key := cacheKey{c.id, k}
 	var v *cacheValue
-	if vi, ok := c.c.Get(k); ok {
+	if vi, ok := c.c.Get(key); ok {
 		// cache hit, wait until ready
 		c.mu.Unlock()
 		v = vi.(*cacheValue)
@@ -54,7 +68,7 @@ func (c *boundedCache) Get(k interface{}, fill func() interface{}) interface{} {
 	} else {
 		// cache miss. Add unready result to cache and fill
 		v = &cacheValue{ready: make(chan struct{})}
-		c.c.Add(k, v)
+		c.c.Add(key, v)
 		c.mu.Unlock()
 
 		defer close(v.ready)
@@ -65,5 +79,24 @@ func (c *boundedCache) Get(k interface{}, fill func() interface{}) interface{} {
 }
 
 func (c *boundedCache) Purge() {
-	c.c.Purge()
+	// c.c is a process level cache. Since c.id is part of the cache keys,
+	// we can just change its values to make it seem like we have purged
+	// the cache.
+	c.mu.Lock()
+	c.id = nextCacheID()
+	c.mu.Unlock()
+}
+
+// newARC is a wrapper around lru.NewARC which does not return an error.
+func newARC(size int) *lru.ARCCache {
+	c, err := lru.NewARC(1000)
+	if err != nil {
+		// This should never happen since our size is always > 0
+		panic(err)
+	}
+	return c
+}
+
+func nextCacheID() int64 {
+	return atomic.AddInt64(&cacheID, 1)
 }

--- a/langserver/cache.go
+++ b/langserver/cache.go
@@ -1,0 +1,56 @@
+package langserver
+
+import "sync"
+
+type cache interface {
+	Get(key interface{}, fill func() interface{}) interface{}
+	Purge()
+}
+
+func newTypecheckCache() *unboundedCache {
+	c := &unboundedCache{}
+	c.Purge()
+	return c
+}
+
+func newSymbolCache() *unboundedCache {
+	c := &unboundedCache{}
+	c.Purge()
+	return c
+}
+
+type cacheValue struct {
+	ready chan struct{} // closed to broadcast readiness
+	value interface{}
+}
+
+type unboundedCache struct {
+	mu sync.Mutex
+	c  map[interface{}]*cacheValue
+}
+
+func (c *unboundedCache) Get(k interface{}, fill func() interface{}) interface{} {
+	c.mu.Lock()
+	v, ok := c.c[k]
+	if ok {
+		// cache hit, wait until ready
+		c.mu.Unlock()
+		<-v.ready
+	} else {
+		// cache miss. Add unready result to cache and fill
+		v = &cacheValue{ready: make(chan struct{})}
+		c.c[k] = v
+		c.mu.Unlock()
+
+		defer close(v.ready)
+		v.value = fill()
+	}
+
+	return v.value
+}
+
+func (c *unboundedCache) Purge() {
+	c.mu.Lock()
+	c.c = make(map[interface{}]*cacheValue)
+	c.mu.Unlock()
+}

--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -36,12 +36,8 @@ type LangHandler struct {
 	*HandlerShared
 	init *InitializeParams // set by "initialize" request
 
-	// cached symbols
-	pkgSymCacheMu sync.Mutex
-	pkgSymCache   map[string]*pkgSymResult
-
-	// cached typechecking results
-	cache map[typecheckKey]*typecheckResult
+	typecheckCache cache
+	symbolCache    cache
 
 	// cache the reverse import graph
 	importGraphOnce sync.Once
@@ -71,19 +67,24 @@ func (h *LangHandler) resetCaches(lock bool) {
 	if lock {
 		h.mu.Lock()
 	}
-	h.cache = map[typecheckKey]*typecheckResult{}
+
 	h.importGraphOnce = sync.Once{}
 	h.importGraph = nil
-	if lock {
-		h.mu.Unlock()
+
+	if h.typecheckCache == nil {
+		h.typecheckCache = newTypecheckCache()
+	} else {
+		h.typecheckCache.Purge()
+	}
+
+	if h.symbolCache == nil {
+		h.symbolCache = newSymbolCache()
+	} else {
+		h.symbolCache.Purge()
 	}
 
 	if lock {
-		h.pkgSymCacheMu.Lock()
-	}
-	h.pkgSymCache = map[string]*pkgSymResult{}
-	if lock {
-		h.pkgSymCacheMu.Unlock()
+		h.mu.Unlock()
 	}
 }
 

--- a/langserver/loader.go
+++ b/langserver/loader.go
@@ -181,10 +181,9 @@ type typecheckKey struct {
 }
 
 type typecheckResult struct {
-	ready chan struct{} // closed to broadcast readiness
-	fset  *token.FileSet
-	prog  *loader.Program
-	err   error
+	fset *token.FileSet
+	prog *loader.Program
+	err  error
 }
 
 func (h *LangHandler) cachedTypecheck(ctx context.Context, bctx *build.Context, bpkg *build.Package) (*token.FileSet, *loader.Program, diagnostics, error) {
@@ -196,28 +195,19 @@ func (h *LangHandler) cachedTypecheck(ctx context.Context, bctx *build.Context, 
 	ctx = opentracing.ContextWithSpan(ctx, span)
 	defer span.Finish()
 
-	k := typecheckKey{bpkg.ImportPath, bpkg.Dir, bpkg.Name}
-
-	h.mu.Lock()
-	res, ok := h.cache[k]
-	if !ok {
-		res = &typecheckResult{ready: make(chan struct{})}
-		h.cache[k] = res
-		defer close(res.ready)
-	}
-	h.mu.Unlock()
-
-	span.SetTag("cached", ok)
 	var diags diagnostics
-	if ok {
-		// cache hit, but wait until ready
-		typecheckCacheTotal.WithLabelValues("hit").Inc()
-		<-res.ready
-	} else {
-		typecheckCacheTotal.WithLabelValues("miss").Inc()
-		res.fset = token.NewFileSet()
+	r := h.typecheckCache.Get(typecheckKey{bpkg.ImportPath, bpkg.Dir, bpkg.Name}, func() interface{} {
+		res := &typecheckResult{
+			fset: token.NewFileSet(),
+		}
 		res.prog, diags, res.err = typecheck(ctx, res.fset, bctx, bpkg, h.getFindPackageFunc())
+		return res
+	})
+	if r == nil {
+		// This can happen if we panic
+		return nil, nil, diags, nil
 	}
+	res := r.(*typecheckResult)
 	return res.fset, res.prog, diags, res.err
 }
 

--- a/langserver/loader.go
+++ b/langserver/loader.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 
 	opentracing "github.com/opentracing/opentracing-go"
-	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/sourcegraph/go-langserver/pkg/lsp"
 
@@ -301,15 +300,4 @@ func clearInfoFields(info *loader.PackageInfo) {
 func isMultiplePackageError(err error) bool {
 	_, ok := err.(*build.MultiplePackageError)
 	return ok
-}
-
-var typecheckCacheTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
-	Namespace: "golangserver",
-	Subsystem: "typecheck",
-	Name:      "cache_request_total",
-	Help:      "Count of requests to cache.",
-}, []string{"type"})
-
-func init() {
-	prometheus.MustRegister(typecheckCacheTotal)
 }

--- a/langserver/symbol.go
+++ b/langserver/symbol.go
@@ -20,7 +20,6 @@ import (
 	"golang.org/x/tools/go/buildutil"
 
 	"github.com/neelance/parallel"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sourcegraph/go-langserver/pkg/lsp"
 	"github.com/sourcegraph/jsonrpc2"
 )
@@ -453,17 +452,6 @@ func maybeLogImportError(pkg string, err error) {
 	if !(isNoGoError || !isMultiplePackageError(err) || strings.HasPrefix(pkg, "github.com/golang/go/test/")) {
 		log.Printf("skipping possible package %s: %s", pkg, err)
 	}
-}
-
-var symbolCacheTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
-	Namespace: "golangserver",
-	Subsystem: "symbol",
-	Name:      "cache_request_total",
-	Help:      "Count of requests to cache.",
-}, []string{"type"})
-
-func init() {
-	prometheus.MustRegister(symbolCacheTotal)
 }
 
 // listPkgsUnderDir is buildutil.ExpandPattern(ctxt, []string{dir +


### PR DESCRIPTION
We experience OOMs on a semi-regular basis at the moment in sourcegraph production. This is due to our caches being unbounded. This PR is an experiment at bounding the caches. We bound them at the process level since in sourcegraph.com production we can have multiple active langserver in the same process. The initial cache sizes are estimates at what a useful size is. After experimentation with this having production traffic, I'll update the defaults.