### PR TITLE
do not panic on non-file:/// URIs

### DIFF
--- a/langserver/definition.go
+++ b/langserver/definition.go
@@ -3,6 +3,7 @@ package langserver
 import (
 	"context"
 	"errors"
+	"fmt"
 	"go/ast"
 	"log"
 
@@ -24,6 +25,13 @@ func (h *LangHandler) handleDefinition(ctx context.Context, conn jsonrpc2.JSONRP
 }
 
 func (h *LangHandler) handleXDefinition(ctx context.Context, conn jsonrpc2.JSONRPC2, req *jsonrpc2.Request, params lsp.TextDocumentPositionParams) ([]symbolLocationInformation, error) {
+	if !isFileURI(params.TextDocument.URI) {
+		return nil, &jsonrpc2.Error{
+			Code:    jsonrpc2.CodeInvalidParams,
+			Message: fmt.Sprintf("%s not yet supported for out-of-workspace URI (%q)", req.Method, params.TextDocument.URI),
+		}
+	}
+
 	rootPath := h.FilePath(h.init.RootPath)
 	bctx := h.BuildContext(ctx)
 

--- a/langserver/format.go
+++ b/langserver/format.go
@@ -3,6 +3,7 @@ package langserver
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"go/ast"
 	"go/parser"
 	"go/printer"
@@ -16,6 +17,13 @@ import (
 )
 
 func (h *LangHandler) handleTextDocumentFormatting(ctx context.Context, conn jsonrpc2.JSONRPC2, req *jsonrpc2.Request, params lsp.DocumentFormattingParams) ([]lsp.TextEdit, error) {
+	if !isFileURI(params.TextDocument.URI) {
+		return nil, &jsonrpc2.Error{
+			Code:    jsonrpc2.CodeInvalidParams,
+			Message: fmt.Sprintf("%s not yet supported for out-of-workspace URI (%q)", req.Method, params.TextDocument.URI),
+		}
+	}
+
 	filename := h.FilePath(params.TextDocument.URI)
 	bctx := h.BuildContext(ctx)
 	fset := token.NewFileSet()

--- a/langserver/fs.go
+++ b/langserver/fs.go
@@ -166,7 +166,7 @@ func (h *overlay) didClose(params *lsp.DidCloseTextDocumentParams) {
 }
 
 func uriToOverlayPath(uri string) string {
-	if isURI(uri) {
+	if isFileURI(uri) {
 		return strings.TrimPrefix(uriToPath(uri), "/")
 	}
 	return uri

--- a/langserver/fs.go
+++ b/langserver/fs.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -167,7 +168,7 @@ func (h *overlay) didClose(params *lsp.DidCloseTextDocumentParams) {
 
 func uriToOverlayPath(uri string) string {
 	if isFileURI(uri) {
-		return strings.TrimPrefix(uriToPath(uri), "/")
+		return strings.TrimPrefix(uriToFilePath(uri), "/")
 	}
 	return uri
 }
@@ -204,7 +205,7 @@ func (h *overlay) del(uri string) {
 }
 
 func (h *HandlerShared) FilePath(uri string) string {
-	path := uriToPath(uri)
+	path := uriToFilePath(uri)
 	if !strings.HasPrefix(path, "/") {
 		panic(fmt.Sprintf("bad uri %q (path %q MUST have leading slash; it can't be relative)", uri, path))
 	}
@@ -212,6 +213,9 @@ func (h *HandlerShared) FilePath(uri string) string {
 }
 
 func (h *HandlerShared) readFile(ctx context.Context, uri string) ([]byte, error) {
+	if !isFileURI(uri) {
+		return nil, &os.PathError{Op: "Open", Path: uri, Err: errors.New("unable to read out-of-workspace resource from virtual file system")}
+	}
 	h.Mu.Lock()
 	fs := h.FS
 	h.Mu.Unlock()

--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -183,7 +183,7 @@ func (h *LangHandler) Handle(ctx context.Context, conn jsonrpc2.JSONRPC2, req *j
 
 		// HACK: RootPath is not a URI, but historically we treated it
 		// as such. Convert it to a file URI
-		if !isURI(params.RootPath) {
+		if !isFileURI(params.RootPath) {
 			params.RootPath = pathToURI(params.RootPath)
 		}
 

--- a/langserver/handler_common.go
+++ b/langserver/handler_common.go
@@ -26,7 +26,7 @@ func (h *HandlerCommon) Reset(rootURI string) error {
 	if h.shutdown {
 		return errors.New("unable to reset a server that is shutting down")
 	}
-	if !isURI(rootURI) {
+	if !isFileURI(rootURI) {
 		return fmt.Errorf("invalid root path %q: must be file:/// URI", rootURI)
 	}
 	h.RootFSPath = uriToPath(rootURI) // retain leading slash

--- a/langserver/handler_common.go
+++ b/langserver/handler_common.go
@@ -29,7 +29,7 @@ func (h *HandlerCommon) Reset(rootURI string) error {
 	if !isFileURI(rootURI) {
 		return fmt.Errorf("invalid root path %q: must be file:/// URI", rootURI)
 	}
-	h.RootFSPath = uriToPath(rootURI) // retain leading slash
+	h.RootFSPath = uriToFilePath(rootURI) // retain leading slash
 	return nil
 }
 

--- a/langserver/hover.go
+++ b/langserver/hover.go
@@ -16,6 +16,13 @@ import (
 )
 
 func (h *LangHandler) handleHover(ctx context.Context, conn jsonrpc2.JSONRPC2, req *jsonrpc2.Request, params lsp.TextDocumentPositionParams) (*lsp.Hover, error) {
+	if !isFileURI(params.TextDocument.URI) {
+		return nil, &jsonrpc2.Error{
+			Code:    jsonrpc2.CodeInvalidParams,
+			Message: fmt.Sprintf("textDocument/hover not yet supported for out-of-workspace URI (%q)", params.TextDocument.URI),
+		}
+	}
+
 	fset, node, _, prog, pkg, _, err := h.typecheck(ctx, conn, params.TextDocument.URI, params.Position)
 	if err != nil {
 		// Invalid nodes means we tried to click on something which is

--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -29,7 +29,7 @@ func TestServer(t *testing.T) {
 		cases    lspTestCases
 	}{
 		"go basic": {
-			rootPath: "/src/test/pkg",
+			rootPath: "file:///src/test/pkg",
 			fs: map[string]string{
 				"a.go": "package p; func A() { A() }",
 				"b.go": "package p; func B() { A() }",
@@ -883,7 +883,7 @@ type Header struct {
 				}
 			}()
 
-			rootFSPath := uriToPath(test.rootPath)
+			rootFSPath := uriToFilePath(test.rootPath)
 
 			// Prepare the connection.
 			ctx := context.Background()
@@ -1061,7 +1061,7 @@ func definitionTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, rootPat
 	if err != nil {
 		t.Fatal(err)
 	}
-	definition = uriToPath(definition)
+	definition = uriToFilePath(definition)
 	if definition != want {
 		t.Errorf("got %q, want %q", definition, want)
 	}
@@ -1076,7 +1076,7 @@ func xdefinitionTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, rootPa
 	if err != nil {
 		t.Fatal(err)
 	}
-	xdefinition = uriToPath(xdefinition)
+	xdefinition = uriToFilePath(xdefinition)
 	if xdefinition != want {
 		t.Errorf("\ngot  %q\nwant %q", xdefinition, want)
 	}
@@ -1092,7 +1092,7 @@ func referencesTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, rootPat
 		t.Fatal(err)
 	}
 	for i := range references {
-		references[i] = uriToPath(references[i])
+		references[i] = uriToFilePath(references[i])
 	}
 	sort.Strings(references)
 	sort.Strings(want)
@@ -1107,7 +1107,7 @@ func symbolsTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, rootPath s
 		t.Fatal(err)
 	}
 	for i := range symbols {
-		symbols[i] = uriToPath(symbols[i])
+		symbols[i] = uriToFilePath(symbols[i])
 	}
 	if !reflect.DeepEqual(symbols, want) {
 		t.Errorf("got %q, want %q", symbols, want)
@@ -1120,7 +1120,7 @@ func workspaceSymbolsTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, r
 		t.Fatal(err)
 	}
 	for i := range symbols {
-		symbols[i] = uriToPath(symbols[i])
+		symbols[i] = uriToFilePath(symbols[i])
 	}
 	if !reflect.DeepEqual(symbols, want) {
 		t.Errorf("got %#v, want %q", symbols, want)
@@ -1322,7 +1322,7 @@ func callWorkspaceReferences(ctx context.Context, c *jsonrpc2.Conn, params lspex
 	}
 	refs := make([]string, len(references))
 	for i, r := range references {
-		locationURI := uriToPath(r.Reference.URI)
+		locationURI := uriToFilePath(r.Reference.URI)
 		start := r.Reference.Range.Start
 		end := r.Reference.Range.End
 		refs[i] = fmt.Sprintf("%s:%d:%d-%d:%d -> %v", locationURI, start.Line+1, start.Character+1, end.Line+1, end.Character+1, r.Symbol)

--- a/langserver/loader.go
+++ b/langserver/loader.go
@@ -30,6 +30,10 @@ func (h *LangHandler) typecheck(ctx context.Context, conn jsonrpc2.JSONRPC2, fil
 	ctx = opentracing.ContextWithSpan(ctx, span)
 	defer span.Finish()
 
+	if !isFileURI(fileURI) {
+		return nil, nil, nil, nil, nil, nil, fmt.Errorf("typechecking of out-of-workspace URI (%q) is not yet supported", fileURI)
+	}
+
 	filename := h.FilePath(fileURI)
 
 	contents, err := h.readFile(ctx, fileURI)

--- a/langserver/references.go
+++ b/langserver/references.go
@@ -29,6 +29,13 @@ import (
 var streamExperiment = len(os.Getenv("STREAM_EXPERIMENT")) > 0
 
 func (h *LangHandler) handleTextDocumentReferences(ctx context.Context, conn jsonrpc2.JSONRPC2, req *jsonrpc2.Request, params lsp.ReferenceParams) ([]lsp.Location, error) {
+	if !isFileURI(params.TextDocument.URI) {
+		return nil, &jsonrpc2.Error{
+			Code:    jsonrpc2.CodeInvalidParams,
+			Message: fmt.Sprintf("textDocument/references not yet supported for out-of-workspace URI (%q)", params.TextDocument.URI),
+		}
+	}
+
 	// Begin computing the reverse import graph immediately, as this
 	// occurs in the background and is IO-bound.
 	reverseImportGraphC := h.reverseImportGraph(ctx, conn)

--- a/langserver/signature.go
+++ b/langserver/signature.go
@@ -2,6 +2,7 @@ package langserver
 
 import (
 	"context"
+	"fmt"
 	"go/ast"
 	"go/token"
 	"go/types"
@@ -11,6 +12,13 @@ import (
 )
 
 func (h *LangHandler) handleTextDocumentSignatureHelp(ctx context.Context, conn jsonrpc2.JSONRPC2, req *jsonrpc2.Request, params lsp.TextDocumentPositionParams) (*lsp.SignatureHelp, error) {
+	if !isFileURI(params.TextDocument.URI) {
+		return nil, &jsonrpc2.Error{
+			Code:    jsonrpc2.CodeInvalidParams,
+			Message: fmt.Sprintf("textDocument/signatureHelp not yet supported for out-of-workspace URI (%q)", params.TextDocument.URI),
+		}
+	}
+
 	fset, _, nodes, prog, pkg, start, err := h.typecheck(ctx, conn, params.TextDocument.URI, params.Position)
 	if err != nil {
 		if _, ok := err.(*invalidNodeError); !ok {

--- a/langserver/symbol_test.go
+++ b/langserver/symbol_test.go
@@ -18,72 +18,72 @@ func Test_resultSorter(t *testing.T) {
 		rawQuery: "foo.bar",
 		allSymbols: []lsp.SymbolInformation{{
 			ContainerName: "foo", Name: "bar",
-			Location: lsp.Location{URI: "file.go"},
+			Location: lsp.Location{URI: "file:///file.go"},
 			Kind:     lsp.SKFunction,
 		}, {
 			ContainerName: "foo", Name: "Bar",
-			Location: lsp.Location{URI: "file.go"},
+			Location: lsp.Location{URI: "file:///file.go"},
 			Kind:     lsp.SKFunction,
 		}, {
 			ContainerName: "asdf", Name: "foo",
-			Location: lsp.Location{URI: "file.go"},
+			Location: lsp.Location{URI: "file:///file.go"},
 			Kind:     lsp.SKFunction,
 		}, {
 			ContainerName: "asdf", Name: "asdf",
-			Location: lsp.Location{URI: "foo.go"},
+			Location: lsp.Location{URI: "file:///foo.go"},
 			Kind:     lsp.SKFunction,
 		}, {
 			ContainerName: "one", Name: "two",
-			Location: lsp.Location{URI: "file.go"},
+			Location: lsp.Location{URI: "file:///file.go"},
 			Kind:     lsp.SKFunction,
 		}},
 		expResults: []lsp.SymbolInformation{{
 			ContainerName: "foo", Name: "Bar",
-			Location: lsp.Location{URI: "file.go"},
+			Location: lsp.Location{URI: "file:///file.go"},
 			Kind:     lsp.SKFunction,
 		}, {
 			ContainerName: "foo", Name: "bar",
-			Location: lsp.Location{URI: "file.go"},
+			Location: lsp.Location{URI: "file:///file.go"},
 			Kind:     lsp.SKFunction,
 		}, {
 			ContainerName: "asdf", Name: "foo",
-			Location: lsp.Location{URI: "file.go"},
+			Location: lsp.Location{URI: "file:///file.go"},
 			Kind:     lsp.SKFunction,
 		}, {
 			ContainerName: "asdf", Name: "asdf",
-			Location: lsp.Location{URI: "foo.go"},
+			Location: lsp.Location{URI: "file:///foo.go"},
 			Kind:     lsp.SKFunction,
 		}},
 	}, {
 		rawQuery: "foo bar",
 		allSymbols: []lsp.SymbolInformation{{
 			ContainerName: "foo", Name: "bar",
-			Location: lsp.Location{URI: "file.go"},
+			Location: lsp.Location{URI: "file:///file.go"},
 			Kind:     lsp.SKFunction,
 		}, {
 			ContainerName: "asdf", Name: "foo",
-			Location: lsp.Location{URI: "file.go"},
+			Location: lsp.Location{URI: "file:///file.go"},
 			Kind:     lsp.SKFunction,
 		}, {
 			ContainerName: "asdf", Name: "asdf",
-			Location: lsp.Location{URI: "foo.go"},
+			Location: lsp.Location{URI: "file:///foo.go"},
 			Kind:     lsp.SKFunction,
 		}, {
 			ContainerName: "one", Name: "two",
-			Location: lsp.Location{URI: "file.go"},
+			Location: lsp.Location{URI: "file:///file.go"},
 			Kind:     lsp.SKFunction,
 		}},
 		expResults: []lsp.SymbolInformation{{
 			ContainerName: "foo", Name: "bar",
-			Location: lsp.Location{URI: "file.go"},
+			Location: lsp.Location{URI: "file:///file.go"},
 			Kind:     lsp.SKFunction,
 		}, {
 			ContainerName: "asdf", Name: "foo",
-			Location: lsp.Location{URI: "file.go"},
+			Location: lsp.Location{URI: "file:///file.go"},
 			Kind:     lsp.SKFunction,
 		}, {
 			ContainerName: "asdf", Name: "asdf",
-			Location: lsp.Location{URI: "foo.go"},
+			Location: lsp.Location{URI: "file:///foo.go"},
 			Kind:     lsp.SKFunction,
 		}},
 	}, {
@@ -92,24 +92,24 @@ func Test_resultSorter(t *testing.T) {
 		rawQuery: "is:exported",
 		allSymbols: []lsp.SymbolInformation{{
 			ContainerName: "foo", Name: "bar",
-			Location: lsp.Location{URI: "file.go"},
+			Location: lsp.Location{URI: "file:///file.go"},
 			Kind:     lsp.SKFunction,
 		}},
 		expResults: []lsp.SymbolInformation{{
 			ContainerName: "foo", Name: "bar",
-			Location: lsp.Location{URI: "file.go"},
+			Location: lsp.Location{URI: "file:///file.go"},
 			Kind:     lsp.SKFunction,
 		}},
 	}, {
 		rawQuery: "",
 		allSymbols: []lsp.SymbolInformation{{
 			ContainerName: "foo", Name: "bar",
-			Location: lsp.Location{URI: "file.go"},
+			Location: lsp.Location{URI: "file:///file.go"},
 			Kind:     lsp.SKFunction,
 		}},
 		expResults: []lsp.SymbolInformation{{
 			ContainerName: "foo", Name: "bar",
-			Location: lsp.Location{URI: "file.go"},
+			Location: lsp.Location{URI: "file:///file.go"},
 			Kind:     lsp.SKFunction,
 		}},
 	}}

--- a/langserver/util.go
+++ b/langserver/util.go
@@ -35,7 +35,7 @@ func IsVendorDir(dir string) bool {
 	return strings.HasPrefix(dir, "vendor/") || strings.Contains(dir, "/vendor/")
 }
 
-// isFileURI tells if s denotes an URI
+// isFileURI tells if s denotes an absolute file URI.
 func isFileURI(s string) bool {
 	return strings.HasPrefix(s, "file:///")
 }
@@ -45,8 +45,12 @@ func pathToURI(path string) string {
 	return "file://" + path
 }
 
-// uriToPath converts given file URI to path
-func uriToPath(uri string) string {
+// uriToFilePath converts given absolute file URI to path. It panics if
+// uri does not begin with "file:///".
+func uriToFilePath(uri string) string {
+	if !isFileURI(uri) {
+		panic("not an absolute file URI: " + uri)
+	}
 	return strings.TrimPrefix(uri, "file://")
 }
 

--- a/langserver/util.go
+++ b/langserver/util.go
@@ -35,8 +35,8 @@ func IsVendorDir(dir string) bool {
 	return strings.HasPrefix(dir, "vendor/") || strings.Contains(dir, "/vendor/")
 }
 
-// isURI tells if s denotes an URI
-func isURI(s string) bool {
+// isFileURI tells if s denotes an URI
+func isFileURI(s string) bool {
 	return strings.HasPrefix(s, "file:///")
 }
 


### PR DESCRIPTION
This prevents a client from causing a panic when it opens a non-file:/// URI in the workspace (e.g., a `git://` URI), and returns a nicer error instead (that can be shown to the user).

This PR is not intended to support URI schemes other than file:/// (it is only to make the server more robust and not panic in that case).