### PR TITLE
references: Make it possible to use incremental import graphs

### DIFF
--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -191,6 +191,7 @@ func TestServer(t *testing.T) {
 				"a.go":      "package p; var A int",
 				"a_test.go": `package p; import "test/pkg/b"; var X = b.B; func TestB() {}`,
 				"b/b.go":    "package b; var B int; func C() int { return B };",
+				"c/c.go":    `package c; import "test/pkg/b"; var X = b.B;`,
 			},
 			cases: lspTestCases{
 				wantHover: map[string]string{
@@ -202,6 +203,7 @@ func TestServer(t *testing.T) {
 						"/src/test/pkg/a_test.go:1:43",
 						"/src/test/pkg/b/b.go:1:16",
 						"/src/test/pkg/b/b.go:1:45",
+						"/src/test/pkg/c/c.go:1:43",
 					},
 					"a_test.go:1:41": []string{
 						"/src/test/pkg/a_test.go:1:19",

--- a/langserver/references.go
+++ b/langserver/references.go
@@ -205,9 +205,15 @@ func (h *LangHandler) reverseImportGraph() <-chan importgraph.Graph {
 			findPackage := func(bctx *build.Context, importPath, fromDir string, mode build.ImportMode) (*build.Package, error) {
 				return findPackageWithCtx(ctx, bctx, importPath, fromDir, mode)
 			}
+			h.mu.Lock()
 			h.importGraph = tools.BuildReverseImportGraph(bctx, findPackage, h.FilePath(h.init.RootPath))
+			h.mu.Unlock()
 		})
-		c <- h.importGraph
+		h.mu.Lock()
+		// TODO(keegancsmith) h.importGraph may have been reset after once
+		importGraph := h.importGraph
+		h.mu.Unlock()
+		c <- importGraph
 
 		close(c)
 	}()

--- a/langserver/references.go
+++ b/langserver/references.go
@@ -112,9 +112,9 @@ func (h *LangHandler) handleTextDocumentReferences(ctx context.Context, conn JSO
 		// type-checking.
 		var users map[string]bool
 		if pkgLevel {
-			users = reverseImportGraph[defpkg]
-			if users == nil {
-				users = map[string]bool{}
+			users = map[string]bool{}
+			for pkg := range reverseImportGraph[defpkg] {
+				users[pkg] = true
 			}
 			users[defpkg] = true
 		} else {


### PR DESCRIPTION
This change is mostly refactoring and cleanup. It is intended to make it possible to use inaccurate import graphs, as well as making it possible to do multiple passes with more accurate import graphs. I have made some changes to `findReferences` which makes it responsibility clearer as well.

The follow up PR for this will actually implement the major perf improvement of using a cached import graph. I left it out of this PR in the interest of keeping this smaller.