### PR TITLE
update to use new ServerCapabilities.TextDocumentSync field in LSP spec

### DIFF
--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -179,7 +179,10 @@ func (h *LangHandler) Handle(ctx context.Context, conn JSONRPC2Conn, req *jsonrp
 
 		return lsp.InitializeResult{
 			Capabilities: lsp.ServerCapabilities{
-				TextDocumentSync:             lsp.TDSKFull,
+				TextDocumentSync: lsp.TextDocumentSyncOptions{
+					OpenClose: true,
+					Change:    lsp.TDSKFull,
+				},
 				DefinitionProvider:           true,
 				DocumentFormattingProvider:   true,
 				DocumentSymbolProvider:       true,

--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -177,11 +177,11 @@ func (h *LangHandler) Handle(ctx context.Context, conn JSONRPC2Conn, req *jsonrp
 			}()
 		}
 
+		kind := lsp.TDSKFull
 		return lsp.InitializeResult{
 			Capabilities: lsp.ServerCapabilities{
-				TextDocumentSync: lsp.TextDocumentSyncOptions{
-					OpenClose: true,
-					Change:    lsp.TDSKFull,
+				TextDocumentSync: lsp.TextDocumentSyncOptionsOrKind{
+					Kind: &kind,
 				},
 				DefinitionProvider:           true,
 				DocumentFormattingProvider:   true,

--- a/pkg/lsp/service.go
+++ b/pkg/lsp/service.go
@@ -35,6 +35,10 @@ type InitializeError struct {
 	Retry bool `json:"retry"`
 }
 
+// TextDocumentSyncKind is a DEPRECATED way to describe how text
+// document syncing works. Use TextDocumentSyncOptions instead (or the
+// Options field of TextDocumentSyncOptionsOrKind if you need to
+// support JSON-(un)marshaling both).
 type TextDocumentSyncKind int
 
 const (

--- a/pkg/lsp/service.go
+++ b/pkg/lsp/service.go
@@ -1,5 +1,10 @@
 package lsp
 
+import (
+	"bytes"
+	"encoding/json"
+)
+
 type None struct{}
 
 type InitializeParams struct {
@@ -34,8 +39,8 @@ type TextDocumentSyncKind int
 
 const (
 	TDSKNone        TextDocumentSyncKind = 0
-	TDSKFull                             = 1
-	TDSKIncremental                      = 2
+	TDSKFull        TextDocumentSyncKind = 1
+	TDSKIncremental TextDocumentSyncKind = 2
 )
 
 type TextDocumentSyncOptions struct {
@@ -46,12 +51,55 @@ type TextDocumentSyncOptions struct {
 	Save              *SaveOptions         `json:"save,omitempty"`
 }
 
+// TextDocumentSyncOptions holds either a TextDocumentSyncKind or
+// TextDocumentSyncOptions. The LSP API allows either to be specified
+// in the (ServerCapabilities).TextDocumentSync field.
+type TextDocumentSyncOptionsOrKind struct {
+	Kind    *TextDocumentSyncKind
+	Options *TextDocumentSyncOptions
+}
+
+// MarshalJSON implements json.Marshaler.
+func (v TextDocumentSyncOptionsOrKind) MarshalJSON() ([]byte, error) {
+	if v.Kind != nil {
+		return json.Marshal(v.Kind)
+	}
+	return json.Marshal(v.Options)
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (v *TextDocumentSyncOptionsOrKind) UnmarshalJSON(data []byte) error {
+	if bytes.Equal(data, []byte("null")) {
+		*v = TextDocumentSyncOptionsOrKind{}
+		return nil
+	}
+	var kind TextDocumentSyncKind
+	if err := json.Unmarshal(data, &kind); err == nil {
+		// Create equivalent TextDocumentSyncOptions using the same
+		// logic as in vscode-languageclient. Also set the Kind field
+		// so that JSON-marshaling and unmarshaling are inverse
+		// operations (for backward compatibility, preserving the
+		// original input but accepting both).
+		*v = TextDocumentSyncOptionsOrKind{
+			Options: &TextDocumentSyncOptions{OpenClose: true, Change: kind},
+			Kind:    &kind,
+		}
+		return nil
+	}
+	var tmp TextDocumentSyncOptions
+	if err := json.Unmarshal(data, &tmp); err != nil {
+		return err
+	}
+	*v = TextDocumentSyncOptionsOrKind{Options: &tmp}
+	return nil
+}
+
 type SaveOptions struct {
 	IncludeText bool `json:"includeText"`
 }
 
 type ServerCapabilities struct {
-	TextDocumentSync                 TextDocumentSyncOptions          `json:"textDocumentSync,omitempty"`
+	TextDocumentSync                 TextDocumentSyncOptionsOrKind    `json:"textDocumentSync,omitempty"`
 	HoverProvider                    bool                             `json:"hoverProvider,omitempty"`
 	CompletionProvider               *CompletionOptions               `json:"completionProvider,omitempty"`
 	SignatureHelpProvider            *SignatureHelpOptions            `json:"signatureHelpProvider,omitempty"`

--- a/pkg/lsp/service.go
+++ b/pkg/lsp/service.go
@@ -38,8 +38,20 @@ const (
 	TDSKIncremental                      = 2
 )
 
+type TextDocumentSyncOptions struct {
+	OpenClose         bool                 `json:"openClose,omitempty"`
+	Change            TextDocumentSyncKind `json:"change"`
+	WillSave          bool                 `json:"willSave,omitempty"`
+	WillSaveWaitUntil bool                 `json:"willSaveWaitUntil,omitempty"`
+	Save              *SaveOptions         `json:"save,omitempty"`
+}
+
+type SaveOptions struct {
+	IncludeText bool `json:"includeText"`
+}
+
 type ServerCapabilities struct {
-	TextDocumentSync                 int                              `json:"textDocumentSync,omitempty"`
+	TextDocumentSync                 TextDocumentSyncOptions          `json:"textDocumentSync,omitempty"`
 	HoverProvider                    bool                             `json:"hoverProvider,omitempty"`
 	CompletionProvider               *CompletionOptions               `json:"completionProvider,omitempty"`
 	SignatureHelpProvider            *SignatureHelpOptions            `json:"signatureHelpProvider,omitempty"`

--- a/pkg/lsp/service_test.go
+++ b/pkg/lsp/service_test.go
@@ -1,0 +1,63 @@
+package lsp
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestTextDocumentSyncOptionsOrKind_MarshalUnmarshalJSON(t *testing.T) {
+	kindPtr := func(kind TextDocumentSyncKind) *TextDocumentSyncKind {
+		return &kind
+	}
+
+	tests := []struct {
+		data []byte
+		want TextDocumentSyncOptionsOrKind
+	}{
+		{
+			data: []byte(`null`),
+			want: TextDocumentSyncOptionsOrKind{},
+		},
+		{
+			data: []byte(`2`),
+			want: TextDocumentSyncOptionsOrKind{
+				Options: &TextDocumentSyncOptions{
+					OpenClose: true,
+					Change:    TDSKIncremental,
+				},
+				Kind: kindPtr(2),
+			},
+		},
+		{
+			data: []byte(`{"openClose":true,"change":1,"save":{"includeText":true}}`),
+			want: TextDocumentSyncOptionsOrKind{
+				Options: &TextDocumentSyncOptions{
+					OpenClose: true,
+					Change:    TDSKFull,
+					Save:      &SaveOptions{IncludeText: true},
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		var got TextDocumentSyncOptionsOrKind
+		if err := json.Unmarshal(test.data, &got); err != nil {
+			t.Error(err)
+			continue
+		}
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("got %+v, want %+v", got, test.want)
+			continue
+		}
+		data, err := json.Marshal(got)
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+		if !bytes.Equal(data, test.data) {
+			t.Errorf("got JSON %q, want %q", data, test.data)
+		}
+	}
+}


### PR DESCRIPTION
The server capabilities should be equivalent to what was sent previously, but they are sent using the new, richer TextDocumentSyncOptions.