### PR TITLE
references: Use xcache to store older importgraphs

### DIFF
--- a/langserver/references.go
+++ b/langserver/references.go
@@ -229,9 +229,7 @@ func (h *LangHandler) reverseImportGraph(conn jsonrpc2.JSONRPC2) <-chan importgr
 			h.mu.Unlock()
 
 			// Update cache in background
-			go func() {
-				h.cacheSet(ctx, conn, cacheKey, g)
-			}()
+			go h.cacheSet(ctx, conn, cacheKey, g)
 		})
 		h.mu.Lock()
 		// TODO(keegancsmith) h.importGraph may have been reset after once

--- a/langserver/references.go
+++ b/langserver/references.go
@@ -44,7 +44,7 @@ func (h *LangHandler) handleTextDocumentReferences(ctx context.Context, conn jso
 
 	// Begin computing the reverse import graph immediately, as this
 	// occurs in the background and is IO-bound.
-	reverseImportGraphC := h.reverseImportGraph()
+	reverseImportGraphC := h.reverseImportGraph(conn)
 
 	fset, node, _, _, pkg, err := h.typecheck(ctx, conn, params.TextDocument.URI, params.Position)
 	if err != nil {
@@ -190,16 +190,32 @@ func (h *LangHandler) handleTextDocumentReferences(ctx context.Context, conn jso
 // such we may send down more than one import graph. The later a graph is
 // sent, the more accurate it is. The channel will be closed, and the last
 // graph sent is accurate. The reader does not have to read all the values.
-func (h *LangHandler) reverseImportGraph() <-chan importgraph.Graph {
+func (h *LangHandler) reverseImportGraph(conn jsonrpc2.JSONRPC2) <-chan importgraph.Graph {
 	// Ensure our buffer is big enough to prevent deadlock
-	c := make(chan importgraph.Graph, 1)
+	c := make(chan importgraph.Graph, 2)
 
 	// Note: We use a background context since this operation should not
 	// be linked to an individual request.
 	ctx := context.Background()
 
 	go func() {
-		// TODO fetch from cache an inaccurate import graph
+		// This should always be related to the go import path for
+		// this repo. For sourcegraph.com this means we share the
+		// import graph across commits. We want this behaviour since
+		// we assume that they don't change drastically across
+		// commits.
+		cacheKey := "importgraph:" + h.init.RootPath
+
+		h.mu.Lock()
+		tryCache := h.importGraph == nil
+		h.mu.Unlock()
+		if tryCache {
+			g := make(importgraph.Graph)
+			if hit := h.cacheGet(ctx, conn, cacheKey, g); hit {
+				// \o/
+				c <- g
+			}
+		}
 
 		bctx := h.BuildContext(ctx)
 		h.importGraphOnce.Do(func() {
@@ -211,6 +227,11 @@ func (h *LangHandler) reverseImportGraph() <-chan importgraph.Graph {
 			h.mu.Lock()
 			h.importGraph = g
 			h.mu.Unlock()
+
+			// Update cache in background
+			go func() {
+				h.cacheSet(ctx, conn, cacheKey, g)
+			}()
 		})
 		h.mu.Lock()
 		// TODO(keegancsmith) h.importGraph may have been reset after once

--- a/langserver/xcache.go
+++ b/langserver/xcache.go
@@ -1,0 +1,43 @@
+package langserver
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+
+	"github.com/sourcegraph/go-langserver/pkg/lspext"
+	"github.com/sourcegraph/jsonrpc2"
+)
+
+// cacheGet will do a xcache/get request for key, and unmarshal the result
+// into v on a cache hit. If it is a cache miss, false is returned. If the
+// client is not a XCacheProvider, cacheGet will always return false.
+func (h *LangHandler) cacheGet(ctx context.Context, conn jsonrpc2.JSONRPC2, key string, v interface{}) bool {
+	if !h.init.Capabilities.XCacheProvider {
+		return false
+	}
+
+	var r json.RawMessage
+	err := conn.Call(ctx, "xcache/get", lspext.CacheGetParams{Key: key}, &r)
+	if err != nil {
+		return false
+	}
+	b := []byte(r)
+	if bytes.Equal(b, []byte("null")) {
+		return false
+	}
+	err = json.Unmarshal(b, &v)
+	return err == nil
+}
+
+// cacheSet will do a xcache/set request for key and a marshalled value. If
+// the client is not a XCacheProvider, cacheSet will do nothing.
+func (h *LangHandler) cacheSet(ctx context.Context, conn jsonrpc2.JSONRPC2, key string, v interface{}) {
+	if !h.init.Capabilities.XCacheProvider {
+		return
+	}
+
+	b, _ := json.Marshal(v)
+	m := json.RawMessage(b)
+	_ = conn.Notify(ctx, "xcache/set", lspext.CacheSetParams{Key: key, Value: &m})
+}


### PR DESCRIPTION
This should greatly speed up initial reference requests in the common case. In
sourcegraph.com production this would make us use a possibly inaccurate
importgraph to find references (computed from another commit). We still follow
up with the correct import graph, but only typecheck the package we had not
already checked. With this change and streaming, references should hopefully
almost instantaneously start streaming back, even on large repos.