### PR TITLE
Send comments in hover as string

### DIFF
--- a/langserver/hover.go
+++ b/langserver/hover.go
@@ -3,6 +3,7 @@ package langserver
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"go/ast"
 	"go/build"
@@ -147,12 +148,23 @@ func maybeAddComments(comments string, contents []lsp.MarkedString) []lsp.Marked
 	if comments == "" {
 		return contents
 	}
+
+	var m lsp.MarkedString
+	input, marshallErr := json.Marshal(comments)
+	if marshallErr == nil {
+		unMarshallErr := json.Unmarshal(input, &m)
+		if unMarshallErr == nil {
+			return append(contents, m)
+		}
+	}
+
 	var b bytes.Buffer
 	doc.ToMarkdown(&b, comments, nil)
-	return append(contents, lsp.MarkedString{
+	m = lsp.MarkedString{
 		Language: "markdown",
 		Value:    b.String(),
-	})
+	}
+	return append(contents, m)
 }
 
 // packageDoc finds the documentation for the named package from its files or


### PR DESCRIPTION
This PR is to fix https://github.com/Microsoft/vscode-go/issues/852

@keegancsmith The tests at https://github.com/sourcegraph/go-langserver/blob/master/langserver/langserver_test.go#L778 are failing.

There is an expected ` \n\n` but it is finding only `\n`

My guess is that this is due to trimming at https://github.com/sourcegraph/go-langserver/blob/1212ac52443c77f5e6530e9e11f5793b3e9de0fe/pkg/lsp/service.go#L214

I am not clear why we are adding the extra `\n` in the first place.



