### PR TITLE
langserver: More robust doc extraction for hover

### DIFF
--- a/langserver/hover.go
+++ b/langserver/hover.go
@@ -78,28 +78,22 @@ func (h *LangHandler) handleHover(ctx context.Context, conn jsonrpc2.JSONRPC2, r
 			return ""
 		}
 
-		// Pull the comment out of the comment map for the file.
-		pathIndex := 1
-		switch v := o.(type) {
-		case *types.Var:
-			if !v.IsField() {
-				pathIndex = 2
-			}
-		case *types.TypeName:
-			pathIndex = 2
-		}
+		// Pull the comment out of the comment map for the file. Do
+		// not search too far away from the current path.
 		var doc *ast.CommentGroup
-		switch v := path[pathIndex].(type) {
-		case *ast.Field:
-			doc = v.Doc
-		case *ast.ValueSpec:
-			doc = v.Doc
-		case *ast.TypeSpec:
-			doc = v.Doc
-		case *ast.GenDecl:
-			doc = v.Doc
-		case *ast.FuncDecl:
-			doc = v.Doc
+		for i := 0; i < 3 && i < len(path) && doc == nil; i++ {
+			switch v := path[i].(type) {
+			case *ast.Field:
+				doc = v.Doc
+			case *ast.ValueSpec:
+				doc = v.Doc
+			case *ast.TypeSpec:
+				doc = v.Doc
+			case *ast.GenDecl:
+				doc = v.Doc
+			case *ast.FuncDecl:
+				doc = v.Doc
+			}
 		}
 		if doc == nil {
 			return ""

--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -742,6 +742,14 @@ type T struct {
 
 // Foo is the best string.
 var Foo string
+
+var (
+	// I1 is an int
+	I1 = 1
+
+	// I2 is an int
+	I2 = 3
+)
 `,
 				"vendor/github.com/a/pkg2/x.go": `// Package pkg2 shows dependencies.
 //
@@ -777,6 +785,7 @@ type Header struct {
 					"a.go:20:2":  "struct field H test/pkg/vendor/github.com/a/pkg2.Header; H is a header. \n\n",
 					"a.go:20:4":  "package pkg2 (\"test/pkg/vendor/github.com/a/pkg2\"); Package pkg2 shows dependencies. \n\nHow to \n\n```\nExample Code!\n\n```\n",
 					"a.go:24:5":  "var Foo string; Foo is the best string. \n\n",
+					"a.go:31:2":  "var I2 int; I2 is an int \n\n",
 				},
 			},
 		},


### PR DESCRIPTION
Hardcoding the path index has a bunch of corner cases. For example look at the
test case added in this commit. It would not find doc strings in that case.
Instead we look at the first 3 in the path, which is as far as we would ever
look.