### PR TITLE
refs: Remove hardcoded timeout from workspace/refs

### DIFF
--- a/langserver/workspace_refs.go
+++ b/langserver/workspace_refs.go
@@ -26,16 +26,8 @@ import (
 	"github.com/sourcegraph/jsonrpc2"
 )
 
-// workspaceReferencesTimeout is the timeout used for workspace/xreferences
-// calls.
-const workspaceReferencesTimeout = 15 * time.Second
-
 func (h *LangHandler) handleWorkspaceReferences(ctx context.Context, conn jsonrpc2.JSONRPC2, req *jsonrpc2.Request, params lspext.WorkspaceReferencesParams) ([]referenceInformation, error) {
-	// TODO: Add support for the cancelRequest LSP method instead of using
-	// hard-coded timeouts like this here.
-	//
-	// See: https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md#cancelRequest
-	ctx, cancel := context.WithTimeout(ctx, workspaceReferencesTimeout)
+	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	rootPath := h.FilePath(h.init.RootPath)
 	bctx := h.BuildContext(ctx)


### PR DESCRIPTION
This is a relic from before we had streaming support. We still don't support
passing on `$/cancelRequest`. However, that should be fine since it seems to be
fine for references.