### PR TITLE
send hover markdown as raw MarkedString

### DIFF
--- a/langserver/hover.go
+++ b/langserver/hover.go
@@ -149,10 +149,7 @@ func maybeAddComments(comments string, contents []lsp.MarkedString) []lsp.Marked
 	}
 	var b bytes.Buffer
 	doc.ToMarkdown(&b, comments, nil)
-	return append(contents, lsp.MarkedString{
-		Language: "markdown",
-		Value:    b.String(),
-	})
+	return append(contents, lsp.RawMarkedString(b.String()))
 }
 
 // packageDoc finds the documentation for the named package from its files or

--- a/pkg/lsp/service.go
+++ b/pkg/lsp/service.go
@@ -221,7 +221,7 @@ func (m *MarkedString) UnmarshalJSON(data []byte) error {
 		m.isRawString = true
 		return nil
 	}
-	// Markdown
+	// Language string
 	ms := (*markedString)(m)
 	return json.Unmarshal(data, ms)
 }

--- a/pkg/lsp/service.go
+++ b/pkg/lsp/service.go
@@ -233,6 +233,12 @@ func (m MarkedString) MarshalJSON() ([]byte, error) {
 	return json.Marshal((markedString)(m))
 }
 
+// RawMarkedString returns a MarkedString consisting of only a raw
+// string (i.e., "foo" instead of {"value":"foo", "language":"bar"}).
+func RawMarkedString(s string) MarkedString {
+	return MarkedString{Value: s, isRawString: true}
+}
+
 type SignatureHelp struct {
 	Signatures      []SignatureInformation `json:"signatures"`
 	ActiveSignature int                    `json:"activeSignature"`


### PR DESCRIPTION
Alternative fix for https://github.com/sourcegraph/go-langserver/pull/182

Follow-on to https://github.com/sourcegraph/go-langserver/pull/181

Confirmed that this results in docstrings being rendered in a sans-serif font in vscode 1.11.0.

cc @ramya-rao-a 