### PR TITLE
references: Send a final partialResult

### DIFF
--- a/langserver/references.go
+++ b/langserver/references.go
@@ -218,6 +218,7 @@ func (h *LangHandler) handleTextDocumentReferences(ctx context.Context, conn JSO
 			partial := refs
 			mu.Unlock()
 			if len(partial) == streamPos {
+				// Everything currently in refs has already been sent.
 				return
 			}
 


### PR DESCRIPTION
This will allow clients to ignore the actual result, and just rely on
partialResult.