### PR TITLE
langserver: Find references defined in tests

### DIFF
--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -170,7 +170,7 @@ func TestServer(t *testing.T) {
 			rootPath: "file:///src/test/pkg",
 			fs: map[string]string{
 				"a.go":      "package p; var A int",
-				"a_test.go": `package p; import "test/pkg/b"; var X = b.B`,
+				"a_test.go": `package p; import "test/pkg/b"; var X = b.B; func TestB() {}`,
 				"b/b.go":    "package b; var B int; func C() int { return B };",
 			},
 			cases: lspTestCases{
@@ -184,7 +184,13 @@ func TestServer(t *testing.T) {
 						"/src/test/pkg/b/b.go:1:16",
 						"/src/test/pkg/b/b.go:1:45",
 					},
-					// "a_test.go:1:41": []string{}, // currently failing to do references on the pkg. eg for `b.B`, we return an error for refs on `b`.
+					"a_test.go:1:41": []string{
+						"/src/test/pkg/a_test.go:1:19",
+						"/src/test/pkg/a_test.go:1:41",
+					},
+					"a_test.go:1:51": []string{
+						"/src/test/pkg/a_test.go:1:51",
+					},
 				},
 			},
 		},

--- a/langserver/references.go
+++ b/langserver/references.go
@@ -147,13 +147,13 @@ func (h *LangHandler) handleTextDocumentReferences(ctx context.Context, conn JSO
 	}
 
 	lconf.Load() // ignore error
-	if afterTypeCheckErr != nil {
-		// Only triggered by 1 specific error above (where we assign
-		// afterTypeCheckErr), not any general loader error.
-		return nil, afterTypeCheckErr
-	}
 
 	if qobj == nil {
+		if afterTypeCheckErr != nil {
+			// Only triggered by 1 specific error above (where we assign
+			// afterTypeCheckErr), not any general loader error.
+			return nil, afterTypeCheckErr
+		}
 		return nil, errors.New("query object not found during reloading")
 	}
 


### PR DESCRIPTION
`AfterTypeCheck` can be called twice. This is from its docstrings:

> The function may be called twice for the same PackageInfo:
> once for the files of the package and again for the
> in-package test files.

So on the first call we wouldn't find anything defined in-package test files, so
we would set `afterTypeCheckErr`. The second call would then find it, but the
old logic would return the previous error rather than use the found object.