### PR TITLE
Disable textDocument/publishDiagnostics

### DIFF
--- a/langserver/diagnostics.go
+++ b/langserver/diagnostics.go
@@ -18,6 +18,15 @@ type diagnostics map[string][]*lsp.Diagnostic // map of URI to diagnostics (for 
 // publishDiagnostics sends diagnostic information (such as compile
 // errors) to the client.
 func (h *LangHandler) publishDiagnostics(ctx context.Context, conn JSONRPC2Conn, diags diagnostics) error {
+	// Our diagnostics are currently disabled because they behave
+	// incorrectly. We do not keep track of which files have failed /
+	// succeeded, so we do not send empty diagnostics to clear compiler
+	// errors/etc. https://github.com/sourcegraph/go-langserver/issues/23
+	// Leaving the code here for when we do actually fix this.
+	if cake := false; !cake {
+		return nil
+	}
+
 	for filename, diags := range diags {
 		params := lsp.PublishDiagnosticsParams{
 			URI:         "file://" + filename,


### PR DESCRIPTION
Our support is currently broken, leading to a frustrating UX in editors.

Fixes #23