### PR TITLE
significantly lower memory consumption for vscode-go users

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,21 @@ go get github.com/sourcegraph/go-langserver
 |    | Hover | Jump to def | Find references | Workspace symbols | VFS extension | Isolated | Parallel |
 |----|-------|-------------|-----------------|-------------------|---------------|----------|----------|
 | Go |   x   |      x      |        x        |         x         |       x       |     x    |     x    |
+
+## Profiling
+
+If you run into performance issues while using the language server, it can be very helpful to attach a CPU or memory profile with the issue report. To capture one, first [install Go](https://golang.org/doc/install) and then:
+
+Capture a heap (memory) profile:
+
+```bash
+go tool pprof -svg $GOPATH/bin/go-langserver http://localhost:6060/debug/pprof/heap > heap.svg
+```
+
+Capture a CPU profile:
+
+```bash
+go tool pprof -svg $GOPATH/bin/go-langserver http://localhost:6060/debug/pprof/profile > cpu.svg
+```
+
+Since these capture the active resource usage, it's best to run these commands while the issue is occuring (i.e. while memory or CPU is high).

--- a/main.go
+++ b/main.go
@@ -7,10 +7,13 @@ import (
 	"io"
 	"log"
 	"net"
+	"net/http"
 	"os"
 
 	"github.com/sourcegraph/go-langserver/langserver"
 	"github.com/sourcegraph/jsonrpc2"
+
+	_ "net/http/pprof"
 )
 
 var (
@@ -19,6 +22,7 @@ var (
 	trace        = flag.Bool("trace", false, "print all requests and responses")
 	logfile      = flag.String("logfile", "", "also log to this file (in addition to stderr)")
 	printVersion = flag.Bool("version", false, "print version and exit")
+	pprof        = flag.String("pprof", ":6060", "start a pprof http server (https://golang.org/pkg/net/http/pprof/)")
 )
 
 // version is the version field we report back. If you are releasing a new version:
@@ -31,6 +35,13 @@ const version = "v2-dev"
 func main() {
 	flag.Parse()
 	log.SetFlags(0)
+
+	// Start pprof server, if desired.
+	if *pprof != "" {
+		go func() {
+			log.Println(http.ListenAndServe(*pprof, nil))
+		}()
+	}
 
 	if err := run(); err != nil {
 		fmt.Fprintln(os.Stderr, err)


### PR DESCRIPTION
- This change significantly lowers memory consumption when running in editor mode (i.e. with vscode-go). From 7GB down to 4GB for a large project such as Docker.
- Additionally adds a pprof HTTP server by default, for capturing profiles easily (see README).
- Also adds an `-freeosmemory=true` flag, which when set to false can be used to disable this behavior for testing purposes (we'll also probably disable on sourcegraph.com).

Significantly helps https://github.com/sourcegraph/go-langserver/issues/178 (probably fixes entirely, but I have more improvements coming soon that I believe will lower memory consumption even further :) ).