### PR TITLE
hover: Use a node's Doc commentgroup

### DIFF
--- a/langserver/hover.go
+++ b/langserver/hover.go
@@ -79,8 +79,6 @@ func (h *LangHandler) handleHover(ctx context.Context, conn JSONRPC2Conn, req *j
 		}
 
 		// Pull the comment out of the comment map for the file.
-		f := path[len(path)-1].(*ast.File)
-		cmap := ast.NewCommentMap(fset, f, f.Comments)
 		pathIndex := 1
 		switch v := o.(type) {
 		case *types.Var:
@@ -90,7 +88,23 @@ func (h *LangHandler) handleHover(ctx context.Context, conn JSONRPC2Conn, req *j
 		case *types.TypeName:
 			pathIndex = 2
 		}
-		return commentsToText(cmap[path[pathIndex]])
+		var doc *ast.CommentGroup
+		switch v := path[pathIndex].(type) {
+		case *ast.Field:
+			doc = v.Doc
+		case *ast.ValueSpec:
+			doc = v.Doc
+		case *ast.TypeSpec:
+			doc = v.Doc
+		case *ast.GenDecl:
+			doc = v.Doc
+		case *ast.FuncDecl:
+			doc = v.Doc
+		}
+		if doc == nil {
+			return ""
+		}
+		return doc.Text()
 	}
 
 	comments := findComments(o)

--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -728,6 +728,8 @@ var Foo string
 //
 package pkg2
 
+// A comment that should be ignored
+
 // X does the unknown.
 func X() {
 	panic("zomg")


### PR DESCRIPTION
Previously we used `ast.NewCommentMap` which would suck in non-docstring related
comments. An common example of a bad docstring it would produce is `Fprintf`
would include this line at the start of the docstring
https://sourcegraph.com/github.com/golang/go@6bdb0c11c73ecf2337918d784c54f9dda2207ca7/-/blob/src/fmt/print.go#L175:1-176:1

The test case was updated to reflect this behaviour. Before this change the test
case fails.