### PR TITLE
implement workspace/symbol extension

### DIFF
--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -167,7 +167,7 @@ func (h *LangHandler) Handle(ctx context.Context, conn JSONRPC2Conn, req *jsonrp
 			go func() {
 				ctx, cancel := context.WithDeadline(ctx, time.Now().Add(30*time.Second))
 				defer cancel()
-				_, _ = h.handleWorkspaceSymbol(ctx, conn, req, lsp.WorkspaceSymbolParams{
+				_, _ = h.handleWorkspaceSymbol(ctx, conn, req, lspext.WorkspaceSymbolParams{
 					Query: "",
 					Limit: 100,
 				})
@@ -185,6 +185,7 @@ func (h *LangHandler) Handle(ctx context.Context, conn JSONRPC2Conn, req *jsonrp
 				WorkspaceSymbolProvider:      true,
 				XWorkspaceReferencesProvider: true,
 				XDefinitionProvider:          true,
+				XWorkspaceSymbolByProperties: true,
 				SignatureHelpProvider:        &lsp.SignatureHelpOptions{TriggerCharacters: []string{"(", ","}},
 			},
 		}, nil
@@ -273,7 +274,7 @@ func (h *LangHandler) Handle(ctx context.Context, conn JSONRPC2Conn, req *jsonrp
 		if req.Params == nil {
 			return nil, &jsonrpc2.Error{Code: jsonrpc2.CodeInvalidParams}
 		}
-		var params lsp.WorkspaceSymbolParams
+		var params lspext.WorkspaceSymbolParams
 		if err := json.Unmarshal(*req.Params, &params); err != nil {
 			return nil, err
 		}

--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -49,10 +49,10 @@ func TestServer(t *testing.T) {
 					"b.go:1:23": "/src/test/pkg/a.go:1:17",
 				},
 				wantXDefinition: map[string]string{
-					"a.go:1:17": "/src/test/pkg/a.go:1:17 name:A package:test/pkg packageName:p recv: vendor:false",
-					"a.go:1:23": "/src/test/pkg/a.go:1:17 name:A package:test/pkg packageName:p recv: vendor:false",
-					"b.go:1:17": "/src/test/pkg/b.go:1:17 name:B package:test/pkg packageName:p recv: vendor:false",
-					"b.go:1:23": "/src/test/pkg/a.go:1:17 name:A package:test/pkg packageName:p recv: vendor:false",
+					"a.go:1:17": "/src/test/pkg/a.go:1:17 id:test/pkg:p::A name:A package:test/pkg packageName:p recv: vendor:false",
+					"a.go:1:23": "/src/test/pkg/a.go:1:17 id:test/pkg:p::A name:A package:test/pkg packageName:p recv: vendor:false",
+					"b.go:1:17": "/src/test/pkg/b.go:1:17 id:test/pkg:p::B name:B package:test/pkg packageName:p recv: vendor:false",
+					"b.go:1:23": "/src/test/pkg/a.go:1:17 id:test/pkg:p::A name:A package:test/pkg packageName:p recv: vendor:false",
 				},
 				wantReferences: map[string][]string{
 					"a.go:1:17": []string{
@@ -106,6 +106,14 @@ func TestServer(t *testing.T) {
 					{Symbol: lspext.SymbolDescriptor{"package": "test/pkg", "name": "B", "packageName": "p"}}:                              []string{"/src/test/pkg/b.go:function:pkg.B:1:17"},
 					{Symbol: lspext.SymbolDescriptor{"package": "test/pkg", "name": "B", "packageName": "p", "recv": ""}}:                  []string{"/src/test/pkg/b.go:function:pkg.B:1:17"},
 					{Symbol: lspext.SymbolDescriptor{"package": "test/pkg", "name": "B", "packageName": "p", "recv": "", "vendor": false}}: []string{"/src/test/pkg/b.go:function:pkg.B:1:17"},
+
+					// By ID (first form, `<package>:<packageName>:<recv>:<name>`).
+					{Symbol: lspext.SymbolDescriptor{"id": "test/pkg:p::B"}}: []string{"/src/test/pkg/b.go:function:pkg.B:1:17"},
+					{Symbol: lspext.SymbolDescriptor{"id": "test/pkg:p::A"}}: []string{"/src/test/pkg/a.go:function:pkg.A:1:17"},
+
+					// By ID (second form, `<package>:<recv>:<name>`).
+					{Symbol: lspext.SymbolDescriptor{"id": "test/pkg::B"}}: []string{"/src/test/pkg/b.go:function:pkg.B:1:17"},
+					{Symbol: lspext.SymbolDescriptor{"id": "test/pkg::A"}}: []string{"/src/test/pkg/a.go:function:pkg.A:1:17"},
 				},
 				wantFormatting: map[string]string{
 					"a.go": "package p\n\nfunc A() { A() }\n",
@@ -184,11 +192,11 @@ func TestServer(t *testing.T) {
 					"d2/b.go:1:52": "/src/test/pkg/d/d2/b.go:1:39",
 				},
 				wantXDefinition: map[string]string{
-					"a.go:1:17":    "/src/test/pkg/d/a.go:1:17 name:A package:test/pkg/d packageName:d recv: vendor:false",
-					"a.go:1:23":    "/src/test/pkg/d/a.go:1:17 name:A package:test/pkg/d packageName:d recv: vendor:false",
-					"d2/b.go:1:39": "/src/test/pkg/d/d2/b.go:1:39 name:B package:test/pkg/d/d2 packageName:d2 recv: vendor:false",
-					"d2/b.go:1:47": "/src/test/pkg/d/a.go:1:17 name:A package:test/pkg/d packageName:d recv: vendor:false",
-					"d2/b.go:1:52": "/src/test/pkg/d/d2/b.go:1:39 name:B package:test/pkg/d/d2 packageName:d2 recv: vendor:false",
+					"a.go:1:17":    "/src/test/pkg/d/a.go:1:17 id:test/pkg/d:d::A name:A package:test/pkg/d packageName:d recv: vendor:false",
+					"a.go:1:23":    "/src/test/pkg/d/a.go:1:17 id:test/pkg/d:d::A name:A package:test/pkg/d packageName:d recv: vendor:false",
+					"d2/b.go:1:39": "/src/test/pkg/d/d2/b.go:1:39 id:test/pkg/d/d2:d2::B name:B package:test/pkg/d/d2 packageName:d2 recv: vendor:false",
+					"d2/b.go:1:47": "/src/test/pkg/d/a.go:1:17 id:test/pkg/d:d::A name:A package:test/pkg/d packageName:d recv: vendor:false",
+					"d2/b.go:1:52": "/src/test/pkg/d/d2/b.go:1:39 id:test/pkg/d/d2:d2::B name:B package:test/pkg/d/d2 packageName:d2 recv: vendor:false",
 				},
 				wantSymbols: map[string][]string{
 					"a.go":    []string{"/src/test/pkg/d/a.go:function:d.A:1:17"},
@@ -217,26 +225,26 @@ func TestServer(t *testing.T) {
 
 					// Matching against a dirs hint with multiple dirs.
 					{Query: lspext.SymbolDescriptor{"package": "test/pkg/d"}, Hints: map[string]interface{}{"dirs": []string{"file:///src/test/pkg/d/d2", "file:///src/test/pkg/d/invalid"}}}: []string{
-						"/src/test/pkg/d/d2/b.go:1:20-1:20 -> name: package:test/pkg/d packageName:d recv: vendor:false",
-						"/src/test/pkg/d/d2/b.go:1:47-1:47 -> name:A package:test/pkg/d packageName:d recv: vendor:false",
+						"/src/test/pkg/d/d2/b.go:1:20-1:20 -> id:test/pkg/d:d:: name: package:test/pkg/d packageName:d recv: vendor:false",
+						"/src/test/pkg/d/d2/b.go:1:47-1:47 -> id:test/pkg/d:d::A name:A package:test/pkg/d packageName:d recv: vendor:false",
 					},
 
 					// Matching against a dirs hint.
 					{Query: lspext.SymbolDescriptor{"package": "test/pkg/d"}, Hints: map[string]interface{}{"dirs": []string{"file:///src/test/pkg/d/d2"}}}: []string{
-						"/src/test/pkg/d/d2/b.go:1:20-1:20 -> name: package:test/pkg/d packageName:d recv: vendor:false",
-						"/src/test/pkg/d/d2/b.go:1:47-1:47 -> name:A package:test/pkg/d packageName:d recv: vendor:false",
+						"/src/test/pkg/d/d2/b.go:1:20-1:20 -> id:test/pkg/d:d:: name: package:test/pkg/d packageName:d recv: vendor:false",
+						"/src/test/pkg/d/d2/b.go:1:47-1:47 -> id:test/pkg/d:d::A name:A package:test/pkg/d packageName:d recv: vendor:false",
 					},
 
 					// Matching against single field.
 					{Query: lspext.SymbolDescriptor{"package": "test/pkg/d"}}: []string{
-						"/src/test/pkg/d/d2/b.go:1:20-1:20 -> name: package:test/pkg/d packageName:d recv: vendor:false",
-						"/src/test/pkg/d/d2/b.go:1:47-1:47 -> name:A package:test/pkg/d packageName:d recv: vendor:false",
+						"/src/test/pkg/d/d2/b.go:1:20-1:20 -> id:test/pkg/d:d:: name: package:test/pkg/d packageName:d recv: vendor:false",
+						"/src/test/pkg/d/d2/b.go:1:47-1:47 -> id:test/pkg/d:d::A name:A package:test/pkg/d packageName:d recv: vendor:false",
 					},
 
 					// Matching against no fields.
 					{Query: lspext.SymbolDescriptor{}}: []string{
-						"/src/test/pkg/d/d2/b.go:1:20-1:20 -> name: package:test/pkg/d packageName:d recv: vendor:false",
-						"/src/test/pkg/d/d2/b.go:1:47-1:47 -> name:A package:test/pkg/d packageName:d recv: vendor:false",
+						"/src/test/pkg/d/d2/b.go:1:20-1:20 -> id:test/pkg/d:d:: name: package:test/pkg/d packageName:d recv: vendor:false",
+						"/src/test/pkg/d/d2/b.go:1:47-1:47 -> id:test/pkg/d:d::A name:A package:test/pkg/d packageName:d recv: vendor:false",
 					},
 					{
 						Query: lspext.SymbolDescriptor{
@@ -246,7 +254,7 @@ func TestServer(t *testing.T) {
 							"recv":        "",
 							"vendor":      false,
 						},
-					}: []string{"/src/test/pkg/d/d2/b.go:1:20-1:20 -> name: package:test/pkg/d packageName:d recv: vendor:false"},
+					}: []string{"/src/test/pkg/d/d2/b.go:1:20-1:20 -> id:test/pkg/d:d:: name: package:test/pkg/d packageName:d recv: vendor:false"},
 					{
 						Query: lspext.SymbolDescriptor{
 							"name":        "A",
@@ -255,7 +263,7 @@ func TestServer(t *testing.T) {
 							"recv":        "",
 							"vendor":      false,
 						},
-					}: []string{"/src/test/pkg/d/d2/b.go:1:47-1:47 -> name:A package:test/pkg/d packageName:d recv: vendor:false"},
+					}: []string{"/src/test/pkg/d/d2/b.go:1:47-1:47 -> id:test/pkg/d:d::A name:A package:test/pkg/d packageName:d recv: vendor:false"},
 				},
 			},
 		},
@@ -288,8 +296,8 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 					// "main.go:3:52": "/src/test/pkg/main.go:3:39", // B() -> func B()
 				},
 				wantXDefinition: map[string]string{
-					"a.go:1:17": "/src/test/pkg/a.go:1:17 name:A package:test/pkg packageName:p recv: vendor:false",
-					"a.go:1:23": "/src/test/pkg/a.go:1:17 name:A package:test/pkg packageName:p recv: vendor:false",
+					"a.go:1:17": "/src/test/pkg/a.go:1:17 id:test/pkg:p::A name:A package:test/pkg packageName:p recv: vendor:false",
+					"a.go:1:23": "/src/test/pkg/a.go:1:17 id:test/pkg:p::A name:A package:test/pkg packageName:p recv: vendor:false",
 				},
 				wantSymbols: map[string][]string{
 					"a.go": []string{"/src/test/pkg/a.go:function:pkg.A:1:17"},
@@ -322,7 +330,7 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 					// "a.go:1:53": "/goroot/src/builtin/builtin.go:TODO:TODO", // TODO(sqs): support builtins
 				},
 				wantXDefinition: map[string]string{
-					"a.go:1:40": "/goroot/src/fmt/print.go:1:19 name:Println package:fmt packageName:fmt recv: vendor:false",
+					"a.go:1:40": "/goroot/src/fmt/print.go:1:19 id:fmt:fmt::Println name:Println package:fmt packageName:fmt recv: vendor:false",
 				},
 				wantSymbols: map[string][]string{
 					"a.go": []string{
@@ -341,8 +349,8 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				},
 				wantWorkspaceReferences: map[*lspext.WorkspaceReferencesParams][]string{
 					{Query: lspext.SymbolDescriptor{}}: []string{
-						"/src/test/pkg/a.go:1:19-1:19 -> name: package:fmt packageName:fmt recv: vendor:false",
-						"/src/test/pkg/a.go:1:38-1:38 -> name:Println package:fmt packageName:fmt recv: vendor:false",
+						"/src/test/pkg/a.go:1:19-1:19 -> id:fmt:fmt:: name: package:fmt packageName:fmt recv: vendor:false",
+						"/src/test/pkg/a.go:1:38-1:38 -> id:fmt:fmt::Println name:Println package:fmt packageName:fmt recv: vendor:false",
 					},
 				},
 			},
@@ -365,8 +373,8 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 					"b/b.go:1:43": "/src/test/pkg/a/a.go:1:17",
 				},
 				wantXDefinition: map[string]string{
-					"a/a.go:1:17": "/src/test/pkg/a/a.go:1:17 name:A package:test/pkg/a packageName:a recv: vendor:false",
-					"b/b.go:1:43": "/src/test/pkg/a/a.go:1:17 name:A package:test/pkg/a packageName:a recv: vendor:false",
+					"a/a.go:1:17": "/src/test/pkg/a/a.go:1:17 id:test/pkg/a:a::A name:A package:test/pkg/a packageName:a recv: vendor:false",
+					"b/b.go:1:43": "/src/test/pkg/a/a.go:1:17 id:test/pkg/a:a::A name:A package:test/pkg/a packageName:a recv: vendor:false",
 				},
 				wantReferences: map[string][]string{
 					"a/a.go:1:17": []string{
@@ -388,8 +396,8 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				},
 				wantWorkspaceReferences: map[*lspext.WorkspaceReferencesParams][]string{
 					{Query: lspext.SymbolDescriptor{}}: []string{
-						"/src/test/pkg/b/b.go:1:19-1:19 -> name: package:test/pkg/a packageName:a recv: vendor:false",
-						"/src/test/pkg/b/b.go:1:43-1:43 -> name:A package:test/pkg/a packageName:a recv: vendor:false",
+						"/src/test/pkg/b/b.go:1:19-1:19 -> id:test/pkg/a:a:: name: package:test/pkg/a packageName:a recv: vendor:false",
+						"/src/test/pkg/b/b.go:1:43-1:43 -> id:test/pkg/a:a::A name:A package:test/pkg/a packageName:a recv: vendor:false",
 					},
 				},
 			},
@@ -408,7 +416,7 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 					"a.go:1:61": "/src/test/pkg/vendor/github.com/v/vendored/v.go:1:24",
 				},
 				wantXDefinition: map[string]string{
-					"a.go:1:61": "/src/test/pkg/vendor/github.com/v/vendored/v.go:1:24 name:V package:test/pkg/vendor/github.com/v/vendored packageName:vendored recv: vendor:true",
+					"a.go:1:61": "/src/test/pkg/vendor/github.com/v/vendored/v.go:1:24 id:test/pkg/vendor/github.com/v/vendored:vendored::V name:V package:test/pkg/vendor/github.com/v/vendored packageName:vendored recv: vendor:true",
 				},
 				wantReferences: map[string][]string{
 					"vendor/github.com/v/vendored/v.go:1:24": []string{
@@ -429,8 +437,8 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				},
 				wantWorkspaceReferences: map[*lspext.WorkspaceReferencesParams][]string{
 					{Query: lspext.SymbolDescriptor{}}: []string{
-						"/src/test/pkg/a.go:1:19-1:19 -> name: package:test/pkg/vendor/github.com/v/vendored packageName:vendored recv: vendor:true",
-						"/src/test/pkg/a.go:1:61-1:61 -> name:V package:test/pkg/vendor/github.com/v/vendored packageName:vendored recv: vendor:true",
+						"/src/test/pkg/a.go:1:19-1:19 -> id:test/pkg/vendor/github.com/v/vendored:vendored:: name: package:test/pkg/vendor/github.com/v/vendored packageName:vendored recv: vendor:true",
+						"/src/test/pkg/a.go:1:61-1:61 -> id:test/pkg/vendor/github.com/v/vendored:vendored::V name:V package:test/pkg/vendor/github.com/v/vendored packageName:vendored recv: vendor:true",
 					},
 				},
 			},
@@ -491,7 +499,7 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 					"a.go:1:51": "/src/github.com/d/dep/d.go:1:19",
 				},
 				wantXDefinition: map[string]string{
-					"a.go:1:51": "/src/github.com/d/dep/d.go:1:19 name:D package:github.com/d/dep packageName:dep recv: vendor:false",
+					"a.go:1:51": "/src/github.com/d/dep/d.go:1:19 id:github.com/d/dep:dep::D name:D package:github.com/d/dep packageName:dep recv: vendor:false",
 				},
 				wantReferences: map[string][]string{
 					"a.go:1:51": []string{
@@ -504,9 +512,9 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				},
 				wantWorkspaceReferences: map[*lspext.WorkspaceReferencesParams][]string{
 					{Query: lspext.SymbolDescriptor{}}: []string{
-						"/src/test/pkg/a.go:1:19-1:19 -> name: package:github.com/d/dep packageName:dep recv: vendor:false",
-						"/src/test/pkg/a.go:1:51-1:51 -> name:D package:github.com/d/dep packageName:dep recv: vendor:false",
-						"/src/test/pkg/a.go:1:66-1:66 -> name:D package:github.com/d/dep packageName:dep recv: vendor:false",
+						"/src/test/pkg/a.go:1:19-1:19 -> id:github.com/d/dep:dep:: name: package:github.com/d/dep packageName:dep recv: vendor:false",
+						"/src/test/pkg/a.go:1:51-1:51 -> id:github.com/d/dep:dep::D name:D package:github.com/d/dep packageName:dep recv: vendor:false",
+						"/src/test/pkg/a.go:1:66-1:66 -> id:github.com/d/dep:dep::D name:D package:github.com/d/dep packageName:dep recv: vendor:false",
 					},
 				},
 			},
@@ -527,13 +535,13 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 					"a.go:1:55": "/src/github.com/d/dep/vendor/vendp/vp.go:1:32",
 				},
 				wantXDefinition: map[string]string{
-					"a.go:1:55": "/src/github.com/d/dep/vendor/vendp/vp.go:1:32 name:F package:github.com/d/dep/vendor/vendp packageName:vendp recv:V vendor:true",
+					"a.go:1:55": "/src/github.com/d/dep/vendor/vendp/vp.go:1:32 id:github.com/d/dep/vendor/vendp:vendp:V:F name:F package:github.com/d/dep/vendor/vendp packageName:vendp recv:V vendor:true",
 				},
 				wantWorkspaceReferences: map[*lspext.WorkspaceReferencesParams][]string{
 					{Query: lspext.SymbolDescriptor{}}: []string{
-						"/src/test/pkg/a.go:1:19-1:19 -> name: package:github.com/d/dep packageName:dep recv: vendor:false",
-						"/src/test/pkg/a.go:1:55-1:55 -> name:F package:github.com/d/dep/vendor/vendp packageName:vendp recv:V vendor:true",
-						"/src/test/pkg/a.go:1:51-1:51 -> name:D package:github.com/d/dep packageName:dep recv: vendor:false",
+						"/src/test/pkg/a.go:1:19-1:19 -> id:github.com/d/dep:dep:: name: package:github.com/d/dep packageName:dep recv: vendor:false",
+						"/src/test/pkg/a.go:1:55-1:55 -> id:github.com/d/dep/vendor/vendp:vendp:V:F name:F package:github.com/d/dep/vendor/vendp packageName:vendp recv:V vendor:true",
+						"/src/test/pkg/a.go:1:51-1:51 -> id:github.com/d/dep:dep::D name:D package:github.com/d/dep packageName:dep recv: vendor:false",
 					},
 				},
 			},
