### PR TITLE
symbol: Remove missing build pkg logspam

### DIFF
--- a/langserver/symbol.go
+++ b/langserver/symbol.go
@@ -385,9 +385,6 @@ func (h *LangHandler) collectFromPkg(ctx context.Context, bctx *build.Context, p
 		}
 		astPkg := astPkgs[buildPkg.Name]
 		if astPkg == nil {
-			if !strings.HasPrefix(buildPkg.ImportPath, "github.com/golang/go/misc/cgo/") {
-				log.Printf("didn't find build package name %q in parsed AST packages %v", buildPkg.ImportPath, astPkgs)
-			}
 			return nil
 		}
 		// TODO(keegancsmith) Remove vendored doc/go once https://github.com/golang/go/issues/17788 is shipped


### PR DESCRIPTION
This may be a real issue. If so ignore this PR and lets fix the underlying
issue. However, our logs have lots of logspam with this.

```
didn't find build package name "sourcegraph.com/sourcegraph/sourcegraph/xlang/python" in parsed AST packages map[]
didn't find build package name "sourcegraph.com/sourcegraph/sourcegraph/xlang/php/src/Server" in parsed AST packages map[]
...
didn't find build package name "sourcegraph.com/sourcegraph/sourcegraph/ui/vendor/node_modules/vscode/src/vs/workbench/browser/parts/statusbar/media" in parsed AST packages map[]
didn't find build package name "sourcegraph.com/sourcegraph/sourcegraph/ui/vendor/node_modules/vscode/src/vs/workbench/parts/backup/common" in parsed AST packages map[]
didn't find build package name "sourcegraph.com/sourcegraph/sourcegraph/ui/vendor/node_modules/vscode/src/vs/workbench/parts/contentprovider" in parsed AST packages map[]
...
didn't find build package name "archive" in parsed AST packages map[]
didn't find build package name "cmd" in parsed AST packages map[]
didn't find build package name "cmd/asm/internal" in parsed AST packages map[]
didn't find build package name "cmd/compile/internal" in parsed AST packages map[]
didn't find build package name "cmd/compile/internal/gc/builtin" in parsed AST packages map[runtime:0xc520ad4780]
didn't find build package name "cmd/internal" in parsed AST packages map[]
```