### PR TITLE
refs: Find refs for xtest pkg definitions

### DIFF
--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -164,6 +164,19 @@ func TestServer(t *testing.T) {
 					"a_test.go:1:40": "var X int",
 					"a_test.go:1:46": "var A int",
 				},
+				wantReferences: map[string][]string{
+					"a.go:1:16": []string{
+						"/src/test/pkg/a.go:1:16",
+						// "/src/test/pkg/a_test.go:1:46", // we do not support xtest refs yet
+					},
+					"a_test.go:1:46": []string{
+						"/src/test/pkg/a.go:1:16",
+						// "/src/test/pkg/a_test.go:1:46", // we do not support xtest refs yet
+					},
+					"a_test.go:1:40": []string{
+						"/src/test/pkg/a_test.go:1:40",
+					},
+				},
 			},
 		},
 		"go test": {

--- a/langserver/references.go
+++ b/langserver/references.go
@@ -89,7 +89,8 @@ func (h *LangHandler) handleTextDocumentReferences(ctx context.Context, conn JSO
 			// Don't typecheck func bodies in dependency packages
 			// (except the package that defines the object), because
 			// we wouldn't return those refs anyway.
-			return users[strings.TrimSuffix(path, "_test")] && (pkgInWorkspace(path) || path == defpkg)
+			path = strings.TrimSuffix(path, "_test")
+			return users[path] && (pkgInWorkspace(path) || path == defpkg)
 		},
 	}
 	allowErrors(&lconf)
@@ -130,7 +131,7 @@ func (h *LangHandler) handleTextDocumentReferences(ctx context.Context, conn JSO
 			// because each go/loader Load invocation creates new
 			// objects, and we need to test for equality later when we
 			// look up refs.
-			if qobj == nil && info.Pkg.Path() == defpkg {
+			if qobj == nil && strings.TrimSuffix(info.Pkg.Path(), "_test") == defpkg {
 				// Find the object by its position (slightly ugly).
 				qobj = findObject(fset, &info.Info, objposn)
 				if qobj == nil {


### PR DESCRIPTION
Previously `TypeCheckFuncBodies` excluded xtest pkgs since `obj.Pkg().Path()`
would return the path without the `_test` suffix. I'm not sure why that is, but
normalising the pkg paths to not have _test allows find references to work.