### PR TITLE
DONOTMERGE langserver: Publish empty diagnostics

### DIFF
--- a/langserver/diagnostics.go
+++ b/langserver/diagnostics.go
@@ -34,7 +34,7 @@ func (h *LangHandler) publishDiagnostics(ctx context.Context, conn JSONRPC2Conn,
 }
 
 func errsToDiagnostics(typeErrs []error, prog *loader.Program) (diagnostics, error) {
-	var diags diagnostics
+	diags := diagnostics{}
 	for _, typeErr := range typeErrs {
 		var (
 			p    token.Position
@@ -78,9 +78,6 @@ func errsToDiagnostics(typeErrs []error, prog *loader.Program) (diagnostics, err
 			Severity: lsp.Error,
 			Source:   "go",
 			Message:  strings.TrimSpace(msg),
-		}
-		if diags == nil {
-			diags = diagnostics{}
 		}
 		diags[p.Filename] = append(diags[p.Filename], diag)
 	}

--- a/langserver/loader.go
+++ b/langserver/loader.go
@@ -58,7 +58,8 @@ func (h *LangHandler) typecheck(ctx context.Context, conn JSONRPC2Conn, fileURI 
 		return nil, nil, nil, nil, nil, err
 	}
 
-	if len(diags) > 0 {
+	if diags != nil {
+		// We actually did some typechecking, publish the (possibly empty) diagnostics
 		go func() {
 			if err := h.publishDiagnostics(ctx, conn, diags); err != nil {
 				log.Printf("warning: failed to send diagnostics: %s.", err)

--- a/langserver/loader_test.go
+++ b/langserver/loader_test.go
@@ -93,6 +93,7 @@ func TestLoaderDiagnostics(t *testing.T) {
 		{
 			Name: "none",
 			FS:   map[string]string{"/src/p/f.go": `package p; func F() {}`},
+			Want: diagnostics{},
 		},
 		{
 			Name: "malformed",


### PR DESCRIPTION
We publish empty diagnostics if we had a typecheck cache miss (ie we actually
did typechecking). This change works since at this point diags is nil
https://sourcegraph.com/github.com/sourcegraph/go-langserver@39e41a9f7071d047fc97dfe52d51dca11d6ac04b/-/blob/langserver/loader.go#L197:1-198:1
but is only updated to the diags returned by `typecheck` if we have a cache
miss. `typecheck` always returns a non-nil (but possibly empty) diags after this
change.

I'm not 100% sure if this solves the underlying issue, since the list of diagnostics we are publishing here are specific to a file and some extra dependencies.

Fixes #23