### PR TITLE
refs: Stream back partial results

### DIFF
--- a/pkg/lspext/partial.go
+++ b/pkg/lspext/partial.go
@@ -4,12 +4,13 @@ import "github.com/sourcegraph/go-langserver/pkg/lsp"
 
 // PartialResultParams is the input for "$/partialResult", a notification.
 type PartialResultParams struct {
-	ID      lsp.ID      `json:"id"`
-	Patches []JSONPatch `json:"patches"`
-}
+	// ID is the jsonrpc2 ID of the request we are returning partial
+	// results for.
+	ID lsp.ID `json:"id"`
 
-type JSONPatch struct {
-	OP    string      `json:"op"`
-	Path  string      `json:"path"`
-	Value interface{} `json:"value"`
+	// Patch is a JSON patch as specified at http://jsonpatch.com/
+	//
+	// It is an interface{}, since our only requirement is that it JSON
+	// marshals to a valid list of JSON Patch operations.
+	Patch interface{} `json:"patch"`
 }

--- a/pkg/lspext/partial.go
+++ b/pkg/lspext/partial.go
@@ -1,0 +1,15 @@
+package lspext
+
+import "github.com/sourcegraph/go-langserver/pkg/lsp"
+
+// PartialResultParams is the input for "$/partialResult", a notification.
+type PartialResultParams struct {
+	ID      lsp.ID      `json:"id"`
+	Patches []JSONPatch `json:"patches"`
+}
+
+type JSONPatch struct {
+	OP    string      `json:"op"`
+	Path  string      `json:"path"`
+	Value interface{} `json:"value"`
+}


### PR DESCRIPTION
This is an experiment for streaming back reference results, before the reference
operation is finished. It uses an unspecced notification called
`$/partialResult` which is a list of JSONPatch operations to apply. We stream
back results every second if we have any unsent results.

Currently the order results are sent back in is very different to what the final
result will be. It will also ignore the limit specifier. We can adjust this in
future as we see how the prototype behaves.