@@ -556,12 +564,12 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 					"a.go:1:57": "/src/github.com/d/dep/subp/d.go:1:20",
 				},
 				wantXDefinition: map[string]string{
-					"a.go:1:57": "/src/github.com/d/dep/subp/d.go:1:20 name:D package:github.com/d/dep/subp packageName:subp recv: vendor:false",
+					"a.go:1:57": "/src/github.com/d/dep/subp/d.go:1:20 id:github.com/d/dep/subp:subp::D name:D package:github.com/d/dep/subp packageName:subp recv: vendor:false",
 				},
 				wantWorkspaceReferences: map[*lspext.WorkspaceReferencesParams][]string{
 					{Query: lspext.SymbolDescriptor{}}: []string{
-						"/src/test/pkg/a.go:1:19-1:19 -> name: package:github.com/d/dep/subp packageName:subp recv: vendor:false",
-						"/src/test/pkg/a.go:1:57-1:57 -> name:D package:github.com/d/dep/subp packageName:subp recv: vendor:false",
+						"/src/test/pkg/a.go:1:19-1:19 -> id:github.com/d/dep/subp:subp:: name: package:github.com/d/dep/subp packageName:subp recv: vendor:false",
+						"/src/test/pkg/a.go:1:57-1:57 -> id:github.com/d/dep/subp:subp::D name:D package:github.com/d/dep/subp packageName:subp recv: vendor:false",
 					},
 				},
 			},
