### PR TITLE
support *_test.go files inside of workspace/xreferences

### DIFF
--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -177,6 +177,12 @@ func TestServer(t *testing.T) {
 						"/src/test/pkg/a_test.go:1:40",
 					},
 				},
+				wantWorkspaceReferences: map[*lspext.WorkspaceReferencesParams][]string{
+					{Query: lspext.SymbolDescriptor{}}: []string{
+						"/src/test/pkg/a_test.go:1:24-1:34 -> id:test/pkg name: package:test/pkg packageName:p recv: vendor:false",
+						"/src/test/pkg/a_test.go:1:46-1:47 -> id:test/pkg/-/A name:A package:test/pkg packageName:p recv: vendor:false",
+					},
+				},
 			},
 		},
 		"go test": {

--- a/langserver/workspace_refs.go
+++ b/langserver/workspace_refs.go
@@ -67,6 +67,7 @@ func (h *LangHandler) handleWorkspaceReferences(ctx context.Context, conn JSONRP
 			}
 		}
 		unvendoredPackages[bpkg.ImportPath] = struct{}{}
+		unvendoredPackages[bpkg.ImportPath+"_test"] = struct{}{}
 		pkgs = append(pkgs, pkg)
 	}
 	if len(pkgs) == 0 {
@@ -97,7 +98,7 @@ func (h *LangHandler) handleWorkspaceReferences(ctx context.Context, conn JSONRP
 				_ = panicf(recover(), "%v for pkg %v", req.Method, pkg)
 			}()
 
-			err := h.workspaceRefsFromPkg(ctx, bctx, conn, params, fset, pkg, rootPath, &results)
+			err := h.workspaceRefsFromPkg(ctx, bctx, conn, params, fset, pkg, files, rootPath, &results)
 			if err != nil {
 				log.Printf("workspaceRefsFromPkg: %v: %v", pkg, err)
 			}
@@ -176,8 +177,10 @@ func (h *LangHandler) workspaceRefsTypecheck(ctx context.Context, bctx *build.Co
 			afterTypeCheck(pkg, files)
 		},
 	}
+	// The importgraph doesn't treat external test packages
+	// as separate nodes, so we must use ImportWithTests.
 	for _, path := range pkgs {
-		conf.Import(path)
+		conf.ImportWithTests(path)
 	}
 
 	// Load and typecheck the packages.
@@ -207,7 +210,7 @@ func (h *LangHandler) workspaceRefsTypecheck(ctx context.Context, bctx *build.Co
 
 // workspaceRefsFromPkg collects all the references made to dependencies from
 // the specified package and returns the results.
-func (h *LangHandler) workspaceRefsFromPkg(ctx context.Context, bctx *build.Context, conn JSONRPC2Conn, params lspext.WorkspaceReferencesParams, fs *token.FileSet, pkg *loader.PackageInfo, rootPath string, results *refResultSorter) (err error) {
+func (h *LangHandler) workspaceRefsFromPkg(ctx context.Context, bctx *build.Context, conn JSONRPC2Conn, params lspext.WorkspaceReferencesParams, fs *token.FileSet, pkg *loader.PackageInfo, files []*ast.File, rootPath string, results *refResultSorter) (err error) {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -226,7 +229,7 @@ func (h *LangHandler) workspaceRefsFromPkg(ctx context.Context, bctx *build.Cont
 	cfg := &refs.Config{
 		FileSet:  fs,
 		Pkg:      pkg.Pkg,
-		PkgFiles: pkg.Files,
+		PkgFiles: files,
 		Info:     &pkg.Info,
 	}
 	refsErr := cfg.Refs(func(r *refs.Ref) {


### PR DESCRIPTION
See commit descriptions for more details