### PR TITLE
WIP cancel typechecking upon context cancellation

### DIFF
--- a/langserver/build_context.go
+++ b/langserver/build_context.go
@@ -13,6 +13,40 @@ import (
 	"golang.org/x/net/context"
 )
 
+// withCancelContext creates a build.Context which wraps the input
+// *build.Context and aborts pending operations after ctx.Done
+func (h *LangHandler) withCancelContext(ctx context.Context, w *build.Context) *build.Context {
+	// We're mutating the build context that we intend to wrap, so copy it.
+	copy := *w
+	bctx := &copy
+
+	bctx.OpenFile = func(path string) (io.ReadCloser, error) {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		return w.OpenFile(path)
+	}
+	bctx.IsDir = func(path string) bool {
+		if err := ctx.Err(); err != nil {
+			return false
+		}
+		return w.IsDir(path)
+	}
+	bctx.HasSubdir = func(root, dir string) (rel string, ok bool) {
+		if err := ctx.Err(); err != nil {
+			return "", false
+		}
+		return w.HasSubdir(root, dir)
+	}
+	bctx.ReadDir = func(dir string) ([]os.FileInfo, error) {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		return w.ReadDir(dir)
+	}
+	return bctx
+}
+
 // BuildContext creates a build.Context which uses the overlay FS and the InitializeParams.BuildContext overrides.
 func (h *LangHandler) BuildContext(ctx context.Context) *build.Context {
 	var bctx *build.Context
@@ -36,6 +70,8 @@ func (h *LangHandler) BuildContext(ctx context.Context) *build.Context {
 		copy := build.Default
 		bctx = &copy
 	}
+
+	bctx = h.withCancelContext(ctx, bctx)
 
 	h.Mu.Lock()
 	fs := h.FS

--- a/langserver/loader.go
+++ b/langserver/loader.go
@@ -230,6 +230,9 @@ func typecheck(ctx context.Context, fset *token.FileSet, bctx *build.Context, bp
 		},
 		ParserMode: parser.AllErrors | parser.ParseComments, // prevent parser from bailing out
 		FindPackage: func(bctx *build.Context, importPath, fromDir string, mode build.ImportMode) (*build.Package, error) {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
 			// When importing a package, ignore any
 			// MultipleGoErrors. This occurs, e.g., when you have a
 			// main.go with "// +build ignore" that imports the

--- a/langserver/references.go
+++ b/langserver/references.go
@@ -102,6 +102,9 @@ func (h *LangHandler) handleTextDocumentReferences(ctx context.Context, conn JSO
 		Fset:  fset,
 		Build: bctx,
 		FindPackage: func(bctx *build.Context, importPath, fromDir string, mode build.ImportMode) (*build.Package, error) {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
 			// When importing a package, ignore any
 			// MultipleGoErrors. This occurs, e.g., when you have a
 			// main.go with "// +build ignore" that imports the

--- a/langserver/workspace_refs.go
+++ b/langserver/workspace_refs.go
@@ -159,6 +159,9 @@ func (h *LangHandler) workspaceRefsTypecheck(ctx context.Context, bctx *build.Co
 		AllowErrors: true,
 		ParserMode:  parser.AllErrors | parser.ParseComments, // prevent parser from bailing out
 		FindPackage: func(bctx *build.Context, importPath, fromDir string, mode build.ImportMode) (*build.Package, error) {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
 			// When importing a package, ignore any
 			// MultipleGoErrors. This occurs, e.g., when you have a
 			// main.go with "// +build ignore" that imports the


### PR DESCRIPTION
This change causes us to:

1. Effectively abort type checking operations when the context deadline has occurred, thus freeing up valuable CPU and memory resources.
2. Properly cache FindPackage invocations made in textDocument/references requests.