### PR TITLE
Always send $/partialResult

### DIFF
--- a/langserver/references.go
+++ b/langserver/references.go
@@ -11,7 +11,6 @@ import (
 	"go/token"
 	"go/types"
 	"math"
-	"os"
 	"strings"
 	"sync"
 	"time"
@@ -25,8 +24,6 @@ import (
 	"github.com/sourcegraph/go-langserver/pkg/lspext"
 	"github.com/sourcegraph/jsonrpc2"
 )
-
-var streamExperiment = len(os.Getenv("STREAM_EXPERIMENT")) > 0
 
 func (h *LangHandler) handleTextDocumentReferences(ctx context.Context, conn jsonrpc2.JSONRPC2, req *jsonrpc2.Request, params lsp.ReferenceParams) ([]lsp.Location, error) {
 	if !isFileURI(params.TextDocument.URI) {
@@ -249,17 +246,6 @@ func refStreamAndCollect(ctx context.Context, conn jsonrpc2.JSONRPC2, req *jsonr
 	if limit == 0 {
 		// If we don't have a limit, just set it to a value we should never exceed
 		limit = math.MaxInt32
-	}
-
-	if !streamExperiment {
-		var locs []lsp.Location
-		for n := range refs {
-			locs = append(locs, goRangeToLSPLocation(fset, n.Pos(), n.End()))
-		}
-		if len(locs) > limit {
-			locs = locs[:limit]
-		}
-		return locs
 	}
 
 	id := lsp.ID{

--- a/langserver/workspace_refs.go
+++ b/langserver/workspace_refs.go
@@ -122,56 +122,52 @@ func (h *LangHandler) handleWorkspaceReferences(ctx context.Context, conn jsonrp
 		limit = math.MaxInt32
 	}
 
-	streamUpdate := func() bool { return true }
-	streamTick := make(<-chan time.Time, 1)
-	if streamExperiment {
-		initial := json.RawMessage(`[{"op":"replace","path":"","value":[]}]`)
+	initial := json.RawMessage(`[{"op":"replace","path":"","value":[]}]`)
+	conn.Notify(ctx, "$/partialResult", &lspext.PartialResultParams{
+		ID: lsp.ID{
+			Num:      req.ID.Num,
+			Str:      req.ID.Str,
+			IsString: req.ID.IsString,
+		},
+		Patch: &initial,
+	})
+	t := time.NewTicker(100 * time.Millisecond)
+	defer t.Stop()
+	streamTick := t.C
+	streamPos := 0
+	streamUpdate := func() bool {
+		results.resultsMu.Lock()
+		partial := results.results
+		results.resultsMu.Unlock()
+		if len(partial) == streamPos || streamPos == limit {
+			// Everything currently in refs has already been sent.
+			// return true if we can stream more results.
+			return streamPos < limit
+		}
+		if len(partial) > limit {
+			partial = partial[:limit]
+		}
+
+		patch := make([]xreferenceAddOp, 0, len(partial)-streamPos)
+		for ; streamPos < len(partial); streamPos++ {
+			patch = append(patch, xreferenceAddOp{
+				OP:    "add",
+				Path:  "/-",
+				Value: partial[streamPos],
+			})
+		}
 		conn.Notify(ctx, "$/partialResult", &lspext.PartialResultParams{
 			ID: lsp.ID{
 				Num:      req.ID.Num,
 				Str:      req.ID.Str,
 				IsString: req.ID.IsString,
 			},
-			Patch: &initial,
+			// We use xreferencePatch so the build server can rewrite URIs
+			Patch: xreferencePatch(patch),
 		})
-		t := time.NewTicker(100 * time.Millisecond)
-		defer t.Stop()
-		streamTick = t.C
-		streamPos := 0
-		streamUpdate = func() bool {
-			results.resultsMu.Lock()
-			partial := results.results
-			results.resultsMu.Unlock()
-			if len(partial) == streamPos || streamPos == limit {
-				// Everything currently in refs has already been sent.
-				// return true if we can stream more results.
-				return streamPos < limit
-			}
-			if len(partial) > limit {
-				partial = partial[:limit]
-			}
 
-			patch := make([]xreferenceAddOp, 0, len(partial)-streamPos)
-			for ; streamPos < len(partial); streamPos++ {
-				patch = append(patch, xreferenceAddOp{
-					OP:    "add",
-					Path:  "/-",
-					Value: partial[streamPos],
-				})
-			}
-			conn.Notify(ctx, "$/partialResult", &lspext.PartialResultParams{
-				ID: lsp.ID{
-					Num:      req.ID.Num,
-					Str:      req.ID.Str,
-					IsString: req.ID.IsString,
-				},
-				// We use xreferencePatch so the build server can rewrite URIs
-				Patch: xreferencePatch(patch),
-			})
-
-			// return true if we can stream more results.
-			return len(partial) < limit
-		}
+		// return true if we can stream more results.
+		return len(partial) < limit
 	}
 
 loop:


### PR DESCRIPTION
If a client does not support $/partialResult, it will just ignore the
notfications.