### PR TITLE
allow callers to indicate they do not need deps to be fetched when they call FindPackage

### DIFF
--- a/langserver/handler_shared.go
+++ b/langserver/handler_shared.go
@@ -25,9 +25,9 @@ type HandlerShared struct {
 
 // FindPackageFunc matches the signature of loader.Config.FindPackage, except
 // also takes a context.Context.
-type FindPackageFunc func(ctx context.Context, bctx *build.Context, importPath, fromDir string, mode build.ImportMode) (*build.Package, error)
+type FindPackageFunc func(ctx context.Context, bctx *build.Context, importPath, fromDir string, mode build.ImportMode, fetchTransitiveDeps bool) (*build.Package, error)
 
-func defaultFindPackageFunc(ctx context.Context, bctx *build.Context, importPath, fromDir string, mode build.ImportMode) (*build.Package, error) {
+func defaultFindPackageFunc(ctx context.Context, bctx *build.Context, importPath, fromDir string, mode build.ImportMode, fetchTransitiveDeps bool) (*build.Package, error) {
 	return bctx.Import(importPath, fromDir, mode)
 }
 

--- a/langserver/loader.go
+++ b/langserver/loader.go
@@ -239,7 +239,7 @@ func typecheck(ctx context.Context, fset *token.FileSet, bctx *build.Context, bp
 			// MultipleGoErrors. This occurs, e.g., when you have a
 			// main.go with "// +build ignore" that imports the
 			// non-main package in the same dir.
-			bpkg, err := findPackage(ctx, bctx, importPath, fromDir, mode)
+			bpkg, err := findPackage(ctx, bctx, importPath, fromDir, mode, true)
 			if err != nil && !isMultiplePackageError(err) {
 				return bpkg, err
 			}

--- a/langserver/references.go
+++ b/langserver/references.go
@@ -220,7 +220,7 @@ func (h *LangHandler) reverseImportGraph(ctx context.Context, conn jsonrpc2.JSON
 			bctx := h.BuildContext(ctx)
 			findPackageWithCtx := h.getFindPackageFunc()
 			findPackage := func(bctx *build.Context, importPath, fromDir string, mode build.ImportMode) (*build.Package, error) {
-				return findPackageWithCtx(ctx, bctx, importPath, fromDir, mode)
+				return findPackageWithCtx(ctx, bctx, importPath, fromDir, mode, true)
 			}
 			g := tools.BuildReverseImportGraph(bctx, findPackage, h.FilePath(h.init.RootPath))
 			h.mu.Lock()

--- a/langserver/symbol.go
+++ b/langserver/symbol.go
@@ -384,7 +384,7 @@ type pkgSymResult struct {
 func (h *LangHandler) collectFromPkg(ctx context.Context, bctx *build.Context, pkg string, rootPath string, results *resultSorter) {
 	symbols := h.symbolCache.Get(pkg, func() interface{} {
 		findPackage := h.getFindPackageFunc()
-		buildPkg, err := findPackage(ctx, bctx, pkg, rootPath, 0)
+		buildPkg, err := findPackage(ctx, bctx, pkg, rootPath, 0, false /* only this pkg's files are needed */)
 		if err != nil {
 			maybeLogImportError(pkg, err)
 			return nil

--- a/langserver/workspace_refs.go
+++ b/langserver/workspace_refs.go
@@ -48,7 +48,7 @@ func (h *LangHandler) handleWorkspaceReferences(ctx context.Context, conn jsonrp
 		unvendoredPackages = map[string]struct{}{}
 	)
 	for _, pkg := range tools.ListPkgsUnderDir(bctx, rootPath) {
-		bpkg, err := findPackage(ctx, bctx, pkg, rootPath, build.FindOnly)
+		bpkg, err := findPackage(ctx, bctx, pkg, rootPath, build.FindOnly, true)
 		if err != nil && !isMultiplePackageError(err) {
 			log.Printf("skipping possible package %s: %s", pkg, err)
 			continue
@@ -236,7 +236,7 @@ func (h *LangHandler) workspaceRefsTypecheck(ctx context.Context, bctx *build.Co
 			// MultipleGoErrors. This occurs, e.g., when you have a
 			// main.go with "// +build ignore" that imports the
 			// non-main package in the same dir.
-			bpkg, err := findPackage(ctx, bctx, importPath, fromDir, mode)
+			bpkg, err := findPackage(ctx, bctx, importPath, fromDir, mode, true)
 			if err != nil && !isMultiplePackageError(err) {
 				return bpkg, err
 			}
@@ -337,7 +337,7 @@ func (h *LangHandler) workspaceRefsFromPkg(ctx context.Context, bctx *build.Cont
 }
 
 func defSymbolDescriptor(ctx context.Context, bctx *build.Context, rootPath string, def refs.Def, findPackage FindPackageFunc) (*symbolDescriptor, error) {
-	defPkg, err := findPackage(ctx, bctx, def.ImportPath, rootPath, build.FindOnly)
+	defPkg, err := findPackage(ctx, bctx, def.ImportPath, rootPath, build.FindOnly, false)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Operations that only require parsing of a single file (or a single package's files) do not need deps to be fetched. Skipping dep fetching makes them much faster.

Use case: The gitlens vscode extension calls textDocument/documentSymbol on each document when it is opened, to know where to position its code lenses containing git information. This should be a super quick parsing-only task, but it takes a long time when using the Go lang server because it must fetch deps needlessly.

(To actually get the speed benefits, consumers need to update the FindPackage func they provide use this new param.)