### PR TITLE
Move cmd to top-level repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,18 @@
-# Go language server (based on the Language Server Protocol) [![Build Status](https://travis-ci.org/sourcegraph/go-langserver.svg)](https://travis-ci.org/sourcegraph/go-langserver)
+# Go Language Server [![Build Status](https://travis-ci.org/sourcegraph/go-langserver.svg)](https://travis-ci.org/sourcegraph/go-langserver)
 
-go-langserver is a [Go](https://golang.org) language server that speaks [Language Server Protocol](https://github.com/Microsoft/language-server-protocol). It supports editor features such as go-to-definition, hover, and find-references for Go projects.
+go-langserver is a [Go](https://golang.org) language server that
+speaks
+[Language Server Protocol](https://github.com/Microsoft/language-server-protocol). It
+supports editor features such as go-to-definition, hover, and find-references
+for Go projects.
+
+[**Open in Sourcegraph**](https://sourcegraph.com/github.com/sourcegraph/go-langserver/-/tree/langserver)
+
+To build and install the standalone `go-langserver` run
+
+```
+go get github.com/sourcegraph/go-langserver
+```
 
 **Status: experimental**
 
-[**Open in Sourcegraph**](https://sourcegraph.com/github.com/sourcegraph/go-langserver/-/tree/langserver)

--- a/langserver/cmd/langserver-go/.gitignore
+++ b/langserver/cmd/langserver-go/.gitignore
@@ -1,1 +1,0 @@
-/langserver-go

--- a/langserver/cmd/langserver-go/Dockerfile
+++ b/langserver/cmd/langserver-go/Dockerfile
@@ -1,7 +1,0 @@
-# Docker image for langserver-go
-
-FROM alpine:3.4
-MAINTAINER Quinn Slack <sqs@sourcegraph.com>
-RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community ca-certificates
-ADD langserver-go /langserver-go
-ENTRYPOINT ["/langserver-go"]

--- a/langserver/cmd/langserver-go/Makefile
+++ b/langserver/cmd/langserver-go/Makefile
@@ -1,7 +1,0 @@
-.PHONY: docker-image
-
-TAG ?= latest
-
-docker-image:
-	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o langserver-go .
-	docker build -t us.gcr.io/sourcegraph-dev/langserver-go:$(TAG) .

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-package main // import "github.com/sourcegraph/go-langserver/langserver/cmd/langserver-go"
+package main // import "github.com/sourcegraph/go-langserver"
 
 import (
 	"context"


### PR DESCRIPTION
We expect going forward that users running `go get` to install go-langserver to be a very common use case. As such we can restructure the repo to make that less of a cryptic command.

Note: This changes the name of the standalone binary from `langserver-go` to `go-langserver`

cc @ramya-rao-a 

Part of #154

Fixes #135 