### PR TITLE
Return single result from definition handler

### DIFF
--- a/langserver/definition.go
+++ b/langserver/definition.go
@@ -2,7 +2,6 @@ package langserver
 
 import (
 	"context"
-	"errors"
 	"go/ast"
 	"log"
 
@@ -11,74 +10,65 @@ import (
 	"github.com/sourcegraph/jsonrpc2"
 )
 
-func (h *LangHandler) handleDefinition(ctx context.Context, conn JSONRPC2Conn, req *jsonrpc2.Request, params lsp.TextDocumentPositionParams) ([]lsp.Location, error) {
+func (h *LangHandler) handleDefinition(ctx context.Context, conn JSONRPC2Conn, req *jsonrpc2.Request, params lsp.TextDocumentPositionParams) (*lsp.Location, error) {
 	res, err := h.handleXDefinition(ctx, conn, req, params)
 	if err != nil {
 		return nil, err
 	}
-	locs := make([]lsp.Location, 0, len(res))
-	for _, li := range res {
-		locs = append(locs, li.Location)
-	}
-	return locs, nil
+	return &res.Location, nil
 }
 
-func (h *LangHandler) handleXDefinition(ctx context.Context, conn JSONRPC2Conn, req *jsonrpc2.Request, params lsp.TextDocumentPositionParams) ([]symbolLocationInformation, error) {
+func (h *LangHandler) handleXDefinition(ctx context.Context, conn JSONRPC2Conn, req *jsonrpc2.Request, params lsp.TextDocumentPositionParams) (*symbolLocationInformation, error) {
 	rootPath := h.FilePath(h.init.RootPath)
 	bctx := h.BuildContext(ctx)
 
-	fset, node, pathEnclosingInterval, _, pkg, err := h.typecheck(ctx, conn, params.TextDocument.URI, params.Position)
+	fset, nodeList, pathEnclosingInterval, _, pkg, err := h.typecheck(ctx, conn, params.TextDocument.URI, params.Position)
 	if err != nil {
 		// Invalid nodes means we tried to click on something which is
 		// not an ident (eg comment/string/etc). Return no locations.
 		if _, ok := err.(*invalidNodeError); ok {
-			return []symbolLocationInformation{}, nil
+			return &symbolLocationInformation{}, nil
 		}
 		return nil, err
 	}
 
-	var nodes []*ast.Ident
-	obj, ok := pkg.Uses[node]
+	obj, ok := pkg.Uses[nodeList]
 	if !ok {
-		obj, ok = pkg.Defs[node]
+		obj, ok = pkg.Defs[nodeList]
 	}
+	p := obj.Pos()
 	if ok && obj != nil {
-		if p := obj.Pos(); p.IsValid() {
-			nodes = append(nodes, &ast.Ident{NamePos: p, Name: obj.Name()})
-		} else {
+		if !p.IsValid() {
 			// Builtins have an invalid Pos. Just don't emit a definition for
 			// them, for now. It's not that valuable to jump to their def.
 			//
 			// TODO(sqs): find a way to actually emit builtin locations
 			// (pointing to builtin/builtin.go).
-			return []symbolLocationInformation{}, nil
+			return &symbolLocationInformation{}, nil
 		}
 	}
-	if len(nodes) == 0 {
-		return nil, errors.New("definition not found")
-	}
-	findPackage := h.getFindPackageFunc()
-	locs := make([]symbolLocationInformation, 0, len(nodes))
-	for _, node := range nodes {
-		// Determine location information for the node.
-		l := symbolLocationInformation{
-			Location: goRangeToLSPLocation(fset, node.Pos(), node.End()),
-		}
 
-		// Determine metadata information for the node.
-		if def, err := refs.DefInfo(pkg.Pkg, &pkg.Info, pathEnclosingInterval, node.Pos()); err == nil {
-			symDesc, err := defSymbolDescriptor(ctx, bctx, rootPath, *def, findPackage)
-			if err != nil {
-				// TODO: tracing
-				log.Println("refs.DefInfo:", err)
-			} else {
-				l.Symbol = symDesc
-			}
-		} else {
+	node := ast.Ident{NamePos: p, Name: obj.Name()}
+
+	findPackage := h.getFindPackageFunc()
+	// Determine location information for the node.
+	l := symbolLocationInformation{
+		Location: goRangeToLSPLocation(fset, node.Pos(), node.End()),
+	}
+
+	// Determine metadata information for the node.
+	if def, err := refs.DefInfo(pkg.Pkg, &pkg.Info, pathEnclosingInterval, node.Pos()); err == nil {
+		symDesc, err := defSymbolDescriptor(ctx, bctx, rootPath, *def, findPackage)
+		if err != nil {
 			// TODO: tracing
 			log.Println("refs.DefInfo:", err)
+		} else {
+			l.Symbol = symDesc
 		}
-		locs = append(locs, l)
+	} else {
+		// TODO: tracing
+		log.Println("refs.DefInfo:", err)
 	}
-	return locs, nil
+
+	return &l, nil
 }

--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -1158,47 +1158,27 @@ func callHover(ctx context.Context, c *jsonrpc2.Conn, uri string, line, char int
 }
 
 func callDefinition(ctx context.Context, c *jsonrpc2.Conn, uri string, line, char int) (string, error) {
-	var res locations
+	var loc lsp.Location
 	err := c.Call(ctx, "textDocument/definition", lsp.TextDocumentPositionParams{
 		TextDocument: lsp.TextDocumentIdentifier{URI: uri},
 		Position:     lsp.Position{Line: line, Character: char},
-	}, &res)
+	}, &loc)
 	if err != nil {
 		return "", err
 	}
-	var str string
-	for i, loc := range res {
-		if loc.URI == "" {
-			continue
-		}
-		if i != 0 {
-			str += ", "
-		}
-		str += fmt.Sprintf("%s:%d:%d-%d:%d", loc.URI, loc.Range.Start.Line+1, loc.Range.Start.Character+1, loc.Range.End.Line+1, loc.Range.End.Character+1)
-	}
-	return str, nil
+	return fmt.Sprintf("%s:%d:%d-%d:%d", loc.URI, loc.Range.Start.Line+1, loc.Range.Start.Character+1, loc.Range.End.Line+1, loc.Range.End.Character+1), nil
 }
 
 func callXDefinition(ctx context.Context, c *jsonrpc2.Conn, uri string, line, char int) (string, error) {
-	var res []lspext.SymbolLocationInformation
+	var loc lspext.SymbolLocationInformation
 	err := c.Call(ctx, "textDocument/xdefinition", lsp.TextDocumentPositionParams{
 		TextDocument: lsp.TextDocumentIdentifier{URI: uri},
 		Position:     lsp.Position{Line: line, Character: char},
-	}, &res)
+	}, &loc)
 	if err != nil {
 		return "", err
 	}
-	var str string
-	for i, loc := range res {
-		if loc.Location.URI == "" {
-			continue
-		}
-		if i != 0 {
-			str += ", "
-		}
-		str += fmt.Sprintf("%s:%d:%d %s", loc.Location.URI, loc.Location.Range.Start.Line+1, loc.Location.Range.Start.Character+1, loc.Symbol)
-	}
-	return str, nil
+	return fmt.Sprintf("%s:%d:%d %s", loc.Location.URI, loc.Location.Range.Start.Line+1, loc.Location.Range.Start.Character+1, loc.Symbol), nil
 }
 
 func callReferences(ctx context.Context, c *jsonrpc2.Conn, uri string, line, char int) ([]string, error) {


### PR DESCRIPTION
The definition handler was returning list of definitions, when it could only return one.