### PR TITLE
references: Perf improvements to importgraph building

### DIFF
--- a/langserver/internal/tools/buildutil.go
+++ b/langserver/internal/tools/buildutil.go
@@ -1,0 +1,106 @@
+package tools
+
+import (
+	"go/build"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+
+	"golang.org/x/tools/go/buildutil"
+)
+
+// ListPkgsUnderDir is buildutil.ExpandPattern(ctxt, []string{dir +
+// "/..."}). The implementation is modified from the upstream
+// buildutil.ExpandPattern so we can be much faster. buildutil.ExpandPattern
+// looks at all directories under GOPATH if there is a `...` pattern. This
+// instead only explores the directories under dir. In future
+// buildutil.ExpandPattern may be more performant (there are TODOs for it).
+func ListPkgsUnderDir(ctxt *build.Context, dir string) []string {
+	ch := make(chan string)
+
+	var wg sync.WaitGroup
+	for _, root := range ctxt.SrcDirs() {
+		root := root
+		wg.Add(1)
+		go func() {
+			allPackages(ctxt, root, dir, ch)
+			wg.Done()
+		}()
+	}
+	go func() {
+		wg.Wait()
+		close(ch)
+	}()
+
+	var pkgs []string
+	for p := range ch {
+		pkgs = append(pkgs, p)
+	}
+	sort.Strings(pkgs)
+	return pkgs
+}
+
+// We use a process-wide counting semaphore to limit
+// the number of parallel calls to ReadDir.
+var ioLimit = make(chan bool, 20)
+
+// allPackages is from tools/go/buildutil. We don't use the exported method
+// since it doesn't allow searching from a directory. We need from a specific
+// directory for performance on large GOPATHs.
+func allPackages(ctxt *build.Context, root, start string, ch chan<- string) {
+	root = filepath.Clean(root) + string(os.PathSeparator)
+	start = filepath.Clean(start) + string(os.PathSeparator)
+
+	if strings.HasPrefix(root, start) {
+		// If we are a child of start, we can just start at the
+		// root. A concrete example of this happening is when
+		// root=/goroot/src and start=/goroot
+		start = root
+	}
+
+	if !strings.HasPrefix(start, root) {
+		return
+	}
+
+	var wg sync.WaitGroup
+
+	var walkDir func(dir string)
+	walkDir = func(dir string) {
+		// Avoid .foo, _foo, and testdata directory trees.
+		base := filepath.Base(dir)
+		if base == "" || base[0] == '.' || base[0] == '_' || base == "testdata" {
+			return
+		}
+
+		pkg := filepath.ToSlash(strings.TrimPrefix(dir, root))
+
+		// Prune search if we encounter any of these import paths.
+		switch pkg {
+		case "builtin":
+			return
+		}
+
+		if pkg != "" {
+			ch <- pkg
+		}
+
+		ioLimit <- true
+		files, _ := buildutil.ReadDir(ctxt, dir)
+		<-ioLimit
+		for _, fi := range files {
+			fi := fi
+			if fi.IsDir() {
+				wg.Add(1)
+				go func() {
+					walkDir(filepath.Join(dir, fi.Name()))
+					wg.Done()
+				}()
+			}
+		}
+	}
+
+	walkDir(start)
+	wg.Wait()
+}

--- a/langserver/internal/tools/doc.go
+++ b/langserver/internal/tools/doc.go
@@ -1,0 +1,3 @@
+// tools mainly contains variations on code found under golang.org/x/tools,
+// but modified to be optimized for our usecase.
+package tools

