### PR TITLE
langserver: Extract panic handlers into panicf

### DIFF
--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
-	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -99,15 +97,8 @@ func (h *LangHandler) handle(ctx context.Context, conn *jsonrpc2.Conn, req *json
 func (h *LangHandler) Handle(ctx context.Context, conn JSONRPC2Conn, req *jsonrpc2.Request) (result interface{}, err error) {
 	// Prevent any uncaught panics from taking the entire server down.
 	defer func() {
-		if r := recover(); r != nil {
-			err = fmt.Errorf("unexpected panic: %v", r)
-
-			// Same as net/http
-			const size = 64 << 10
-			buf := make([]byte, size)
-			buf = buf[:runtime.Stack(buf, false)]
-			log.Printf("panic serving %v: %v\n%s", req.Method, r, buf)
-			return
+		if perr := panicf(recover(), "%v", req.Method); perr != nil {
+			err = perr
 		}
 	}()
 

--- a/langserver/references.go
+++ b/langserver/references.go
@@ -10,7 +10,6 @@ import (
 	"go/types"
 	"log"
 	"path"
-	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -176,14 +175,7 @@ func (h *LangHandler) handleTextDocumentReferences(ctx context.Context, conn JSO
 		// Prevent any uncaught panics from taking the entire server down.
 		defer func() {
 			close(done)
-			if r := recover(); r != nil {
-				// Same as net/http
-				const size = 64 << 10
-				buf := make([]byte, size)
-				buf = buf[:runtime.Stack(buf, false)]
-				log.Printf("ignoring panic serving %v", req.Method)
-				return
-			}
+			_ = panicf(recover(), "%v", req.Method)
 		}()
 
 		lconf.Load() // ignore error

--- a/langserver/symbol.go
+++ b/langserver/symbol.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -333,14 +332,7 @@ func (h *LangHandler) handleSymbol(ctx context.Context, conn JSONRPC2Conn, req *
 				// https://github.com/golang/go/issues/17788
 				defer func() {
 					par.Release()
-					if r := recover(); r != nil {
-						// Same as net/http
-						const size = 64 << 10
-						buf := make([]byte, size)
-						buf = buf[:runtime.Stack(buf, false)]
-						log.Printf("ignoring panic serving %v for pkg %v: %v\n%s", req.Method, pkg, r, buf)
-						return
-					}
+					_ = panicf(recover(), "%v for pkg %v", req.Method, pkg)
 				}()
 				h.collectFromPkg(ctx, bctx, pkg, rootPath, &results)
 			}(pkg)

--- a/langserver/util.go
+++ b/langserver/util.go
@@ -1,7 +1,10 @@
 package langserver
 
 import (
+	"fmt"
+	"log"
 	"os"
+	"runtime"
 	"strings"
 )
 
@@ -30,4 +33,21 @@ func pathEqual(a, b string) bool {
 // IsVendorDir tells if the specified directory is a vendor directory.
 func IsVendorDir(dir string) bool {
 	return strings.HasPrefix(dir, "vendor/") || strings.Contains(dir, "/vendor/")
+}
+
+// panicf takes the return value of recover() and outputs data to the log with
+// the stack trace appended. Arguments are handled in the manner of
+// fmt.Printf. Arguments should format to a string which identifies what the
+// panic code was doing. Returns a non-nil error if it recovered from a panic.
+func panicf(r interface{}, format string, v ...interface{}) error {
+	if r != nil {
+		// Same as net/http
+		const size = 64 << 10
+		buf := make([]byte, size)
+		buf = buf[:runtime.Stack(buf, false)]
+		id := fmt.Sprintf(format, v...)
+		log.Printf("panic serving %s: %v\n%s", id, r, string(buf))
+		return fmt.Errorf("unexpected panic: %v", r)
+	}
+	return nil
 }


### PR DESCRIPTION
This should reduce the copy-paste of panic handlers.