### PR TITLE
RFC WIP Move init/shutdown to another server

### DIFF
--- a/pkg/lspserver/lspserver.go
+++ b/pkg/lspserver/lspserver.go
@@ -1,0 +1,67 @@
+// package lspserver implements a general LSP server.
+package lspserver
+
+import (
+	"context"
+	"sync"
+
+	"github.com/sourcegraph/jsonrpc2"
+)
+
+type Handler struct {
+	Init func(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) jsonrpc2.Handler
+
+	mu sync.Mutex
+	h  jsonrpc2.Handler
+}
+
+func (h *Handler) Handle(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) {
+	switch req.Method {
+	case "initialize":
+		h.mu.Lock()
+		defer h.mu.Unlock()
+		if h.h != nil {
+			conn.SendResponse(ctx, &jsonrpc2.Response{
+				ID: req.ID,
+				Error: &jsonrpc2.Error{
+					Code:    jsonrpc2.CodeInvalidRequest,
+					Message: "language server is already initialized",
+				}})
+			return
+		}
+		h.h = h.Init(ctx, conn, req)
+
+	case "shutdown":
+		h.mu.Lock()
+		defer h.mu.Unlock()
+		if h.h == nil {
+			conn.SendResponse(ctx, &jsonrpc2.Response{
+				ID: req.ID,
+				Error: &jsonrpc2.Error{
+					Code:    jsonrpc2.CodeInvalidRequest,
+					Message: "language server is not initialized",
+				}})
+			return
+		}
+		h.h.Handle(ctx, conn, req)
+		h.h = nil
+
+	case "exit":
+		conn.Close()
+
+	default:
+		h.mu.Lock()
+		h2 := h
+		h.mu.Unlock()
+		if h2 == nil {
+			conn.SendResponse(ctx, &jsonrpc2.Response{
+				ID: req.ID,
+				Error: &jsonrpc2.Error{
+					Code:    jsonrpc2.CodeInvalidRequest,
+					Message: "language server is not initialized",
+				}})
+			return
+		}
+		h2.Handle(ctx, conn, req)
+	}
+}


### PR DESCRIPTION
This a WIP PR to get feedback on this approach. One of the most annoying things about go-langserver right now is all the handler fields have to be protected by a mutex, since we do not know if they have been init yet. It is also written that way since we have to handle the server being shutdown and reused for another workspace.

Instead this PR pulls Init and Shutdown into another handler. It has a function Init which is just like Handle, except it will only ever be called for initialize and it is expected to return a jsonrpc2.Handler which can then handle usual requests. The reason this is an improvement is the handler Init returns doesn't ever have to worry about `Reset`/etc, so we can pretty much get rid of the large amount of locking we do whenever we access something.

Related to https://github.com/sourcegraph/go-langserver/issues/85