@@ -589,14 +597,14 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 					"a.go:1:58": "/src/github.com/d/dep2/d2.go:1:32", // field D2
 				},
 				wantXDefinition: map[string]string{
-					"a.go:1:53": "/src/github.com/d/dep1/d1.go:1:48 name:D1 package:github.com/d/dep1 packageName:dep1 recv: vendor:false",
-					"a.go:1:58": "/src/github.com/d/dep2/d2.go:1:32 name:D2 package:github.com/d/dep2 packageName:dep2 recv:D2 vendor:false",
+					"a.go:1:53": "/src/github.com/d/dep1/d1.go:1:48 id:github.com/d/dep1:dep1::D1 name:D1 package:github.com/d/dep1 packageName:dep1 recv: vendor:false",
+					"a.go:1:58": "/src/github.com/d/dep2/d2.go:1:32 id:github.com/d/dep2:dep2:D2:D2 name:D2 package:github.com/d/dep2 packageName:dep2 recv:D2 vendor:false",
 				},
 				wantWorkspaceReferences: map[*lspext.WorkspaceReferencesParams][]string{
 					{Query: lspext.SymbolDescriptor{}}: []string{
-						"/src/test/pkg/a.go:1:19-1:19 -> name: package:github.com/d/dep1 packageName:dep1 recv: vendor:false",
-						"/src/test/pkg/a.go:1:58-1:58 -> name:D2 package:github.com/d/dep2 packageName:dep2 recv:D2 vendor:false",
-						"/src/test/pkg/a.go:1:53-1:53 -> name:D1 package:github.com/d/dep1 packageName:dep1 recv: vendor:false",
+						"/src/test/pkg/a.go:1:19-1:19 -> id:github.com/d/dep1:dep1:: name: package:github.com/d/dep1 packageName:dep1 recv: vendor:false",
+						"/src/test/pkg/a.go:1:58-1:58 -> id:github.com/d/dep2:dep2:D2:D2 name:D2 package:github.com/d/dep2 packageName:dep2 recv:D2 vendor:false",
+						"/src/test/pkg/a.go:1:53-1:53 -> id:github.com/d/dep1:dep1::D1 name:D1 package:github.com/d/dep1 packageName:dep1 recv: vendor:false",
 					},
 				},
 			},