--- a/langserver/internal/tools/importgraph.go
+++ b/langserver/internal/tools/importgraph.go
@@ -1,0 +1,131 @@
+// Original importgraph.Build contains the below copyright notice:
+//
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package tools
+
+import (
+	"go/build"
+	"sync"
+
+	"golang.org/x/tools/go/buildutil"
+	"golang.org/x/tools/refactor/importgraph"
+)
+
+func Build(ctxt *build.Context) (forward, reverse importgraph.Graph, errors map[string]error) {
+	type importEdge struct {
+		from, to string
+	}
+	type pathError struct {
+		path string
+		err  error
+	}
+
+	ch := make(chan interface{})
+
+	go func() {
+		sema := make(chan int, 20) // I/O concurrency limiting semaphore
+		var wg sync.WaitGroup
+		buildutil.ForEachPackage(ctxt, func(path string, err error) {
+			if err != nil {
+				ch <- pathError{path, err}
+				return
+			}
+
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+
+				sema <- 1
+				bp, err := ctxt.Import(path, "", 0)
+				<-sema
+
+				if err != nil {
+					if _, ok := err.(*build.NoGoError); ok {
+						// empty directory is not an error
+					} else {
+						ch <- pathError{path, err}
+					}
+					// Even in error cases, Import usually returns a package.
+				}
+
+				// absolutize resolves an import path relative
+				// to the current package bp.
+				// The absolute form may contain "vendor".
+				//
+				// The vendoring feature slows down Build by 3×.
+				// Here are timings from a 1400 package workspace:
+				//    1100ms: current code (with vendor check)
+				//     880ms: with a nonblocking cache around ctxt.IsDir
+				//     840ms: nonblocking cache with duplicate suppression
+				//     340ms: original code (no vendor check)
+				// TODO(adonovan): optimize, somehow.
+				memo := make(map[string]string)
+				absolutize := func(path string) string {
+					canon, ok := memo[path]
+					if !ok {
+						sema <- 1
+						bp2, _ := ctxt.Import(path, bp.Dir, build.FindOnly)
+						<-sema
+
+						if bp2 != nil {
+							canon = bp2.ImportPath
+						} else {
+							canon = path
+						}
+						memo[path] = canon
+					}
+					return canon
+				}
+
+				if bp != nil {
+					for _, imp := range bp.Imports {
+						ch <- importEdge{path, absolutize(imp)}
+					}
+					for _, imp := range bp.TestImports {
+						ch <- importEdge{path, absolutize(imp)}
+					}
+					for _, imp := range bp.XTestImports {
+						ch <- importEdge{path, absolutize(imp)}
+					}
+				}
+
+			}()
+		})
+		wg.Wait()
+		close(ch)
+	}()
+
+	forward = make(importgraph.Graph)
+	reverse = make(importgraph.Graph)
+
+	for e := range ch {
+		switch e := e.(type) {
+		case pathError:
+			if errors == nil {
+				errors = make(map[string]error)
+			}
+			errors[e.path] = e.err
+
+		case importEdge:
+			if e.to == "C" {
+				continue // "C" is fake
+			}
+			addEdge(forward, e.from, e.to)
+			addEdge(reverse, e.to, e.from)
+		}
+	}
+
+	return forward, reverse, errors
+}
+
+func addEdge(g importgraph.Graph, from, to string) {
+	edges := g[from]
+	if edges == nil {
+		edges = make(map[string]bool)
+		g[from] = edges
+	}
+	edges[to] = true
+}

