### PR TITLE
langserver: Use memory efficient and type-safe SymbolDescriptor

### DIFF
--- a/langserver/definition.go
+++ b/langserver/definition.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/sourcegraph/go-langserver/langserver/internal/refs"
 	"github.com/sourcegraph/go-langserver/pkg/lsp"
-	"github.com/sourcegraph/go-langserver/pkg/lspext"
 	"github.com/sourcegraph/jsonrpc2"
 )
 
@@ -24,7 +23,7 @@ func (h *LangHandler) handleDefinition(ctx context.Context, conn JSONRPC2Conn, r
 	return locs, nil
 }
 
-func (h *LangHandler) handleXDefinition(ctx context.Context, conn JSONRPC2Conn, req *jsonrpc2.Request, params lsp.TextDocumentPositionParams) ([]lspext.SymbolLocationInformation, error) {
+func (h *LangHandler) handleXDefinition(ctx context.Context, conn JSONRPC2Conn, req *jsonrpc2.Request, params lsp.TextDocumentPositionParams) ([]symbolLocationInformation, error) {
 	rootPath := h.FilePath(h.init.RootPath)
 	bctx := h.BuildContext(ctx)
 
@@ -59,10 +58,10 @@ func (h *LangHandler) handleXDefinition(ctx context.Context, conn JSONRPC2Conn, 
 		return nil, errors.New("definition not found")
 	}
 	findPackage := h.getFindPackageFunc()
-	locs := make([]lspext.SymbolLocationInformation, 0, len(nodes))
+	locs := make([]symbolLocationInformation, 0, len(nodes))
 	for _, node := range nodes {
 		// Determine location information for the node.
-		l := lspext.SymbolLocationInformation{
+		l := symbolLocationInformation{
 			Location: goRangeToLSPLocation(fset, node.Pos(), node.End()),
 		}
 		// LSP expects a range to be of the entire body, not just of the

--- a/langserver/lsp.go
+++ b/langserver/lsp.go
@@ -1,0 +1,75 @@
+package langserver
+
+import (
+	"github.com/sourcegraph/go-langserver/pkg/lsp"
+	"github.com/sourcegraph/go-langserver/pkg/lspext"
+)
+
+// This file contains lspext but redefined to suit go-langserver
+// needs. Everything in here should be wire compatible.
+
+// symbolDescriptor is the exact fields go-langserver uses for
+// lspext.SymbolDescriptor. It should have the same JSON wire format. We make
+// it a struct for both type safety as well as better memory efficiency.
+type symbolDescriptor struct {
+	Package     string `json:"package"`
+	PackageName string `json:"packageName"`
+	Recv        string `json:"recv"`
+	Name        string `json:"name"`
+	ID          string `json:"id"`
+	Vendor      bool   `json:"vendor"`
+}
+
+// Contains ensures that b is a subset of our symbolDescriptor
+func (a *symbolDescriptor) Contains(b lspext.SymbolDescriptor) bool {
+	for k, v := range b {
+		switch k {
+		case "package":
+			if s, ok := v.(string); !ok || s != a.Package {
+				return false
+			}
+		case "packageName":
+			if s, ok := v.(string); !ok || s != a.PackageName {
+				return false
+			}
+		case "recv":
+			if s, ok := v.(string); !ok || s != a.Recv {
+				return false
+			}
+		case "name":
+			if s, ok := v.(string); !ok || s != a.Name {
+				return false
+			}
+		case "id":
+			if s, ok := v.(string); !ok || s != a.ID {
+				return false
+			}
+		case "vendor":
+			if s, ok := v.(bool); !ok || s != a.Vendor {
+				return false
+			}
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// symbolLocationInformation is lspext.SymbolLocationInformation, but using
+// our custom symbolDescriptor
+type symbolLocationInformation struct {
+	// A concrete location at which the definition is located, if any.
+	Location lsp.Location `json:"location,omitempty"`
+	// Metadata about the definition.
+	Symbol *symbolDescriptor `json:"symbol"`
+}
+
+// referenceInformation is lspext.ReferenceInformation using our custom symbolDescriptor
+type referenceInformation struct {
+	// Reference is the location in the workspace where the `symbol` has been
+	// referenced.
+	Reference lsp.Location `json:"reference"`
+
+	// Symbol is metadata information describing the symbol being referenced.
+	Symbol *symbolDescriptor `json:"symbol"`
+}

--- a/langserver/symbol.go
+++ b/langserver/symbol.go
@@ -123,7 +123,7 @@ var keywords = map[string]lsp.SymbolKind{
 
 type symbolPair struct {
 	lsp.SymbolInformation
-	desc lspext.SymbolDescriptor
+	desc symbolDescriptor
 }
 
 // resultSorter is a utility struct for collecting, filtering, and
@@ -191,7 +191,7 @@ func score(q Query, s symbolPair) (scor int) {
 			return 0
 		}
 	}
-	if q.Symbol != nil && !symbolContains(q.Symbol, s.desc) {
+	if q.Symbol != nil && !s.desc.Contains(q.Symbol) {
 		return -1
 	}
 	name, container := strings.ToLower(s.Name), strings.ToLower(s.ContainerName)
@@ -263,28 +263,15 @@ func toSym(name string, bpkg *build.Package, recv string, kind lsp.SymbolKind, f
 			ContainerName: container,
 		},
 		// NOTE: fields must be kept in sync with workspace_refs.go:defSymbolDescriptor
-		desc: lspext.SymbolDescriptor{
-			"vendor":      IsVendorDir(bpkg.Dir),
-			"package":     path.Clean(bpkg.ImportPath),
-			"packageName": bpkg.Name,
-			"recv":        recv,
-			"name":        name,
-			"id":          fmt.Sprintf("%s:%s:%s:%s", path.Clean(bpkg.ImportPath), bpkg.Name, recv, name),
+		desc: symbolDescriptor{
+			Vendor:      IsVendorDir(bpkg.Dir),
+			Package:     path.Clean(bpkg.ImportPath),
+			PackageName: bpkg.Name,
+			Recv:        recv,
+			Name:        name,
+			ID:          fmt.Sprintf("%s:%s:%s:%s", path.Clean(bpkg.ImportPath), bpkg.Name, recv, name),
 		},
 	}
-}
-
-// symbolContains tells if a exactly contains b.
-//
-// The only exception is the `id` field, which is treated specially. Instead of
-// a byte-by-byte string comparison, idEqual is used.
-func symbolContains(a, b lspext.SymbolDescriptor) bool {
-	for k, v := range a {
-		if bv, ok := b[k]; !ok || bv != v {
-			return false
-		}
-	}
-	return true
 }
 
 // handleTextDocumentSymbol handles `textDocument/documentSymbol` requests for


### PR DESCRIPTION
Our symbol cache uses a significant amount of RAM. This change allows us to use
a more memory efficient way of storing SymbolDescriptors, but keep wire
compatibility with the extension.