### PR TITLE
references: Find refs to symbols defined in xtest

### DIFF
--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -158,6 +158,10 @@ func TestServer(t *testing.T) {
 				"a.go":      "package p; var A int",
 				"x_test.go": `package p_test; import "test/pkg"; var X = p.A`,
 				"y_test.go": "package p_test; func Y() int { return X }",
+
+				// non xtest to ensure we don't mix up xtest and test.
+				"a_test.go": `package p; var X = A`,
+				"b_test.go": "package p; func Y() int { return X }",
 			},
 			cases: lspTestCases{
 				wantHover: map[string]string{
@@ -168,10 +172,12 @@ func TestServer(t *testing.T) {
 				wantReferences: map[string][]string{
 					"a.go:1:16": []string{
 						"/src/test/pkg/a.go:1:16",
+						"/src/test/pkg/a_test.go:1:20",
 						"/src/test/pkg/x_test.go:1:46",
 					},
 					"x_test.go:1:46": []string{
 						"/src/test/pkg/a.go:1:16",
+						"/src/test/pkg/a_test.go:1:20",
 						"/src/test/pkg/x_test.go:1:46",
 					},
 					"x_test.go:1:40": []string{

--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -156,33 +156,33 @@ func TestServer(t *testing.T) {
 			rootPath: "file:///src/test/pkg",
 			fs: map[string]string{
 				"a.go":      "package p; var A int",
-				"a_test.go": `package p_test; import "test/pkg"; var X = p.A`,
-				"b_test.go": "package p_test; func Y() int { return X }",
+				"x_test.go": `package p_test; import "test/pkg"; var X = p.A`,
+				"y_test.go": "package p_test; func Y() int { return X }",
 			},
 			cases: lspTestCases{
 				wantHover: map[string]string{
 					"a.go:1:16":      "var A int",
-					"a_test.go:1:40": "var X int",
-					"a_test.go:1:46": "var A int",
+					"x_test.go:1:40": "var X int",
+					"x_test.go:1:46": "var A int",
 				},
 				wantReferences: map[string][]string{
 					"a.go:1:16": []string{
 						"/src/test/pkg/a.go:1:16",
-						"/src/test/pkg/a_test.go:1:46",
+						"/src/test/pkg/x_test.go:1:46",
 					},
-					"a_test.go:1:46": []string{
+					"x_test.go:1:46": []string{
 						"/src/test/pkg/a.go:1:16",
-						"/src/test/pkg/a_test.go:1:46",
+						"/src/test/pkg/x_test.go:1:46",
 					},
-					"a_test.go:1:40": []string{
-						"/src/test/pkg/a_test.go:1:40",
-						"/src/test/pkg/b_test.go:1:39",
+					"x_test.go:1:40": []string{
+						"/src/test/pkg/x_test.go:1:40",
+						"/src/test/pkg/y_test.go:1:39",
 					},
 				},
 				wantWorkspaceReferences: map[*lspext.WorkspaceReferencesParams][]string{
 					{Query: lspext.SymbolDescriptor{}}: []string{
-						"/src/test/pkg/a_test.go:1:24-1:34 -> id:test/pkg name: package:test/pkg packageName:p recv: vendor:false",
-						"/src/test/pkg/a_test.go:1:46-1:47 -> id:test/pkg/-/A name:A package:test/pkg packageName:p recv: vendor:false",
+						"/src/test/pkg/x_test.go:1:24-1:34 -> id:test/pkg name: package:test/pkg packageName:p recv: vendor:false",
+						"/src/test/pkg/x_test.go:1:46-1:47 -> id:test/pkg/-/A name:A package:test/pkg packageName:p recv: vendor:false",
 					},
 				},
 			},

--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -168,6 +168,8 @@ func TestServer(t *testing.T) {
 					"a.go:1:16":      "var A int",
 					"x_test.go:1:40": "var X int",
 					"x_test.go:1:46": "var A int",
+					"a_test.go:1:16": "var X int",
+					"a_test.go:1:20": "var A int",
 				},
 				wantReferences: map[string][]string{
 					"a.go:1:16": []string{
@@ -183,6 +185,17 @@ func TestServer(t *testing.T) {
 					"x_test.go:1:40": []string{
 						"/src/test/pkg/x_test.go:1:40",
 						"/src/test/pkg/y_test.go:1:39",
+					},
+
+					// The same as the xtest references above, but in the normal test pkg.
+					"a_test.go:1:20": []string{
+						"/src/test/pkg/a.go:1:16",
+						"/src/test/pkg/a_test.go:1:20",
+						"/src/test/pkg/x_test.go:1:46",
+					},
+					"a_test.go:1:16": []string{
+						"/src/test/pkg/a_test.go:1:16",
+						"/src/test/pkg/b_test.go:1:34",
 					},
 				},
 				wantWorkspaceReferences: map[*lspext.WorkspaceReferencesParams][]string{

--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -157,6 +157,7 @@ func TestServer(t *testing.T) {
 			fs: map[string]string{
 				"a.go":      "package p; var A int",
 				"a_test.go": `package p_test; import "test/pkg"; var X = p.A`,
+				"b_test.go": "package p_test; func Y() int { return X }",
 			},
 			cases: lspTestCases{
 				wantHover: map[string]string{
@@ -175,6 +176,7 @@ func TestServer(t *testing.T) {
 					},
 					"a_test.go:1:40": []string{
 						"/src/test/pkg/a_test.go:1:40",
+						"/src/test/pkg/b_test.go:1:39",
 					},
 				},
 				wantWorkspaceReferences: map[*lspext.WorkspaceReferencesParams][]string{


### PR DESCRIPTION
We just need to treat `foo_test` as if it is `foo`. We do that in a few places,
but we now do it everywhere. I was concerned about possibly reporting duplicate
results, but our unit tests indicate that is not a concern.