--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -167,11 +167,11 @@ func TestServer(t *testing.T) {
 				wantReferences: map[string][]string{
 					"a.go:1:16": []string{
 						"/src/test/pkg/a.go:1:16",
-						// "/src/test/pkg/a_test.go:1:46", // we do not support xtest refs yet
+						"/src/test/pkg/a_test.go:1:46",
 					},
 					"a_test.go:1:46": []string{
 						"/src/test/pkg/a.go:1:16",
-						// "/src/test/pkg/a_test.go:1:46", // we do not support xtest refs yet
+						"/src/test/pkg/a_test.go:1:46",
 					},
 					"a_test.go:1:40": []string{
 						"/src/test/pkg/a_test.go:1:40",

--- a/langserver/references.go
+++ b/langserver/references.go
@@ -51,13 +51,14 @@ func (h *LangHandler) handleTextDocumentReferences(ctx context.Context, conn JSO
 		return nil, err
 	}
 
+	rootPath := h.FilePath(h.init.RootPath)
 	bctx := h.BuildContext(ctx)
 	h.importGraphOnce.Do(func() {
 		findPackageWithCtx := h.getFindPackageFunc()
 		findPackage := func(bctx *build.Context, importPath, fromDir string, mode build.ImportMode) (*build.Package, error) {
 			return findPackageWithCtx(ctx, bctx, importPath, fromDir, mode)
 		}
-		h.importGraph = tools.BuildReverseImportGraph(bctx, findPackage)
+		h.importGraph = tools.BuildReverseImportGraph(bctx, findPackage, rootPath)
 	})
 
 	// NOTICE: Code adapted from golang.org/x/tools/cmd/guru

--- a/langserver/references.go
+++ b/langserver/references.go
@@ -52,9 +52,7 @@ func (h *LangHandler) handleTextDocumentReferences(ctx context.Context, conn JSO
 
 	bctx := h.BuildContext(ctx)
 	h.importGraphOnce.Do(func() {
-		// We ignore the errors since we are doing a best-effort analysis
-		_, rev, _ := tools.Build(bctx)
-		h.importGraph = rev
+		h.importGraph = tools.BuildReverseImportGraph(bctx)
 	})
 
 	// NOTICE: Code adapted from golang.org/x/tools/cmd/guru

--- a/langserver/references.go
+++ b/langserver/references.go
@@ -18,9 +18,9 @@ import (
 	"time"
 
 	"golang.org/x/tools/go/loader"
-	"golang.org/x/tools/refactor/importgraph"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sourcegraph/go-langserver/langserver/internal/tools"
 	"github.com/sourcegraph/go-langserver/pkg/lsp"
 	"github.com/sourcegraph/go-langserver/pkg/lspext"
 	"github.com/sourcegraph/jsonrpc2"
@@ -53,7 +53,7 @@ func (h *LangHandler) handleTextDocumentReferences(ctx context.Context, conn JSO
 	bctx := h.BuildContext(ctx)
 	h.importGraphOnce.Do(func() {
 		// We ignore the errors since we are doing a best-effort analysis
-		_, rev, _ := importgraph.Build(bctx)
+		_, rev, _ := tools.Build(bctx)
 		h.importGraph = rev
 	})
 

--- a/langserver/references.go
+++ b/langserver/references.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"go/ast"
+	"go/build"
 	"go/parser"
 	"go/token"
 	"go/types"
@@ -52,7 +53,11 @@ func (h *LangHandler) handleTextDocumentReferences(ctx context.Context, conn JSO
 
 	bctx := h.BuildContext(ctx)
 	h.importGraphOnce.Do(func() {
-		h.importGraph = tools.BuildReverseImportGraph(bctx)
+		findPackageWithCtx := h.getFindPackageFunc()
+		findPackage := func(bctx *build.Context, importPath, fromDir string, mode build.ImportMode) (*build.Package, error) {
+			return findPackageWithCtx(ctx, bctx, importPath, fromDir, mode)
+		}
+		h.importGraph = tools.BuildReverseImportGraph(bctx, findPackage)
 	})
 
 	// NOTICE: Code adapted from golang.org/x/tools/cmd/guru

--- a/langserver/symbol.go
+++ b/langserver/symbol.go
@@ -19,6 +19,7 @@ import (
 	"golang.org/x/tools/go/buildutil"
 
 	"github.com/neelance/parallel"
+	"github.com/sourcegraph/go-langserver/langserver/internal/tools"
 	"github.com/sourcegraph/go-langserver/pkg/lsp"
 	"github.com/sourcegraph/go-langserver/pkg/lspext"
 	"github.com/sourcegraph/jsonrpc2"
@@ -317,7 +318,7 @@ func (h *LangHandler) handleSymbol(ctx context.Context, conn JSONRPC2Conn, req *
 		bctx := h.BuildContext(ctx)
 
 		par := parallel.NewRun(8)
-		for _, pkg := range listPkgsUnderDir(bctx, rootPath) {
+		for _, pkg := range tools.ListPkgsUnderDir(bctx, rootPath) {
 			// If we're restricting results to a single file or dir, ensure the
 			// package dir matches to avoid doing unnecessary work.
 			if results.Query.File != "" {
@@ -492,98 +493,4 @@ func maybeLogImportError(pkg string, err error) {
 	if !(isNoGoError || !isMultiplePackageError(err) || strings.HasPrefix(pkg, "github.com/golang/go/test/")) {
 		log.Printf("skipping possible package %s: %s", pkg, err)
 	}
-}
-
-// listPkgsUnderDir is buildutil.ExpandPattern(ctxt, []string{dir +
-// "/..."}). The implementation is modified from the upstream
-// buildutil.ExpandPattern so we can be much faster. buildutil.ExpandPattern
-// looks at all directories under GOPATH if there is a `...` pattern. This
-// instead only explores the directories under dir. In future
-// buildutil.ExpandPattern may be more performant (there are TODOs for it).
-func listPkgsUnderDir(ctxt *build.Context, dir string) []string {
-	ch := make(chan string)
-
-	var wg sync.WaitGroup
-	for _, root := range ctxt.SrcDirs() {
-		root := root
-		wg.Add(1)
-		go func() {
-			allPackages(ctxt, root, dir, ch)
-			wg.Done()
-		}()
-	}
-	go func() {
-		wg.Wait()
-		close(ch)
-	}()
-
-	var pkgs []string
-	for p := range ch {
-		pkgs = append(pkgs, p)
-	}
-	sort.Strings(pkgs)
-	return pkgs
-}
-
-// We use a process-wide counting semaphore to limit
-// the number of parallel calls to ReadDir.
-var ioLimit = make(chan bool, 20)
-
-// allPackages is from tools/go/buildutil. We don't use the exported method
-// since it doesn't allow searching from a directory. We need from a specific
-// directory for performance on large GOPATHs.
-func allPackages(ctxt *build.Context, root, start string, ch chan<- string) {
-	root = filepath.Clean(root) + string(os.PathSeparator)
-	start = filepath.Clean(start) + string(os.PathSeparator)
-
-	if strings.HasPrefix(root, start) {
-		// If we are a child of start, we can just start at the
-		// root. A concrete example of this happening is when
-		// root=/goroot/src and start=/goroot
-		start = root
-	}
-
-	if !strings.HasPrefix(start, root) {
-		return
-	}
-
-	var wg sync.WaitGroup
-
-	var walkDir func(dir string)
-	walkDir = func(dir string) {
-		// Avoid .foo, _foo, and testdata directory trees.
-		base := filepath.Base(dir)
-		if base == "" || base[0] == '.' || base[0] == '_' || base == "testdata" {
-			return
-		}
-
-		pkg := filepath.ToSlash(strings.TrimPrefix(dir, root))
-
-		// Prune search if we encounter any of these import paths.
-		switch pkg {
-		case "builtin":
-			return
-		}
-
-		if pkg != "" {
-			ch <- pkg
-		}
-
-		ioLimit <- true
-		files, _ := buildutil.ReadDir(ctxt, dir)
-		<-ioLimit
-		for _, fi := range files {
-			fi := fi
-			if fi.IsDir() {
-				wg.Add(1)
-				go func() {
-					walkDir(filepath.Join(dir, fi.Name()))
-					wg.Done()
-				}()
-			}
-		}
-	}
-
-	walkDir(start)
-	wg.Wait()
 }

--- a/langserver/workspace_refs.go
+++ b/langserver/workspace_refs.go
@@ -20,6 +20,7 @@ import (
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 	"github.com/sourcegraph/go-langserver/langserver/internal/refs"
+	"github.com/sourcegraph/go-langserver/langserver/internal/tools"
 	"github.com/sourcegraph/go-langserver/pkg/lsp"
 	"github.com/sourcegraph/go-langserver/pkg/lspext"
 	"github.com/sourcegraph/jsonrpc2"
@@ -46,7 +47,7 @@ func (h *LangHandler) handleWorkspaceReferences(ctx context.Context, conn JSONRP
 		pkgs               []string
 		unvendoredPackages = map[string]struct{}{}
 	)
-	for _, pkg := range listPkgsUnderDir(bctx, rootPath) {
+	for _, pkg := range tools.ListPkgsUnderDir(bctx, rootPath) {
 		bpkg, err := findPackage(ctx, bctx, pkg, rootPath, build.FindOnly)
 		if err != nil && !isMultiplePackageError(err) {
 			log.Printf("skipping possible package %s: %s", pkg, err)


### PR DESCRIPTION
In testing, this is usually the slowest part of a reference request.

This should be easily reviewed a commit at a time.