### PR TITLE
reference: Initial stream op is a replace

### DIFF
--- a/langserver/references.go
+++ b/langserver/references.go
@@ -200,7 +200,7 @@ func (h *LangHandler) handleTextDocumentReferences(ctx context.Context, conn JSO
 	streamUpdate := func() {}
 	streamTick := make(<-chan time.Time, 1)
 	if streamExperiment {
-		initial := json.RawMessage(`[{"op":"add","path":"","value":[]}]`)
+		initial := json.RawMessage(`[{"op":"replace","path":"","value":[]}]`)
 		conn.Notify(ctx, "$/partialResult", &lspext.PartialResultParams{
 			ID: lsp.ID{
 				Num:      req.ID.Num,


### PR DESCRIPTION
This is a more robust way to start the stream. For example, if there is an
automatic retry at some layer (true for sourcegraph.com), this will allow a
retried stream to start from scratch again.