### PR TITLE
textDocument/xdefinition: do not return "nil" AND no error.

### DIFF
--- a/langserver/definition.go
+++ b/langserver/definition.go
@@ -32,7 +32,7 @@ func (h *LangHandler) handleXDefinition(ctx context.Context, conn JSONRPC2Conn, 
 		// Invalid nodes means we tried to click on something which is
 		// not an ident (eg comment/string/etc). Return no locations.
 		if _, ok := err.(*invalidNodeError); ok {
-			return nil, nil
+			return []symbolLocationInformation{}, nil
 		}
 		return nil, err
 	}
@@ -51,7 +51,7 @@ func (h *LangHandler) handleXDefinition(ctx context.Context, conn JSONRPC2Conn, 
 			//
 			// TODO(sqs): find a way to actually emit builtin locations
 			// (pointing to builtin/builtin.go).
-			return nil, nil
+			return []symbolLocationInformation{}, nil
 		}
 	}
 	if len(nodes) == 0 {


### PR DESCRIPTION
The return type signature of `handleDefinition` is `([]lsp.Location, error)`. If `nil, nil`
is returned then ` (*LangHandler).Handle` also returns `result interface{}` as `nil`. When
the result of a jsonrpc2 handler is nil, `jsonrpc2.HandlerWithError` [converts it into a struct](https://sourcegraph.com/github.com/sourcegraph/jsonrpc2/-/blob/handler_with_error.go#L25-28)
which is then encoded as a JSON object instead of an array. When decoding, this results in:

```
json: cannot unmarshal object into Go value of type []lspext.SymbolLocationInformation
```

Which is (obviously) bad because that looks like an error instead of 'no results'.

According to that jsonrpc2 implementation (linked above):

```
// isNilValue tests if an interface is empty, because an empty interface does
// not encode any information, we can't encode it in JSON so that the proxy
// knows it's a response, not a request.
func isNilValue(resp interface{}) bool {
```

This makes it unclear to me whether or not the conversion into a struct is
truly correct or not. I'm open to other ideas on how to resolve this issue.