@@ -716,12 +724,12 @@ type Header struct {
 			cases: lspTestCases{
 				wantWorkspaceReferences: map[*lspext.WorkspaceReferencesParams][]string{
 					{Query: lspext.SymbolDescriptor{}}: []string{
-						"/src/test/pkg/a.go:1:19-1:19 -> name: package:fmt packageName:fmt recv: vendor:false",
-						"/src/test/pkg/a.go:1:38-1:38 -> name:Println package:fmt packageName:fmt recv: vendor:false",
-						"/src/test/pkg/b.go:1:19-1:19 -> name: package:fmt packageName:fmt recv: vendor:false",
-						"/src/test/pkg/b.go:1:38-1:38 -> name:Println package:fmt packageName:fmt recv: vendor:false",
-						"/src/test/pkg/c.go:1:19-1:19 -> name: package:fmt packageName:fmt recv: vendor:false",
-						"/src/test/pkg/c.go:1:38-1:38 -> name:Println package:fmt packageName:fmt recv: vendor:false",
+						"/src/test/pkg/a.go:1:19-1:19 -> id:fmt:fmt:: name: package:fmt packageName:fmt recv: vendor:false",
+						"/src/test/pkg/a.go:1:38-1:38 -> id:fmt:fmt::Println name:Println package:fmt packageName:fmt recv: vendor:false",
+						"/src/test/pkg/b.go:1:19-1:19 -> id:fmt:fmt:: name: package:fmt packageName:fmt recv: vendor:false",
+						"/src/test/pkg/b.go:1:38-1:38 -> id:fmt:fmt::Println name:Println package:fmt packageName:fmt recv: vendor:false",
+						"/src/test/pkg/c.go:1:19-1:19 -> id:fmt:fmt:: name: package:fmt packageName:fmt recv: vendor:false",
+						"/src/test/pkg/c.go:1:38-1:38 -> id:fmt:fmt::Println name:Println package:fmt packageName:fmt recv: vendor:false",
 					},
 				},
 			},

--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -76,7 +76,7 @@ func TestServer(t *testing.T) {
 					"a.go": []string{"/src/test/pkg/a.go:function:pkg.A:1:17"},
 					"b.go": []string{"/src/test/pkg/b.go:function:pkg.B:1:17"},
 				},
-				wantWorkspaceSymbols: map[lspext.WorkspaceSymbolParams][]string{
+				wantWorkspaceSymbols: map[*lspext.WorkspaceSymbolParams][]string{
 					{Query: ""}:            []string{"/src/test/pkg/a.go:function:pkg.A:1:17", "/src/test/pkg/b.go:function:pkg.B:1:17"},
 					{Query: "A"}:           []string{"/src/test/pkg/a.go:function:pkg.A:1:17"},
 					{Query: "B"}:           []string{"/src/test/pkg/b.go:function:pkg.B:1:17"},
@@ -84,6 +84,28 @@ func TestServer(t *testing.T) {
 					{Query: "dir:/"}:       []string{"/src/test/pkg/a.go:function:pkg.A:1:17", "/src/test/pkg/b.go:function:pkg.B:1:17"},
 					{Query: "dir:/ A"}:     []string{"/src/test/pkg/a.go:function:pkg.A:1:17"},
 					{Query: "dir:/ B"}:     []string{"/src/test/pkg/b.go:function:pkg.B:1:17"},
+
+					// non-nil SymbolDescriptor + no keys.
+					{Symbol: make(lspext.SymbolDescriptor)}: []string{"/src/test/pkg/a.go:function:pkg.A:1:17", "/src/test/pkg/b.go:function:pkg.B:1:17"},
+
+					// Individual filter fields.
+					{Symbol: lspext.SymbolDescriptor{"package": "test/pkg"}}: []string{"/src/test/pkg/a.go:function:pkg.A:1:17", "/src/test/pkg/b.go:function:pkg.B:1:17"},
+					{Symbol: lspext.SymbolDescriptor{"name": "A"}}:           []string{"/src/test/pkg/a.go:function:pkg.A:1:17"},
+					{Symbol: lspext.SymbolDescriptor{"name": "B"}}:           []string{"/src/test/pkg/b.go:function:pkg.B:1:17"},
+					{Symbol: lspext.SymbolDescriptor{"packageName": "p"}}:    []string{"/src/test/pkg/a.go:function:pkg.A:1:17", "/src/test/pkg/b.go:function:pkg.B:1:17"},
+					{Symbol: lspext.SymbolDescriptor{"recv": ""}}:            []string{"/src/test/pkg/a.go:function:pkg.A:1:17", "/src/test/pkg/b.go:function:pkg.B:1:17"},
+					{Symbol: lspext.SymbolDescriptor{"vendor": false}}:       []string{"/src/test/pkg/a.go:function:pkg.A:1:17", "/src/test/pkg/b.go:function:pkg.B:1:17"},
+
+					// Combined filter fields.
+					{Symbol: lspext.SymbolDescriptor{"package": "test/pkg"}}:                                                               []string{"/src/test/pkg/a.go:function:pkg.A:1:17", "/src/test/pkg/b.go:function:pkg.B:1:17"},
+					{Symbol: lspext.SymbolDescriptor{"package": "test/pkg", "name": "A"}}:                                                  []string{"/src/test/pkg/a.go:function:pkg.A:1:17"},
+					{Symbol: lspext.SymbolDescriptor{"package": "test/pkg", "name": "A", "packageName": "p"}}:                              []string{"/src/test/pkg/a.go:function:pkg.A:1:17"},
+					{Symbol: lspext.SymbolDescriptor{"package": "test/pkg", "name": "A", "packageName": "p", "recv": ""}}:                  []string{"/src/test/pkg/a.go:function:pkg.A:1:17"},
+					{Symbol: lspext.SymbolDescriptor{"package": "test/pkg", "name": "A", "packageName": "p", "recv": "", "vendor": false}}: []string{"/src/test/pkg/a.go:function:pkg.A:1:17"},
+					{Symbol: lspext.SymbolDescriptor{"package": "test/pkg", "name": "B"}}:                                                  []string{"/src/test/pkg/b.go:function:pkg.B:1:17"},
+					{Symbol: lspext.SymbolDescriptor{"package": "test/pkg", "name": "B", "packageName": "p"}}:                              []string{"/src/test/pkg/b.go:function:pkg.B:1:17"},
+					{Symbol: lspext.SymbolDescriptor{"package": "test/pkg", "name": "B", "packageName": "p", "recv": ""}}:                  []string{"/src/test/pkg/b.go:function:pkg.B:1:17"},
+					{Symbol: lspext.SymbolDescriptor{"package": "test/pkg", "name": "B", "packageName": "p", "recv": "", "vendor": false}}: []string{"/src/test/pkg/b.go:function:pkg.B:1:17"},
 				},
 				wantFormatting: map[string]string{
 					"a.go": "package p\n\nfunc A() { A() }\n",
@@ -104,7 +126,7 @@ func TestServer(t *testing.T) {
 				wantSymbols: map[string][]string{
 					"a.go": []string{"/src/test/pkg/a.go:class:pkg.T:1:17"},
 				},
-				wantWorkspaceSymbols: map[lspext.WorkspaceSymbolParams][]string{
+				wantWorkspaceSymbols: map[*lspext.WorkspaceSymbolParams][]string{
 					{Query: ""}:            []string{"/src/test/pkg/a.go:class:pkg.T:1:17"},
 					{Query: "T"}:           []string{"/src/test/pkg/a.go:class:pkg.T:1:17"},
 					{Query: "F"}:           []string{}, // we don't return fields for now
@@ -121,7 +143,7 @@ func TestServer(t *testing.T) {
 				wantSymbols: map[string][]string{
 					"a.go": []string{"/src/test/pkg/a.go:class:pkg.t:1:17"},
 				},
-				wantWorkspaceSymbols: map[lspext.WorkspaceSymbolParams][]string{
+				wantWorkspaceSymbols: map[*lspext.WorkspaceSymbolParams][]string{
 					{Query: "is:exported"}: []string{},
 				},
 			},
@@ -172,7 +194,7 @@ func TestServer(t *testing.T) {
 					"a.go":    []string{"/src/test/pkg/d/a.go:function:d.A:1:17"},
 					"d2/b.go": []string{"/src/test/pkg/d/d2/b.go:function:d2.B:1:39"},
 				},
-				wantWorkspaceSymbols: map[lspext.WorkspaceSymbolParams][]string{
+				wantWorkspaceSymbols: map[*lspext.WorkspaceSymbolParams][]string{
 					{Query: ""}:            []string{"/src/test/pkg/d/a.go:function:d.A:1:17", "/src/test/pkg/d/d2/b.go:function:d2.B:1:39"},
 					{Query: "is:exported"}: []string{"/src/test/pkg/d/a.go:function:d.A:1:17", "/src/test/pkg/d/d2/b.go:function:d2.B:1:39"},
 					{Query: "dir:"}:        []string{"/src/test/pkg/d/a.go:function:d.A:1:17"},
@@ -272,9 +294,10 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				wantSymbols: map[string][]string{
 					"a.go": []string{"/src/test/pkg/a.go:function:pkg.A:1:17"},
 				},
-				wantWorkspaceSymbols: map[lspext.WorkspaceSymbolParams][]string{
+				wantWorkspaceSymbols: map[*lspext.WorkspaceSymbolParams][]string{
 					{Query: ""}:            []string{"/src/test/pkg/a.go:function:pkg.A:1:17"},
 					{Query: "is:exported"}: []string{"/src/test/pkg/a.go:function:pkg.A:1:17"},
+					{Symbol: lspext.SymbolDescriptor{"package": "test/pkg", "name": "A", "packageName": "p", "recv": "", "vendor": false}}: []string{"/src/test/pkg/a.go:function:pkg.A:1:17"},
 				},
 			},
 		},
@@ -308,12 +331,13 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 					},
 					"": []string{},
 				},
-				wantWorkspaceSymbols: map[lspext.WorkspaceSymbolParams][]string{
+				wantWorkspaceSymbols: map[*lspext.WorkspaceSymbolParams][]string{
 					{Query: ""}: []string{
 						"/src/test/pkg/a.go:variable:pkg._:1:26",
 						"/src/test/pkg/a.go:variable:pkg.x:1:47",
 					},
 					{Query: "is:exported"}: []string{},
+					{Symbol: lspext.SymbolDescriptor{"package": "test/pkg", "name": "x", "packageName": "p", "recv": "", "vendor": false}}: []string{"/src/test/pkg/a.go:variable:pkg.x:1:47"},
 				},
 				wantWorkspaceReferences: map[*lspext.WorkspaceReferencesParams][]string{
 					{Query: lspext.SymbolDescriptor{}}: []string{
@@ -358,7 +382,7 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 					"a/a.go": []string{"/src/test/pkg/a/a.go:function:a.A:1:17"},
 					"b/b.go": []string{"/src/test/pkg/b/b.go:variable:b._:1:33"},
 				},
-				wantWorkspaceSymbols: map[lspext.WorkspaceSymbolParams][]string{
+				wantWorkspaceSymbols: map[*lspext.WorkspaceSymbolParams][]string{
 					{Query: ""}:            []string{"/src/test/pkg/a/a.go:function:a.A:1:17", "/src/test/pkg/b/b.go:variable:b._:1:33"},
 					{Query: "is:exported"}: []string{"/src/test/pkg/a/a.go:function:a.A:1:17"},
 				},
@@ -396,9 +420,12 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 					"a.go": []string{"/src/test/pkg/a.go:variable:pkg._:1:44"},
 					"vendor/github.com/v/vendored/v.go": []string{"/src/test/pkg/vendor/github.com/v/vendored/v.go:function:vendored.V:1:24"},
 				},
-				wantWorkspaceSymbols: map[lspext.WorkspaceSymbolParams][]string{
+				wantWorkspaceSymbols: map[*lspext.WorkspaceSymbolParams][]string{
 					{Query: ""}:            []string{"/src/test/pkg/a.go:variable:pkg._:1:44", "/src/test/pkg/vendor/github.com/v/vendored/v.go:function:vendored.V:1:24"},
 					{Query: "is:exported"}: []string{},
+					{Symbol: lspext.SymbolDescriptor{"package": "test/pkg", "name": "_", "packageName": "a", "recv": "", "vendor": false}}:                                     []string{"/src/test/pkg/a.go:variable:pkg._:1:44"},
+					{Symbol: lspext.SymbolDescriptor{"package": "test/pkg/vendor/github.com/v/vendored", "name": "V", "packageName": "vendored", "recv": "", "vendor": true}}:  []string{"/src/test/pkg/vendor/github.com/v/vendored/v.go:function:vendored.V:1:24"},
+					{Symbol: lspext.SymbolDescriptor{"package": "test/pkg/vendor/github.com/v/vendored", "name": "V", "packageName": "vendored", "recv": "", "vendor": false}}: []string{},
 				},
 				wantWorkspaceReferences: map[*lspext.WorkspaceReferencesParams][]string{
 					{Query: lspext.SymbolDescriptor{}}: []string{
@@ -421,7 +448,7 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 					"vendor/github.com/a/pkg2/x.go": []string{"/src/test/pkg/vendor/github.com/a/pkg2/x.go:function:pkg2.x:1:20"},
 					"vendor/github.com/x/pkg3/x.go": []string{"/src/test/pkg/vendor/github.com/x/pkg3/x.go:function:pkg3.x:1:20"},
 				},
-				wantWorkspaceSymbols: map[lspext.WorkspaceSymbolParams][]string{
+				wantWorkspaceSymbols: map[*lspext.WorkspaceSymbolParams][]string{
 					{Query: ""}: []string{
 						"/src/test/pkg/z.go:function:pkg.x:1:19",
 						"/src/test/pkg/vendor/github.com/a/pkg2/x.go:function:pkg2.x:1:20",
@@ -600,7 +627,7 @@ func yza() {}
 					"bcd.go": []string{"/src/test/pkg/bcd.go:method:YZA.BCD:5:14", "/src/test/pkg/bcd.go:class:pkg.YZA:3:6"},
 					"xyz.go": []string{"/src/test/pkg/xyz.go:function:pkg.yza:3:6"},
 				},
-				wantWorkspaceSymbols: map[lspext.WorkspaceSymbolParams][]string{
+				wantWorkspaceSymbols: map[*lspext.WorkspaceSymbolParams][]string{
 					{Query: ""}:            []string{"/src/test/pkg/abc.go:method:XYZ.ABC:5:14", "/src/test/pkg/bcd.go:method:YZA.BCD:5:14", "/src/test/pkg/abc.go:class:pkg.XYZ:3:6", "/src/test/pkg/bcd.go:class:pkg.YZA:3:6", "/src/test/pkg/xyz.go:function:pkg.yza:3:6"},
 					{Query: "xyz"}:         []string{"/src/test/pkg/abc.go:class:pkg.XYZ:3:6", "/src/test/pkg/abc.go:method:XYZ.ABC:5:14", "/src/test/pkg/xyz.go:function:pkg.yza:3:6"},
 					{Query: "yza"}:         []string{"/src/test/pkg/bcd.go:class:pkg.YZA:3:6", "/src/test/pkg/xyz.go:function:pkg.yza:3:6", "/src/test/pkg/bcd.go:method:YZA.BCD:5:14"},
@@ -829,7 +856,7 @@ type lspTestCases struct {
 	wantXDefinition         map[string]string
 	wantReferences          map[string][]string
 	wantSymbols             map[string][]string
-	wantWorkspaceSymbols    map[lspext.WorkspaceSymbolParams][]string
+	wantWorkspaceSymbols    map[*lspext.WorkspaceSymbolParams][]string
 	wantSignatures          map[string]string
 	wantWorkspaceReferences map[*lspext.WorkspaceReferencesParams][]string
 	wantFormatting          map[string]string
@@ -867,8 +894,8 @@ func lspTests(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, rootPath stri
 	}
 
 	for params, want := range cases.wantWorkspaceSymbols {
-		tbRun(t, fmt.Sprintf("workspaceSymbols(%v)", params), func(t testing.TB) {
-			workspaceSymbolsTest(t, ctx, c, rootPath, params, want)
+		tbRun(t, fmt.Sprintf("workspaceSymbols(%v)", *params), func(t testing.TB) {
+			workspaceSymbolsTest(t, ctx, c, rootPath, *params, want)
 		})
 	}
 

--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -107,13 +107,9 @@ func TestServer(t *testing.T) {
 					{Symbol: lspext.SymbolDescriptor{"package": "test/pkg", "name": "B", "packageName": "p", "recv": ""}}:                  []string{"/src/test/pkg/b.go:function:pkg.B:1:17"},
 					{Symbol: lspext.SymbolDescriptor{"package": "test/pkg", "name": "B", "packageName": "p", "recv": "", "vendor": false}}: []string{"/src/test/pkg/b.go:function:pkg.B:1:17"},
 
-					// By ID (first form, `<package>:<packageName>:<recv>:<name>`).
+					// By ID.
 					{Symbol: lspext.SymbolDescriptor{"id": "test/pkg:p::B"}}: []string{"/src/test/pkg/b.go:function:pkg.B:1:17"},
 					{Symbol: lspext.SymbolDescriptor{"id": "test/pkg:p::A"}}: []string{"/src/test/pkg/a.go:function:pkg.A:1:17"},
-
-					// By ID (second form, `<package>:<recv>:<name>`).
-					{Symbol: lspext.SymbolDescriptor{"id": "test/pkg::B"}}: []string{"/src/test/pkg/b.go:function:pkg.B:1:17"},
-					{Symbol: lspext.SymbolDescriptor{"id": "test/pkg::A"}}: []string{"/src/test/pkg/a.go:function:pkg.A:1:17"},
 				},
 				wantFormatting: map[string]string{
 					"a.go": "package p\n\nfunc A() { A() }\n",

--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -76,14 +76,14 @@ func TestServer(t *testing.T) {
 					"a.go": []string{"/src/test/pkg/a.go:function:pkg.A:1:17"},
 					"b.go": []string{"/src/test/pkg/b.go:function:pkg.B:1:17"},
 				},
-				wantWorkspaceSymbols: map[string][]string{
-					"":            []string{"/src/test/pkg/a.go:function:pkg.A:1:17", "/src/test/pkg/b.go:function:pkg.B:1:17"},
-					"A":           []string{"/src/test/pkg/a.go:function:pkg.A:1:17"},
-					"B":           []string{"/src/test/pkg/b.go:function:pkg.B:1:17"},
-					"is:exported": []string{"/src/test/pkg/a.go:function:pkg.A:1:17", "/src/test/pkg/b.go:function:pkg.B:1:17"},
-					"dir:/":       []string{"/src/test/pkg/a.go:function:pkg.A:1:17", "/src/test/pkg/b.go:function:pkg.B:1:17"},
-					"dir:/ A":     []string{"/src/test/pkg/a.go:function:pkg.A:1:17"},
-					"dir:/ B":     []string{"/src/test/pkg/b.go:function:pkg.B:1:17"},
+				wantWorkspaceSymbols: map[lspext.WorkspaceSymbolParams][]string{
+					{Query: ""}:            []string{"/src/test/pkg/a.go:function:pkg.A:1:17", "/src/test/pkg/b.go:function:pkg.B:1:17"},
+					{Query: "A"}:           []string{"/src/test/pkg/a.go:function:pkg.A:1:17"},
+					{Query: "B"}:           []string{"/src/test/pkg/b.go:function:pkg.B:1:17"},
+					{Query: "is:exported"}: []string{"/src/test/pkg/a.go:function:pkg.A:1:17", "/src/test/pkg/b.go:function:pkg.B:1:17"},
+					{Query: "dir:/"}:       []string{"/src/test/pkg/a.go:function:pkg.A:1:17", "/src/test/pkg/b.go:function:pkg.B:1:17"},
+					{Query: "dir:/ A"}:     []string{"/src/test/pkg/a.go:function:pkg.A:1:17"},
+					{Query: "dir:/ B"}:     []string{"/src/test/pkg/b.go:function:pkg.B:1:17"},
 				},
 				wantFormatting: map[string]string{
 					"a.go": "package p\n\nfunc A() { A() }\n",
@@ -104,11 +104,11 @@ func TestServer(t *testing.T) {
 				wantSymbols: map[string][]string{
 					"a.go": []string{"/src/test/pkg/a.go:class:pkg.T:1:17"},
 				},
-				wantWorkspaceSymbols: map[string][]string{
-					"":            []string{"/src/test/pkg/a.go:class:pkg.T:1:17"},
-					"T":           []string{"/src/test/pkg/a.go:class:pkg.T:1:17"},
-					"F":           []string{}, // we don't return fields for now
-					"is:exported": []string{"/src/test/pkg/a.go:class:pkg.T:1:17"},
+				wantWorkspaceSymbols: map[lspext.WorkspaceSymbolParams][]string{
+					{Query: ""}:            []string{"/src/test/pkg/a.go:class:pkg.T:1:17"},
+					{Query: "T"}:           []string{"/src/test/pkg/a.go:class:pkg.T:1:17"},
+					{Query: "F"}:           []string{}, // we don't return fields for now
+					{Query: "is:exported"}: []string{"/src/test/pkg/a.go:class:pkg.T:1:17"},
 				},
 			},
 		},
@@ -121,8 +121,8 @@ func TestServer(t *testing.T) {
 				wantSymbols: map[string][]string{
 					"a.go": []string{"/src/test/pkg/a.go:class:pkg.t:1:17"},
 				},
-				wantWorkspaceSymbols: map[string][]string{
-					"is:exported": []string{},
+				wantWorkspaceSymbols: map[lspext.WorkspaceSymbolParams][]string{
+					{Query: "is:exported"}: []string{},
 				},
 			},
 		},
@@ -172,16 +172,16 @@ func TestServer(t *testing.T) {
 					"a.go":    []string{"/src/test/pkg/d/a.go:function:d.A:1:17"},
 					"d2/b.go": []string{"/src/test/pkg/d/d2/b.go:function:d2.B:1:39"},
 				},
-				wantWorkspaceSymbols: map[string][]string{
-					"":            []string{"/src/test/pkg/d/a.go:function:d.A:1:17", "/src/test/pkg/d/d2/b.go:function:d2.B:1:39"},
-					"is:exported": []string{"/src/test/pkg/d/a.go:function:d.A:1:17", "/src/test/pkg/d/d2/b.go:function:d2.B:1:39"},
-					"dir:":        []string{"/src/test/pkg/d/a.go:function:d.A:1:17"},
-					"dir:/":       []string{"/src/test/pkg/d/a.go:function:d.A:1:17"},
-					"dir:.":       []string{"/src/test/pkg/d/a.go:function:d.A:1:17"},
-					"dir:./":      []string{"/src/test/pkg/d/a.go:function:d.A:1:17"},
-					"dir:/d2":     []string{"/src/test/pkg/d/d2/b.go:function:d2.B:1:39"},
-					"dir:./d2":    []string{"/src/test/pkg/d/d2/b.go:function:d2.B:1:39"},
-					"dir:d2/":     []string{"/src/test/pkg/d/d2/b.go:function:d2.B:1:39"},
+				wantWorkspaceSymbols: map[lspext.WorkspaceSymbolParams][]string{
+					{Query: ""}:            []string{"/src/test/pkg/d/a.go:function:d.A:1:17", "/src/test/pkg/d/d2/b.go:function:d2.B:1:39"},
+					{Query: "is:exported"}: []string{"/src/test/pkg/d/a.go:function:d.A:1:17", "/src/test/pkg/d/d2/b.go:function:d2.B:1:39"},
+					{Query: "dir:"}:        []string{"/src/test/pkg/d/a.go:function:d.A:1:17"},
+					{Query: "dir:/"}:       []string{"/src/test/pkg/d/a.go:function:d.A:1:17"},
+					{Query: "dir:."}:       []string{"/src/test/pkg/d/a.go:function:d.A:1:17"},
+					{Query: "dir:./"}:      []string{"/src/test/pkg/d/a.go:function:d.A:1:17"},
+					{Query: "dir:/d2"}:     []string{"/src/test/pkg/d/d2/b.go:function:d2.B:1:39"},
+					{Query: "dir:./d2"}:    []string{"/src/test/pkg/d/d2/b.go:function:d2.B:1:39"},
+					{Query: "dir:d2/"}:     []string{"/src/test/pkg/d/d2/b.go:function:d2.B:1:39"},
 				},
 				wantWorkspaceReferences: map[*lspext.WorkspaceReferencesParams][]string{
 					// Non-matching name query.
@@ -272,9 +272,9 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				wantSymbols: map[string][]string{
 					"a.go": []string{"/src/test/pkg/a.go:function:pkg.A:1:17"},
 				},
-				wantWorkspaceSymbols: map[string][]string{
-					"":            []string{"/src/test/pkg/a.go:function:pkg.A:1:17"},
-					"is:exported": []string{"/src/test/pkg/a.go:function:pkg.A:1:17"},
+				wantWorkspaceSymbols: map[lspext.WorkspaceSymbolParams][]string{
+					{Query: ""}:            []string{"/src/test/pkg/a.go:function:pkg.A:1:17"},
+					{Query: "is:exported"}: []string{"/src/test/pkg/a.go:function:pkg.A:1:17"},
 				},
 			},
 		},
@@ -308,12 +308,12 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 					},
 					"": []string{},
 				},
-				wantWorkspaceSymbols: map[string][]string{
-					"": []string{
+				wantWorkspaceSymbols: map[lspext.WorkspaceSymbolParams][]string{
+					{Query: ""}: []string{
 						"/src/test/pkg/a.go:variable:pkg._:1:26",
 						"/src/test/pkg/a.go:variable:pkg.x:1:47",
 					},
-					"is:exported": []string{},
+					{Query: "is:exported"}: []string{},
 				},
 				wantWorkspaceReferences: map[*lspext.WorkspaceReferencesParams][]string{
 					{Query: lspext.SymbolDescriptor{}}: []string{
@@ -358,9 +358,9 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 					"a/a.go": []string{"/src/test/pkg/a/a.go:function:a.A:1:17"},
 					"b/b.go": []string{"/src/test/pkg/b/b.go:variable:b._:1:33"},
 				},
-				wantWorkspaceSymbols: map[string][]string{
-					"":            []string{"/src/test/pkg/a/a.go:function:a.A:1:17", "/src/test/pkg/b/b.go:variable:b._:1:33"},
-					"is:exported": []string{"/src/test/pkg/a/a.go:function:a.A:1:17"},
+				wantWorkspaceSymbols: map[lspext.WorkspaceSymbolParams][]string{
+					{Query: ""}:            []string{"/src/test/pkg/a/a.go:function:a.A:1:17", "/src/test/pkg/b/b.go:variable:b._:1:33"},
+					{Query: "is:exported"}: []string{"/src/test/pkg/a/a.go:function:a.A:1:17"},
 				},
 				wantWorkspaceReferences: map[*lspext.WorkspaceReferencesParams][]string{
 					{Query: lspext.SymbolDescriptor{}}: []string{
@@ -396,9 +396,9 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 					"a.go": []string{"/src/test/pkg/a.go:variable:pkg._:1:44"},
 					"vendor/github.com/v/vendored/v.go": []string{"/src/test/pkg/vendor/github.com/v/vendored/v.go:function:vendored.V:1:24"},
 				},
-				wantWorkspaceSymbols: map[string][]string{
-					"":            []string{"/src/test/pkg/a.go:variable:pkg._:1:44", "/src/test/pkg/vendor/github.com/v/vendored/v.go:function:vendored.V:1:24"},
-					"is:exported": []string{},
+				wantWorkspaceSymbols: map[lspext.WorkspaceSymbolParams][]string{
+					{Query: ""}:            []string{"/src/test/pkg/a.go:variable:pkg._:1:44", "/src/test/pkg/vendor/github.com/v/vendored/v.go:function:vendored.V:1:24"},
+					{Query: "is:exported"}: []string{},
 				},
 				wantWorkspaceReferences: map[*lspext.WorkspaceReferencesParams][]string{
 					{Query: lspext.SymbolDescriptor{}}: []string{
@@ -421,28 +421,28 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 					"vendor/github.com/a/pkg2/x.go": []string{"/src/test/pkg/vendor/github.com/a/pkg2/x.go:function:pkg2.x:1:20"},
 					"vendor/github.com/x/pkg3/x.go": []string{"/src/test/pkg/vendor/github.com/x/pkg3/x.go:function:pkg3.x:1:20"},
 				},
-				wantWorkspaceSymbols: map[string][]string{
-					"": []string{
+				wantWorkspaceSymbols: map[lspext.WorkspaceSymbolParams][]string{
+					{Query: ""}: []string{
 						"/src/test/pkg/z.go:function:pkg.x:1:19",
 						"/src/test/pkg/vendor/github.com/a/pkg2/x.go:function:pkg2.x:1:20",
 						"/src/test/pkg/vendor/github.com/x/pkg3/x.go:function:pkg3.x:1:20",
 					},
-					"x": []string{
+					{Query: "x"}: []string{
 						"/src/test/pkg/z.go:function:pkg.x:1:19",
 						"/src/test/pkg/vendor/github.com/a/pkg2/x.go:function:pkg2.x:1:20",
 						"/src/test/pkg/vendor/github.com/x/pkg3/x.go:function:pkg3.x:1:20",
 					},
-					"pkg2.x": []string{
+					{Query: "pkg2.x"}: []string{
 						"/src/test/pkg/vendor/github.com/a/pkg2/x.go:function:pkg2.x:1:20",
 						"/src/test/pkg/z.go:function:pkg.x:1:19",
 						"/src/test/pkg/vendor/github.com/x/pkg3/x.go:function:pkg3.x:1:20",
 					},
-					"pkg3.x": []string{
+					{Query: "pkg3.x"}: []string{
 						"/src/test/pkg/vendor/github.com/x/pkg3/x.go:function:pkg3.x:1:20",
 						"/src/test/pkg/z.go:function:pkg.x:1:19",
 						"/src/test/pkg/vendor/github.com/a/pkg2/x.go:function:pkg2.x:1:20",
 					},
-					"is:exported": []string{},
+					{Query: "is:exported"}: []string{},
 				},
 			},
 		},
@@ -600,13 +600,13 @@ func yza() {}
 					"bcd.go": []string{"/src/test/pkg/bcd.go:method:YZA.BCD:5:14", "/src/test/pkg/bcd.go:class:pkg.YZA:3:6"},
 					"xyz.go": []string{"/src/test/pkg/xyz.go:function:pkg.yza:3:6"},
 				},
-				wantWorkspaceSymbols: map[string][]string{
-					"":            []string{"/src/test/pkg/abc.go:method:XYZ.ABC:5:14", "/src/test/pkg/bcd.go:method:YZA.BCD:5:14", "/src/test/pkg/abc.go:class:pkg.XYZ:3:6", "/src/test/pkg/bcd.go:class:pkg.YZA:3:6", "/src/test/pkg/xyz.go:function:pkg.yza:3:6"},
-					"xyz":         []string{"/src/test/pkg/abc.go:class:pkg.XYZ:3:6", "/src/test/pkg/abc.go:method:XYZ.ABC:5:14", "/src/test/pkg/xyz.go:function:pkg.yza:3:6"},
-					"yza":         []string{"/src/test/pkg/bcd.go:class:pkg.YZA:3:6", "/src/test/pkg/xyz.go:function:pkg.yza:3:6", "/src/test/pkg/bcd.go:method:YZA.BCD:5:14"},
-					"abc":         []string{"/src/test/pkg/abc.go:method:XYZ.ABC:5:14", "/src/test/pkg/abc.go:class:pkg.XYZ:3:6"},
-					"bcd":         []string{"/src/test/pkg/bcd.go:method:YZA.BCD:5:14", "/src/test/pkg/bcd.go:class:pkg.YZA:3:6"},
-					"is:exported": []string{"/src/test/pkg/abc.go:method:XYZ.ABC:5:14", "/src/test/pkg/bcd.go:method:YZA.BCD:5:14", "/src/test/pkg/abc.go:class:pkg.XYZ:3:6", "/src/test/pkg/bcd.go:class:pkg.YZA:3:6"},
+				wantWorkspaceSymbols: map[lspext.WorkspaceSymbolParams][]string{
+					{Query: ""}:            []string{"/src/test/pkg/abc.go:method:XYZ.ABC:5:14", "/src/test/pkg/bcd.go:method:YZA.BCD:5:14", "/src/test/pkg/abc.go:class:pkg.XYZ:3:6", "/src/test/pkg/bcd.go:class:pkg.YZA:3:6", "/src/test/pkg/xyz.go:function:pkg.yza:3:6"},
+					{Query: "xyz"}:         []string{"/src/test/pkg/abc.go:class:pkg.XYZ:3:6", "/src/test/pkg/abc.go:method:XYZ.ABC:5:14", "/src/test/pkg/xyz.go:function:pkg.yza:3:6"},
+					{Query: "yza"}:         []string{"/src/test/pkg/bcd.go:class:pkg.YZA:3:6", "/src/test/pkg/xyz.go:function:pkg.yza:3:6", "/src/test/pkg/bcd.go:method:YZA.BCD:5:14"},
+					{Query: "abc"}:         []string{"/src/test/pkg/abc.go:method:XYZ.ABC:5:14", "/src/test/pkg/abc.go:class:pkg.XYZ:3:6"},
+					{Query: "bcd"}:         []string{"/src/test/pkg/bcd.go:method:YZA.BCD:5:14", "/src/test/pkg/bcd.go:class:pkg.YZA:3:6"},
+					{Query: "is:exported"}: []string{"/src/test/pkg/abc.go:method:XYZ.ABC:5:14", "/src/test/pkg/bcd.go:method:YZA.BCD:5:14", "/src/test/pkg/abc.go:class:pkg.XYZ:3:6", "/src/test/pkg/bcd.go:class:pkg.YZA:3:6"},
 				},
 			},
 		},
@@ -829,7 +829,7 @@ type lspTestCases struct {
 	wantXDefinition         map[string]string
 	wantReferences          map[string][]string
 	wantSymbols             map[string][]string
-	wantWorkspaceSymbols    map[string][]string
+	wantWorkspaceSymbols    map[lspext.WorkspaceSymbolParams][]string
 	wantSignatures          map[string]string
 	wantWorkspaceReferences map[*lspext.WorkspaceReferencesParams][]string
 	wantFormatting          map[string]string
@@ -866,9 +866,9 @@ func lspTests(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, rootPath stri
 		})
 	}
 
-	for query, want := range cases.wantWorkspaceSymbols {
-		tbRun(t, fmt.Sprintf("workspaceSymbols(q=%q)", query), func(t testing.TB) {
-			workspaceSymbolsTest(t, ctx, c, rootPath, query, want)
+	for params, want := range cases.wantWorkspaceSymbols {
+		tbRun(t, fmt.Sprintf("workspaceSymbols(%v)", params), func(t testing.TB) {
+			workspaceSymbolsTest(t, ctx, c, rootPath, params, want)
 		})
 	}
 
@@ -979,8 +979,8 @@ func symbolsTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, rootPath s
 	}
 }
 
-func workspaceSymbolsTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, rootPath string, query string, want []string) {
-	symbols, err := callWorkspaceSymbols(ctx, c, query)
+func workspaceSymbolsTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, rootPath string, params lspext.WorkspaceSymbolParams, want []string) {
+	symbols, err := callWorkspaceSymbols(ctx, c, params)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1159,9 +1159,9 @@ func callSymbols(ctx context.Context, c *jsonrpc2.Conn, uri string) ([]string, e
 	return syms, nil
 }
 
-func callWorkspaceSymbols(ctx context.Context, c *jsonrpc2.Conn, query string) ([]string, error) {
+func callWorkspaceSymbols(ctx context.Context, c *jsonrpc2.Conn, params lspext.WorkspaceSymbolParams) ([]string, error) {
 	var symbols []lsp.SymbolInformation
-	err := c.Call(ctx, "workspace/symbol", lsp.WorkspaceSymbolParams{Query: query}, &symbols)
+	err := c.Call(ctx, "workspace/symbol", params, &symbols)
 	if err != nil {
 		return nil, err
 	}

--- a/langserver/symbol.go
+++ b/langserver/symbol.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/neelance/parallel"
 	"github.com/sourcegraph/go-langserver/pkg/lsp"
+	"github.com/sourcegraph/go-langserver/pkg/lspext"
 	"github.com/sourcegraph/jsonrpc2"
 )
 
@@ -31,6 +32,8 @@ type Query struct {
 	Filter    FilterType
 	File, Dir string
 	Tokens    []string
+
+	Symbol lspext.SymbolDescriptor
 }
 
 // String converts the query back into a logically equivalent, but not strictly
@@ -118,6 +121,11 @@ var keywords = map[string]lsp.SymbolKind{
 	"const":   lsp.SKConstant,
 }
 
+type symbolPair struct {
+	lsp.SymbolInformation
+	desc lspext.SymbolDescriptor
+}
+
 // resultSorter is a utility struct for collecting, filtering, and
 // sorting symbol results.
 type resultSorter struct {
@@ -130,7 +138,7 @@ type resultSorter struct {
 // It is used internally by resultSorter.
 type scoredSymbol struct {
 	score int
-	lsp.SymbolInformation
+	symbolPair
 }
 
 /*
@@ -156,7 +164,7 @@ func (s *resultSorter) Swap(i, j int) {
 
 // Collect is a thread-safe method that will record the passed-in
 // symbol in the list of results if its score > 0.
-func (s *resultSorter) Collect(si lsp.SymbolInformation) {
+func (s *resultSorter) Collect(si symbolPair) {
 	s.resultsMu.Lock()
 	score := score(s.Query, si)
 	if score > 0 {
@@ -177,11 +185,14 @@ func (s *resultSorter) Results() []lsp.SymbolInformation {
 
 // score returns 0 for results that aren't matches. Results that are matches are assigned
 // a positive score, which should be used for ranking purposes.
-func score(q Query, s lsp.SymbolInformation) (scor int) {
+func score(q Query, s symbolPair) (scor int) {
 	if q.Kind != 0 {
 		if q.Kind != s.Kind {
 			return 0
 		}
+	}
+	if q.Symbol != nil && !symbolContains(q.Symbol, s.desc) {
+		return -1
 	}
 	name, container := strings.ToLower(s.Name), strings.ToLower(s.ContainerName)
 	filename := strings.TrimPrefix(s.Location.URI, "file://")
@@ -239,17 +250,37 @@ func score(q Query, s lsp.SymbolInformation) (scor int) {
 
 // toSym returns a SymbolInformation value derived from values we get
 // from the Go parser and doc packages.
-func toSym(name, container string, kind lsp.SymbolKind, fs *token.FileSet, pos token.Pos) lsp.SymbolInformation {
-	container = filepath.Base(container)
-	if i := strings.LastIndex(container, " "); i >= 0 {
-		container = container[i+1:]
+func toSym(name string, bpkg *build.Package, recv string, kind lsp.SymbolKind, fs *token.FileSet, pos token.Pos) symbolPair {
+	container := recv
+	if container == "" {
+		container = filepath.Base(bpkg.ImportPath)
 	}
-	return lsp.SymbolInformation{
-		Name:          name,
-		Kind:          kind,
-		Location:      goRangeToLSPLocation(fs, pos, pos+token.Pos(len(name))-1),
-		ContainerName: container,
+	return symbolPair{
+		SymbolInformation: lsp.SymbolInformation{
+			Name:          name,
+			Kind:          kind,
+			Location:      goRangeToLSPLocation(fs, pos, pos+token.Pos(len(name))-1),
+			ContainerName: container,
+		},
+		// NOTE: fields must be kept in sync with workspace_refs.go:defSymbolDescriptor
+		desc: lspext.SymbolDescriptor{
+			"vendor":      IsVendorDir(bpkg.Dir),
+			"package":     path.Clean(bpkg.ImportPath),
+			"packageName": bpkg.Name,
+			"recv":        recv,
+			"name":        name,
+		},
 	}
+}
+
+// symbolContains tells if a exactly contains b.
+func symbolContains(a, b lspext.SymbolDescriptor) bool {
+	for k, v := range a {
+		if bv, ok := b[k]; !ok || bv != v {
+			return false
+		}
+	}
+	return true
 }
 
 // handleTextDocumentSymbol handles `textDocument/documentSymbol` requests for
@@ -261,8 +292,9 @@ func (h *LangHandler) handleTextDocumentSymbol(ctx context.Context, conn JSONRPC
 
 // handleSymbol handles `workspace/symbol` requests for the Go
 // language server.
-func (h *LangHandler) handleWorkspaceSymbol(ctx context.Context, conn JSONRPC2Conn, req *jsonrpc2.Request, params lsp.WorkspaceSymbolParams) ([]lsp.SymbolInformation, error) {
+func (h *LangHandler) handleWorkspaceSymbol(ctx context.Context, conn JSONRPC2Conn, req *jsonrpc2.Request, params lspext.WorkspaceSymbolParams) ([]lsp.SymbolInformation, error) {
 	q := ParseQuery(params.Query)
+	q.Symbol = params.Symbol
 	if q.Filter == FilterDir {
 		q.Dir = path.Join(h.init.RootImportPath, q.Dir)
 	}
@@ -358,46 +390,46 @@ func (h *LangHandler) collectFromPkg(ctx context.Context, bctx *build.Context, p
 		docPkg := doc.New(astPkg, buildPkg.ImportPath, doc.AllDecls)
 
 		// Emit decls
-		var pkgSyms []lsp.SymbolInformation
+		var pkgSyms []symbolPair
 		for _, t := range docPkg.Types {
 			if len(t.Decl.Specs) == 1 { // the type name is the first spec in type declarations
-				pkgSyms = append(pkgSyms, toSym(t.Name, buildPkg.ImportPath, lsp.SKClass, fs, t.Decl.Specs[0].Pos()))
+				pkgSyms = append(pkgSyms, toSym(t.Name, buildPkg, "", lsp.SKClass, fs, t.Decl.Specs[0].Pos()))
 			} else { // in case there's some edge case where there's not 1 spec, fall back to the start of the declaration
-				pkgSyms = append(pkgSyms, toSym(t.Name, buildPkg.ImportPath, lsp.SKClass, fs, t.Decl.TokPos))
+				pkgSyms = append(pkgSyms, toSym(t.Name, buildPkg, "", lsp.SKClass, fs, t.Decl.TokPos))
 			}
 
 			for _, v := range t.Funcs {
-				pkgSyms = append(pkgSyms, toSym(v.Name, buildPkg.ImportPath, lsp.SKFunction, fs, v.Decl.Name.NamePos))
+				pkgSyms = append(pkgSyms, toSym(v.Name, buildPkg, "", lsp.SKFunction, fs, v.Decl.Name.NamePos))
 			}
 			for _, v := range t.Methods {
 				if results.Query.Filter == FilterExported && (!ast.IsExported(v.Name) || !ast.IsExported(t.Name)) {
 					continue
 				}
-				pkgSyms = append(pkgSyms, toSym(v.Name, buildPkg.ImportPath+" "+t.Name, lsp.SKMethod, fs, v.Decl.Name.NamePos))
+				pkgSyms = append(pkgSyms, toSym(v.Name, buildPkg, t.Name, lsp.SKMethod, fs, v.Decl.Name.NamePos))
 			}
 			for _, v := range t.Consts {
 				for _, name := range v.Names {
-					pkgSyms = append(pkgSyms, toSym(name, buildPkg.ImportPath, lsp.SKConstant, fs, v.Decl.TokPos))
+					pkgSyms = append(pkgSyms, toSym(name, buildPkg, "", lsp.SKConstant, fs, v.Decl.TokPos))
 				}
 			}
 			for _, v := range t.Vars {
 				for _, name := range v.Names {
-					pkgSyms = append(pkgSyms, toSym(name, buildPkg.ImportPath, lsp.SKField, fs, v.Decl.TokPos))
+					pkgSyms = append(pkgSyms, toSym(name, buildPkg, "", lsp.SKField, fs, v.Decl.TokPos))
 				}
 			}
 		}
 		for _, v := range docPkg.Consts {
 			for _, name := range v.Names {
-				pkgSyms = append(pkgSyms, toSym(name, buildPkg.ImportPath, lsp.SKConstant, fs, v.Decl.TokPos))
+				pkgSyms = append(pkgSyms, toSym(name, buildPkg, "", lsp.SKConstant, fs, v.Decl.TokPos))
 			}
 		}
 		for _, v := range docPkg.Vars {
 			for _, name := range v.Names {
-				pkgSyms = append(pkgSyms, toSym(name, buildPkg.ImportPath, lsp.SKVariable, fs, v.Decl.TokPos))
+				pkgSyms = append(pkgSyms, toSym(name, buildPkg, "", lsp.SKVariable, fs, v.Decl.TokPos))
 			}
 		}
 		for _, v := range docPkg.Funcs {
-			pkgSyms = append(pkgSyms, toSym(v.Name, buildPkg.ImportPath, lsp.SKFunction, fs, v.Decl.Name.NamePos))
+			pkgSyms = append(pkgSyms, toSym(v.Name, buildPkg, "", lsp.SKFunction, fs, v.Decl.Name.NamePos))
 		}
 
 		return pkgSyms
@@ -407,7 +439,7 @@ func (h *LangHandler) collectFromPkg(ctx context.Context, bctx *build.Context, p
 		return
 	}
 
-	for _, sym := range symbols.([]lsp.SymbolInformation) {
+	for _, sym := range symbols.([]symbolPair) {
 		if results.Query.Filter == FilterExported && !ast.IsExported(sym.Name) {
 			continue
 		}

--- a/langserver/symbol.go
+++ b/langserver/symbol.go
@@ -274,55 +274,12 @@ func toSym(name string, bpkg *build.Package, recv string, kind lsp.SymbolKind, f
 	}
 }
 
-func parseID(v string) (pkg, packageName, recv, name string) {
-	f := strings.Split(v, ":")
-	if len(f) != 3 && len(f) != 4 {
-		log.Printf("parseID: invalid ID encountered: %q", v)
-		return "", "", "", ""
-	}
-	if len(f) == 3 {
-		return f[0], "", f[1], f[2]
-	}
-	return f[0], f[1], f[2], f[3]
-}
-
-// idEqual tells if two SymbolDescriptor IDs are equal. The Go IDs are in the form:
-//
-//  <package>:<packageName>:<recv>:<name>
-//
-// Additionally, an extra form with <packageName> omitted entirely is supported:
-//
-//  <package>:<recv>:<name>
-//
-// Examples:
-//
-//  github.com/gorilla/mux:mux_test:Router:ServeHTTP
-//  github.com/gorilla/mux:Router:ServeHTTP
-//
-// When <packageName> is omitted in either a or b, idEqual simply makes no
-// comparison of that field. That is,t he above two examples are said to be
-// equal.
-func idEqual(a, b string) bool {
-	aPkg, aPackageName, aRecv, aName := parseID(a)
-	bPkg, bPackageName, bRecv, bName := parseID(b)
-	if aPackageName == "" || bPackageName == "" {
-		return aPkg == bPkg && aRecv == bRecv && aName == bName
-	}
-	return aPkg == bPkg && aPackageName == bPackageName && aRecv == bRecv && aName == bName
-}
-
 // symbolContains tells if a exactly contains b.
 //
 // The only exception is the `id` field, which is treated specially. Instead of
 // a byte-by-byte string comparison, idEqual is used.
 func symbolContains(a, b lspext.SymbolDescriptor) bool {
 	for k, v := range a {
-		if k == "id" {
-			if bv, ok := b[k]; !ok || !idEqual(v.(string), bv.(string)) {
-				return false
-			}
-			continue
-		}
 		if bv, ok := b[k]; !ok || bv != v {
 			return false
 		}

--- a/langserver/symbol_test.go
+++ b/langserver/symbol_test.go
@@ -117,7 +117,7 @@ func Test_resultSorter(t *testing.T) {
 	for _, test := range tests {
 		results := resultSorter{Query: ParseQuery(test.rawQuery)}
 		for _, s := range test.allSymbols {
-			results.Collect(s)
+			results.Collect(symbolPair{SymbolInformation: s})
 		}
 		sort.Sort(&results)
 		if !reflect.DeepEqual(results.Results(), test.expResults) {

--- a/langserver/workspace_refs.go
+++ b/langserver/workspace_refs.go
@@ -242,6 +242,7 @@ func defSymbolDescriptor(ctx context.Context, bctx *build.Context, rootPath stri
 		"packageName": def.PackageName,
 		"recv":        "",
 		"name":        "",
+		"id":          "",
 	}
 
 	fields := strings.Fields(def.Path)
@@ -256,6 +257,7 @@ func defSymbolDescriptor(ctx context.Context, bctx *build.Context, rootPath stri
 	default:
 		panic("invalid def.Path response from internal/refs")
 	}
+	desc["id"] = fmt.Sprintf("%s:%s:%s:%s", desc["package"], desc["packageName"], desc["recv"], desc["name"])
 	return desc, nil
 }
 

--- a/langserver/workspace_refs.go
+++ b/langserver/workspace_refs.go
@@ -235,6 +235,7 @@ func defSymbolDescriptor(ctx context.Context, bctx *build.Context, rootPath stri
 		return nil, err
 	}
 
+	// NOTE: fields must be kept in sync with symbol.go:symbolEqual
 	desc := lspext.SymbolDescriptor{
 		"vendor":      IsVendorDir(defPkg.Dir),
 		"package":     defPkg.ImportPath,

--- a/pkg/lsp/service.go
+++ b/pkg/lsp/service.go
@@ -62,6 +62,11 @@ type ServerCapabilities struct {
 	// XDefinitionProvider indicates the server provides support for
 	// textDocument/xdefinition. This is a Sourcegraph extension.
 	XDefinitionProvider bool `json:"xdefinitionProvider,omitempty"`
+
+	// XWorkspaceSymbolByProperties indicates the server provides support for
+	// querying symbols by properties with WorkspaceSymbolParams.symbol. This
+	// is a Sourcegraph extension.
+	XWorkspaceSymbolByProperties bool `json:"xworkspaceSymbolByProperties,omitempty"`
 }
 
 type CompletionOptions struct {

--- a/pkg/lspext/lspext.go
+++ b/pkg/lspext/lspext.go
@@ -8,6 +8,13 @@ import (
 	"github.com/sourcegraph/go-langserver/pkg/lsp"
 )
 
+// WorkspaceSymbolParams is the extension workspace/symbol parameter type.
+type WorkspaceSymbolParams struct {
+	Query  string           `json:"query,omitempty"`
+	Limit  int              `json:"limit"`
+	Symbol SymbolDescriptor `json:"symbol,omitempty"`
+}
+
 // WorkspaceReferencesParams is parameters for the `workspace/xreferences` extension
 //
 // See: https://github.com/sourcegraph/language-server-protocol/blob/master/extension-workspace-reference.md


### PR DESCRIPTION
This PR implements the extended workspace/symbol method, per the spec @ https://github.com/sourcegraph/language-server-protocol/blob/master/extension-workspace-references.md#extended-workspace-symbol-request

Additionally, it adds an `id` field to our `SymbolDescriptor` to support Sourcegraph URL-To-Definition links. See the commit message https://github.com/sourcegraph/go-langserver/commit/1dcf5891d33c375b5bf9ada073214b3b108bbb80 for details.