### PR TITLE
langserver: do not clear package info for target packages

### DIFF
--- a/langserver/workspace_refs.go
+++ b/langserver/workspace_refs.go
@@ -95,7 +95,6 @@ func (h *LangHandler) handleWorkspaceReferences(ctx context.Context, conn JSONRP
 		go func() {
 			// Prevent any uncaught panics from taking the entire server down.
 			defer func() {
-				clearInfoFields(pkg) // save memory
 				wg.Done()
 				_ = panicf(recover(), "%v for pkg %v", req.Method, pkg)
 			}()


### PR DESCRIPTION
When independently tested, the following changes passed all tests:

- https://github.com/sourcegraph/go-langserver/pull/119
- https://github.com/sourcegraph/go-langserver/pull/120

However, once merged together they began to fail tests. The reason for this is
that `AfterTypeCheck` can be invoked twice for the same package after augmentation.
Together, this meant that we introduced a race condition between the reference
searching goroutines inside `afterTypeCheck` to try to find their references (to either
package `foo` or package `foo_test`) and clear their info fields. Typically one
completes faster than the other, and subsequently the remaining one fails to find
references due to lack of package information.

We could employ a more complex pattern to prevent this, but instead I've settled for
simply not clearing package info on the packages that we're interested in. We DO however
still clear package info for packages we're not interested in directly (i.e. transitive
dependencies) which means the overall change of #120 is still effective.