### PR TITLE
references: Guard access to import graph once

### DIFF
--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -37,7 +37,7 @@ type LangHandler struct {
 	symbolCache    cache
 
 	// cache the reverse import graph
-	importGraphOnce sync.Once
+	importGraphOnce *sync.Once
 	importGraph     importgraph.Graph
 
 	cancel *cancel
@@ -68,7 +68,7 @@ func (h *LangHandler) resetCaches(lock bool) {
 		h.mu.Lock()
 	}
 
-	h.importGraphOnce = sync.Once{}
+	h.importGraphOnce = &sync.Once{}
 	h.importGraph = nil
 
 	if h.typecheckCache == nil {

--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -36,7 +36,9 @@ type LangHandler struct {
 	typecheckCache cache
 	symbolCache    cache
 
-	// cache the reverse import graph
+	// cache the reverse import graph. The sync.Once is a pointer since it
+	// is reset when we reset caches. If it was a value we would racily
+	// updated the internal mutex when assigning a new sync.Once.
 	importGraphOnce *sync.Once
 	importGraph     importgraph.Graph
 

--- a/langserver/references.go
+++ b/langserver/references.go
@@ -205,6 +205,7 @@ func (h *LangHandler) reverseImportGraph(ctx context.Context, conn jsonrpc2.JSON
 
 		h.mu.Lock()
 		tryCache := h.importGraph == nil
+		once := h.importGraphOnce
 		h.mu.Unlock()
 		if tryCache {
 			g := make(importgraph.Graph)
@@ -215,7 +216,7 @@ func (h *LangHandler) reverseImportGraph(ctx context.Context, conn jsonrpc2.JSON
 		}
 
 		parentCtx := ctx
-		h.importGraphOnce.Do(func() {
+		once.Do(func() {
 			// Note: We use a background context since this
 			// operation should not be cancelled due to an
 			// individual request.


### PR DESCRIPTION
I think import graph being a value + reset would lead to us overwriting the
value of the mutex => once trying to unlock a new mutex after it has finished
importing the graph.

Fixes https://github.com/sourcegraph/go-langserver/issues/146