### PR TITLE
Query.CaseSensitive support for symbols

### DIFF
--- a/langserver/symbol_test.go
+++ b/langserver/symbol_test.go
@@ -130,6 +130,19 @@ func TestQueryString(t *testing.T) {
 	tests := []struct {
 		input, expect string
 	}{
+		// ---
+		// test case sensitive flag...
+		// check default value
+		// check each override
+		// check what we get back
+		// check casesensitive: true ensures file name case is preserved
+		{input: "bar baz", expect: "bar baz"},
+		{input: "casesensitive:true bar baz", expect: "casesensitive:true bar baz"},
+		{input: "casesensitive:false bar baz", expect: "bar baz"},
+		{input: "casesensitive:true bar baz Baz BAz file:fileCaseSensitive", expect: "casesensitive:true bar baz Baz BAz file:fileCaseSensitive"},
+		{input: "casesensitive:false bar baz Baz BAz file:fileCaseInsensitive", expect: "bar baz baz baz file:filecaseinsensitive"},
+		// ---
+
 		// Basic queries.
 		{input: "foo bar", expect: "foo bar"},
 		{input: "func bar", expect: "func bar"},


### PR DESCRIPTION
remove changes made to the langserver-go. (+5 squashed commits)
Squashed commits:
[074aeb5] remove un-needed files.
[2a396a4] `Query.CaseSensitive`:
remove reflection code and use the field name directly.
[ccab9ef] `Query`: fix typo in test.
[988dbe1] `Query`: fix typo should have been CaseSensitive.
[fae87b0] Query.CaseSensitive:
* add flag to indicate if Query is CaseSensitive.
* add tests for, the parsed Query string and the expected output. (+6 squashed commits)
Squashed commits:
[b865b75] set +x.
[8a9f71e] push to fork script.
[b7ad918] * configure tests as a typescript project.
*
[76c7255] * add install scripts to set remotes on the package in the $GOPATH.
* moving JS tests to the tests folder so you can load that in VSCode aswell.
[688cc32] update scripts to start websocket tests.
[a3a52e3] added websocket connect scripts using WebSocket class: run as $ ./scripts/websocket_test.sh

rename tool