### PR TITLE
DONOTMERGE: Unify hover/definition (remove non-godef implementation)

### DIFF
--- a/langserver/definition.go
+++ b/langserver/definition.go
@@ -15,10 +15,6 @@ import (
 	"github.com/sourcegraph/jsonrpc2"
 )
 
-// UseBinaryPkgCache controls whether or not $GOPATH/pkg binary .a files should
-// be used.
-var UseBinaryPkgCache = false
-
 // BuildGoPackage is a callback that invoked prior to using data from a $GOPATH/pkg
 // .a file for the specified import path.
 //
@@ -27,20 +23,8 @@ var UseBinaryPkgCache = false
 var BuildGoPackage func(paths string) error
 
 func (h *LangHandler) handleDefinition(ctx context.Context, conn jsonrpc2.JSONRPC2, req *jsonrpc2.Request, params lsp.TextDocumentPositionParams) ([]lsp.Location, error) {
-	if UseBinaryPkgCache {
-		_, _, locs, err := h.definitionGodef(ctx, params)
-		return locs, err
-	}
-
-	res, err := h.handleXDefinition(ctx, conn, req, params)
-	if err != nil {
-		return nil, err
-	}
-	locs := make([]lsp.Location, 0, len(res))
-	for _, li := range res {
-		locs = append(locs, li.Location)
-	}
-	return locs, nil
+	_, _, locs, err := h.definitionGodef(ctx, params)
+	return locs, err
 }
 
 var testOSToVFSPath func(osPath string) string

--- a/langserver/definition.go
+++ b/langserver/definition.go
@@ -20,6 +20,13 @@ import (
 // be used.
 var UseBinaryPkgCache = false
 
+// BuildGoPackage is a callback that invoked prior to using data from a $GOPATH/pkg
+// .a file for the specified import path.
+//
+// The import path is always absolute (i.e. inclusive of the entire path to the
+// vendor directory).
+var BuildGoPackage func(paths string) error
+
 func (h *LangHandler) handleDefinition(ctx context.Context, conn jsonrpc2.JSONRPC2, req *jsonrpc2.Request, params lsp.TextDocumentPositionParams) ([]lsp.Location, error) {
 	if UseBinaryPkgCache {
 		_, _, locs, err := h.definitionGodef(ctx, params)
@@ -61,7 +68,7 @@ func (h *LangHandler) definitionGodef(ctx context.Context, params lsp.TextDocume
 
 	// Invoke godef to determine the position of the definition.
 	fset := token.NewFileSet()
-	res, err := godef.Godef(fset, offset, filename, contents)
+	res, err := godef.Godef(fset, offset, filename, contents, BuildGoPackage)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/langserver/definition.go
+++ b/langserver/definition.go
@@ -5,10 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"go/ast"
-	"go/build"
 	"go/token"
 	"log"
-	"path/filepath"
+	"path"
 
 	"github.com/sourcegraph/go-langserver/langserver/internal/godef"
 	"github.com/sourcegraph/go-langserver/langserver/internal/refs"
@@ -67,8 +66,9 @@ func (h *LangHandler) definitionGodef(ctx context.Context, params lsp.TextDocume
 	}
 
 	// Invoke godef to determine the position of the definition.
+	bctx := h.BuildContext(ctx)
 	fset := token.NewFileSet()
-	res, err := godef.Godef(fset, offset, filename, contents, BuildGoPackage)
+	res, err := godef.Godef(ctx, bctx, fset, offset, filename, contents, h.FS, BuildGoPackage)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -83,7 +83,7 @@ func (h *LangHandler) definitionGodef(ctx context.Context, params lsp.TextDocume
 		// TODO: builtins do not have valid URIs or locations, so we emit a
 		// phony location here instead. This is better than our other
 		// implementation.
-		loc.URI = pathToURI(filepath.Join(build.Default.GOROOT, "/src/builtin/builtin.go"))
+		loc.URI = pathToURI(path.Join(bctx.GOROOT, "/src/builtin/builtin.go"))
 		loc.Range = lsp.Range{}
 	}
 

--- a/langserver/definition.go
+++ b/langserver/definition.go
@@ -35,7 +35,8 @@ func (h *LangHandler) definitionGodef(ctx context.Context, params lsp.TextDocume
 	// Invoke godef to determine the position of the definition.
 	bctx := h.BuildContext(ctx)
 	fset := token.NewFileSet()
-	res, err := godef.Godef(ctx, bctx, fset, offset, filename, contents, h.FS)
+	findPackage := h.getFindPackageFunc()
+	res, err := godef.Godef(ctx, bctx, fset, offset, filename, contents, h.FS, godef.FindPackageFunc(findPackage))
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -119,6 +119,11 @@ func (h *LangHandler) handle(ctx context.Context, conn *jsonrpc2.Conn, req *json
 	return h.Handle(ctx, conn, req)
 }
 
+// UsePremptiveTypechecking controls whether or not typechecking should be done
+// as early as possible. For just hover/definition, this does not improve time
+// to results, so it's advised for it to be off in local editor environments.
+var UsePremptiveTypechecking = false
+
 // Handle creates a response for a JSONRPC2 LSP request. Note: LSP has strict
 // ordering requirements, so this should not just be wrapped in an
 // jsonrpc2.AsyncHandler. Ensure you have the same ordering as used in the
@@ -356,7 +361,7 @@ func (h *LangHandler) Handle(ctx context.Context, conn jsonrpc2.JSONRPC2, req *j
 				// a user is viewing this path, hint to add it to the cache
 				// (unless we're primarily using binary package cache .a
 				// files).
-				if !UseBinaryPkgCache {
+				if !UsePremptiveTypechecking {
 					go h.typecheck(ctx, conn, uri, lsp.Position{})
 				}
 			}

--- a/langserver/hover.go
+++ b/langserver/hover.go
@@ -393,6 +393,27 @@ func findDocTarget(fset *token.FileSet, target token.Position, in interface{}) i
 		if inRange(target, fset.Position(v.Decl.Pos()), fset.Position(v.Decl.End())) {
 			return v
 		}
+
+		for _, x := range v.Consts {
+			if r := findDocTarget(fset, target, x); r != nil {
+				return r
+			}
+		}
+		for _, x := range v.Vars {
+			if r := findDocTarget(fset, target, x); r != nil {
+				return r
+			}
+		}
+		for _, x := range v.Funcs {
+			if r := findDocTarget(fset, target, x); r != nil {
+				return r
+			}
+		}
+		for _, x := range v.Methods {
+			if r := findDocTarget(fset, target, x); r != nil {
+				return r
+			}
+		}
 		return nil
 	case *doc.Func:
 		if inRange(target, fset.Position(v.Decl.Pos()), fset.Position(v.Decl.End())) {

--- a/langserver/hover.go
+++ b/langserver/hover.go
@@ -5,11 +5,9 @@ import (
 	"context"
 	"fmt"
 	"go/ast"
-	"go/build"
 	"go/format"
 	"go/parser"
 	"go/token"
-	"go/types"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -20,144 +18,7 @@ import (
 )
 
 func (h *LangHandler) handleHover(ctx context.Context, conn jsonrpc2.JSONRPC2, req *jsonrpc2.Request, params lsp.TextDocumentPositionParams) (*lsp.Hover, error) {
-	if UseBinaryPkgCache {
-		return h.handleHoverGodef(ctx, conn, req, params)
-	}
-
-	if !isFileURI(params.TextDocument.URI) {
-		return nil, &jsonrpc2.Error{
-			Code:    jsonrpc2.CodeInvalidParams,
-			Message: fmt.Sprintf("textDocument/hover not yet supported for out-of-workspace URI (%q)", params.TextDocument.URI),
-		}
-	}
-
-	fset, node, _, prog, pkg, _, err := h.typecheck(ctx, conn, params.TextDocument.URI, params.Position)
-	if err != nil {
-		// Invalid nodes means we tried to click on something which is
-		// not an ident (eg comment/string/etc). Return no information.
-		if _, ok := err.(*invalidNodeError); ok {
-			return nil, nil
-		}
-		// This is a common error we get in production when a user is
-		// browsing a go pkg which only contains files we can't
-		// analyse (usually due to build tags). To reduce signal of
-		// actual bad errors, we return no error in this case.
-		if _, ok := err.(*build.NoGoError); ok {
-			return nil, nil
-		}
-		return nil, err
-	}
-
-	o := pkg.ObjectOf(node)
-	t := pkg.TypeOf(node)
-	if o == nil && t == nil {
-		comments := packageDoc(pkg.Files, node.Name)
-
-		// Package statement idents don't have an object, so try that separately.
-		r := rangeForNode(fset, node)
-		if pkgName := packageStatementName(fset, pkg.Files, node); pkgName != "" {
-			return &lsp.Hover{
-				Contents: maybeAddComments(comments, []lsp.MarkedString{{Language: "go", Value: "package " + pkgName}}),
-				Range:    &r,
-			}, nil
-		}
-		return nil, fmt.Errorf("type/object not found at %+v", params.Position)
-	}
-	if o != nil && !o.Pos().IsValid() {
-		// Only builtins have invalid position, and don't have useful info.
-		return nil, nil
-	}
-	// Don't package-qualify the string output.
-	qf := func(*types.Package) string { return "" }
-
-	var s string
-	var extra string
-	if f, ok := o.(*types.Var); ok && f.IsField() {
-		// TODO(sqs): make this be like (T).F not "struct field F string".
-		s = "struct " + o.String()
-	} else if o != nil {
-		if obj, ok := o.(*types.TypeName); ok {
-			typ := obj.Type().Underlying()
-			if _, ok := typ.(*types.Struct); ok {
-				s = "type " + obj.Name() + " struct"
-				extra = prettyPrintTypesString(types.TypeString(typ, qf))
-			}
-			if _, ok := typ.(*types.Interface); ok {
-				s = "type " + obj.Name() + " interface"
-				extra = prettyPrintTypesString(types.TypeString(typ, qf))
-			}
-		}
-		if s == "" {
-			s = types.ObjectString(o, qf)
-		}
-
-	} else if t != nil {
-		s = types.TypeString(t, qf)
-	}
-
-	findComments := func(o types.Object) string {
-		if o == nil {
-			return ""
-		}
-
-		// Package names must be resolved specially, so do this now to avoid
-		// additional overhead.
-		if v, ok := o.(*types.PkgName); ok {
-			return packageDoc(prog.Package(v.Imported().Path()).Files, node.Name)
-		}
-
-		// Resolve the object o into its respective ast.Node
-		_, path, _ := prog.PathEnclosingInterval(o.Pos(), o.Pos())
-		if path == nil {
-			return ""
-		}
-
-		// Pull the comment out of the comment map for the file. Do
-		// not search too far away from the current path.
-		var doc *ast.CommentGroup
-		for i := 0; i < 3 && i < len(path) && doc == nil; i++ {
-			switch v := path[i].(type) {
-			case *ast.Field:
-				doc = v.Doc
-			case *ast.ValueSpec:
-				doc = v.Doc
-			case *ast.TypeSpec:
-				doc = v.Doc
-			case *ast.GenDecl:
-				doc = v.Doc
-			case *ast.FuncDecl:
-				doc = v.Doc
-			}
-		}
-		if doc == nil {
-			return ""
-		}
-		return doc.Text()
-	}
-
-	contents := maybeAddComments(findComments(o), []lsp.MarkedString{{Language: "go", Value: s}})
-	if extra != "" {
-		// If we have extra info, ensure it comes after the usually
-		// more useful documentation
-		contents = append(contents, lsp.MarkedString{Language: "go", Value: extra})
-	}
-
-	r := rangeForNode(fset, node)
-	return &lsp.Hover{
-		Contents: contents,
-		Range:    &r,
-	}, nil
-}
-
-// packageStatementName returns the package name ((*ast.Ident).Name)
-// of node iff node is the package statement of a file ("package p").
-func packageStatementName(fset *token.FileSet, files []*ast.File, node *ast.Ident) string {
-	for _, f := range files {
-		if f.Name == node {
-			return node.Name
-		}
-	}
-	return ""
+	return h.handleHoverGodef(ctx, conn, req, params)
 }
 
 // maybeAddComments appends the specified comments converted to Markdown godoc
@@ -183,75 +44,6 @@ func packageDoc(files []*ast.File, pkgName string) string {
 		}
 	}
 	return ""
-}
-
-// commentsToText converts a slice of []*ast.CommentGroup to a flat string,
-// ensuring whitespace-only comment groups are dropped.
-func commentsToText(cgroups []*ast.CommentGroup) (text string) {
-	for _, c := range cgroups {
-		if strings.TrimSpace(c.Text()) != "" {
-			text += c.Text()
-		}
-	}
-	return text
-}
-
-// prettyPrintTypesString is pretty printing specific to the output of
-// types.*String. Instead of re-implementing the printer, we can just
-// transform its output.
-func prettyPrintTypesString(s string) string {
-	// Don't bother including the fields if it is empty
-	if strings.HasSuffix(s, "{}") {
-		return ""
-	}
-	var b bytes.Buffer
-	b.Grow(len(s))
-	depth := 0
-	for i := 0; i < len(s); i++ {
-		c := s[i]
-		switch c {
-		case ';':
-			b.WriteByte('\n')
-			for j := 0; j < depth; j++ {
-				b.WriteString("    ")
-			}
-			// Skip following space
-			i++
-
-		case '{':
-			if i == len(s)-1 {
-				// This should never happen, but in case it
-				// does give up
-				return s
-			}
-
-			n := s[i+1]
-			if n == '}' {
-				// Do not modify {}
-				b.WriteString("{}")
-				// We have already written }, so skip
-				i++
-			} else {
-				// We expect fields to follow, insert a newline and space
-				depth++
-				b.WriteString(" {\n")
-				for j := 0; j < depth; j++ {
-					b.WriteString("    ")
-				}
-			}
-
-		case '}':
-			depth--
-			if depth < 0 {
-				return s
-			}
-			b.WriteString("\n}")
-
-		default:
-			b.WriteByte(c)
-		}
-	}
-	return b.String()
 }
 
 func (h *LangHandler) handleHoverGodef(ctx context.Context, conn jsonrpc2.JSONRPC2, req *jsonrpc2.Request, params lsp.TextDocumentPositionParams) (*lsp.Hover, error) {

--- a/langserver/hover.go
+++ b/langserver/hover.go
@@ -32,7 +32,8 @@ func (h *LangHandler) handleHover(ctx context.Context, conn jsonrpc2.JSONRPC2, r
 	if res.Package != nil {
 		// res.Package.Name is invalid since it was imported with FindOnly, so
 		// import normally now.
-		bpkg, err := bctx.Import(res.Package.ImportPath, res.Package.Dir, 0)
+		findPackage := h.getFindPackageFunc()
+		bpkg, err := findPackage(ctx, bctx, res.Package.ImportPath, res.Package.Dir, 0)
 		if err != nil {
 			return nil, err
 		}

--- a/langserver/hover.go
+++ b/langserver/hover.go
@@ -18,35 +18,6 @@ import (
 )
 
 func (h *LangHandler) handleHover(ctx context.Context, conn jsonrpc2.JSONRPC2, req *jsonrpc2.Request, params lsp.TextDocumentPositionParams) (*lsp.Hover, error) {
-	return h.handleHoverGodef(ctx, conn, req, params)
-}
-
-// maybeAddComments appends the specified comments converted to Markdown godoc
-// form to the specified contents slice, if the comments string is not empty.
-func maybeAddComments(comments string, contents []lsp.MarkedString) []lsp.MarkedString {
-	if comments == "" {
-		return contents
-	}
-	var b bytes.Buffer
-	doc.ToMarkdown(&b, comments, nil)
-	return append(contents, lsp.RawMarkedString(b.String()))
-}
-
-// packageDoc finds the documentation for the named package from its files or
-// additional files.
-func packageDoc(files []*ast.File, pkgName string) string {
-	for _, f := range files {
-		if f.Name.Name == pkgName {
-			txt := f.Doc.Text()
-			if strings.TrimSpace(txt) != "" {
-				return txt
-			}
-		}
-	}
-	return ""
-}
-
-func (h *LangHandler) handleHoverGodef(ctx context.Context, conn jsonrpc2.JSONRPC2, req *jsonrpc2.Request, params lsp.TextDocumentPositionParams) (*lsp.Hover, error) {
 	bctx := h.BuildContext(ctx)
 
 	// First perform the equivalent of a textDocument/definition request in
@@ -127,6 +98,31 @@ func (h *LangHandler) handleHoverGodef(ctx context.Context, conn jsonrpc2.JSONRP
 		Contents: contents,
 		Range:    &r,
 	}, nil
+}
+
+// maybeAddComments appends the specified comments converted to Markdown godoc
+// form to the specified contents slice, if the comments string is not empty.
+func maybeAddComments(comments string, contents []lsp.MarkedString) []lsp.MarkedString {
+	if comments == "" {
+		return contents
+	}
+	var b bytes.Buffer
+	doc.ToMarkdown(&b, comments, nil)
+	return append(contents, lsp.RawMarkedString(b.String()))
+}
+
+// packageDoc finds the documentation for the named package from its files or
+// additional files.
+func packageDoc(files []*ast.File, pkgName string) string {
+	for _, f := range files {
+		if f.Name.Name == pkgName {
+			txt := f.Doc.Text()
+			if strings.TrimSpace(txt) != "" {
+				return txt
+			}
+		}
+	}
+	return ""
 }
 
 // packageForFile returns the import path and pkg from pkgs that contains the

--- a/langserver/internal/godef/go/types/types.go
+++ b/langserver/internal/godef/go/types/types.go
@@ -76,9 +76,14 @@ func predecl(name string) *ast.Ident {
 
 type Importer func(path string, srcDir string) *ast.Package
 
+var test bool
+
 // DefaultImporter looks for the package; if it finds it,
 // it parses and returns it. If no package was found, it returns nil.
 func DefaultImporter(fset *token.FileSet) func(path string, srcDir string) *ast.Package {
+	if !test {
+		panic("do not use this")
+	}
 	return func(path string, srcDir string) *ast.Package {
 		bpkg, err := build.Default.Import(path, srcDir, 0)
 		if err != nil {
@@ -121,6 +126,9 @@ func DefaultImporter(fset *token.FileSet) func(path string, srcDir string) *ast.
 // DefaultImportPathToName returns the package identifier
 // for the given import path.
 func DefaultImportPathToName(path, srcDir string) (string, error) {
+	if !test {
+		panic("do not use this")
+	}
 	if path == "C" {
 		return "C", nil
 	}

--- a/langserver/internal/godef/go/types/types_test.go
+++ b/langserver/internal/godef/go/types/types_test.go
@@ -19,6 +19,10 @@ import (
 
 var testStdlib = flag.Bool("test-stdlib", false, "test all symbols in standard library (will fail)")
 
+func init() {
+	test = true
+}
+
 // TODO recursive types avoiding infinite loop.
 // e.g.
 // type A struct {*A}

--- a/langserver/internal/godef/parser_kludge.go
+++ b/langserver/internal/godef/parser_kludge.go
@@ -1,0 +1,113 @@
+package godef
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"go/ast"
+	"go/token"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/sourcegraph/ctxvfs"
+	"github.com/sourcegraph/go-langserver/langserver/internal/godef/go/parser"
+)
+
+// This file contains mostly copied functions from ./go/parser/interface.go but
+// modified to use only ctxvfs instead of os filesystem. We can't use the same
+// implementation we use in e.g. functions like /langserver/symbol.go:parseDir
+// because the ./go/parser signatures differ quite a lot.
+//
+// TODO: To remove this, we'll have to replace ./go/parser with stdlib
+// go/parser outright.
+
+func readSource(ctx context.Context, fs ctxvfs.FileSystem, filename string, src interface{}) ([]byte, error) {
+	if src != nil {
+		switch s := src.(type) {
+		case string:
+			return []byte(s), nil
+		case []byte:
+			return s, nil
+		case *bytes.Buffer:
+			// is io.Reader, but src is already available in []byte form
+			if s != nil {
+				return s.Bytes(), nil
+			}
+		case io.Reader:
+			var buf bytes.Buffer
+			_, err := io.Copy(&buf, s)
+			if err != nil {
+				return nil, err
+			}
+			return buf.Bytes(), nil
+		default:
+			return nil, errors.New("invalid source")
+		}
+	}
+
+	return ctxvfs.ReadFile(ctx, fs, filename)
+}
+
+func parseFile(ctx context.Context, fs ctxvfs.FileSystem, fset *token.FileSet, filename string, src interface{}, mode uint, pkgScope *ast.Scope, pathToName parser.ImportPathToName) (*ast.File, error) {
+	src, err := ctxvfs.ReadFile(ctx, fs, filename)
+	if err != nil {
+		return nil, err
+	}
+	return parser.ParseFile(fset, filename, src, mode, pkgScope, pathToName)
+}
+
+func parseFileInPkg(ctx context.Context, fs ctxvfs.FileSystem, fset *token.FileSet, pkgs map[string]*ast.Package, filename string, mode uint, pathToName parser.ImportPathToName) (err error) {
+	data, err := readSource(ctx, fs, filename, nil)
+	if err != nil {
+		return err
+	}
+	// first find package name, so we can use the correct package
+	// scope when parsing the file.
+	src, err := parseFile(ctx, fs, fset, filename, data, parser.PackageClauseOnly, nil, pathToName)
+	if err != nil {
+		return
+	}
+	name := src.Name.Name
+	pkg := pkgs[name]
+	if pkg == nil {
+		pkg = &ast.Package{name, ast.NewScope(parser.Universe), nil, make(map[string]*ast.File)}
+		pkgs[name] = pkg
+	}
+	src, err = parseFile(ctx, fs, fset, filename, data, mode, pkg.Scope, pathToName)
+	if err != nil {
+		return
+	}
+	pkg.Files[filename] = src
+	return
+}
+
+func parseFiles(ctx context.Context, fs ctxvfs.FileSystem, fset *token.FileSet, filenames []string, mode uint, pathToName parser.ImportPathToName) (pkgs map[string]*ast.Package, first error) {
+	pkgs = make(map[string]*ast.Package)
+	for _, filename := range filenames {
+		if err := parseFileInPkg(ctx, fs, fset, pkgs, filename, mode, pathToName); err != nil && first == nil {
+			first = err
+		}
+	}
+	return
+}
+
+func parseDir(ctx context.Context, fs ctxvfs.FileSystem, fset *token.FileSet, path string, filter func(os.FileInfo) bool, mode uint, pathToName parser.ImportPathToName) (map[string]*ast.Package, error) {
+	list, err := fs.ReadDir(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+
+	filenames := make([]string, len(list))
+	n := 0
+	for i := 0; i < len(list); i++ {
+		d := list[i]
+		if filter == nil || filter(d) {
+			filenames[n] = filepath.Join(path, d.Name())
+			n++
+		}
+	}
+	filenames = filenames[0:n]
+
+	return parseFiles(ctx, fs, fset, filenames, mode, pathToName)
+}

--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -1111,15 +1111,18 @@ func lspTests(t testing.TB, ctx context.Context, fs *AtomicFS, c *jsonrpc2.Conn,
 		build.Default.GOPATH = tmpDir
 		tmpRootPath := filepath.Join(tmpDir, rootPath)
 
-		// Install all Go packages in the $GOPATH.
-		oldGOPATH := os.Getenv("GOPATH")
-		os.Setenv("GOPATH", tmpDir)
-		out, err := exec.Command("go", "install", "-v", "...").CombinedOutput()
-		os.Setenv("GOPATH", oldGOPATH)
-		if err != nil {
-			t.Fatal(err)
+		BuildGoPackage = func(path string) error {
+			// Install all Go packages in the $GOPATH.
+			oldGOPATH := os.Getenv("GOPATH")
+			os.Setenv("GOPATH", tmpDir)
+			out, err := exec.Command("go", "install", "-v", path).CombinedOutput()
+			os.Setenv("GOPATH", oldGOPATH)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Logf("$ go install -v %s\n%s", path, out)
+			return nil
 		}
-		t.Logf("$ go install -v ...\n%s", out)
 
 		testOSToVFSPath = func(osPath string) string {
 			return strings.TrimPrefix(osPath, tmpDir)

--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -37,15 +37,8 @@ func TestServer(t *testing.T) {
 				"b.go": "package p; func B() { A() }",
 			},
 			cases: lspTestCases{
-				overrideGodefHover: map[string]string{
-					//"a.go:1:9":  "package p", // TODO(slimsag): sub-optimal "no declaration found for p"
-					"a.go:1:17": "func A()",
-					"a.go:1:23": "func A()",
-					"b.go:1:17": "func B()",
-					"b.go:1:23": "func A()",
-				},
 				wantHover: map[string]string{
-					"a.go:1:9":  "package p",
+					//"a.go:1:9":  "package p", // TODO(slimsag): sub-optimal "no declaration found for p"
 					"a.go:1:17": "func A()",
 					"a.go:1:23": "func A()",
 					"b.go:1:17": "func B()",
@@ -131,18 +124,10 @@ func TestServer(t *testing.T) {
 				"a.go": "package p; type T struct { F string }",
 			},
 			cases: lspTestCases{
-				overrideGodefHover: map[string]string{
-					// "a.go:1:28": "(T).F string", // TODO(sqs): see golang/hover.go; this is the output we want
-					"a.go:1:28": "struct field F string",
-					"a.go:1:17": `type T struct; struct{ F string }`,
-				},
-
 				wantHover: map[string]string{
 					// "a.go:1:28": "(T).F string", // TODO(sqs): see golang/hover.go; this is the output we want
 					"a.go:1:28": "struct field F string",
-					"a.go:1:17": `type T struct; struct {
-    F string
-}`,
+					"a.go:1:17": `type T struct; struct{ F string }`,
 				},
 				wantSymbols: map[string][]string{
 					"a.go": []string{"/src/test/pkg/a.go:class:T:1:17"},
@@ -181,19 +166,11 @@ func TestServer(t *testing.T) {
 				"b_test.go": "package p; func Y() int { return X }",
 			},
 			cases: lspTestCases{
-				overrideGodefHover: map[string]string{
+				wantHover: map[string]string{
 					"a.go:1:16":      "var A int",
 					"x_test.go:1:40": "var X = p.A",
 					"x_test.go:1:46": "var A int",
 					"a_test.go:1:16": "var X = A",
-					"a_test.go:1:20": "var A int",
-				},
-
-				wantHover: map[string]string{
-					"a.go:1:16":      "var A int",
-					"x_test.go:1:40": "var X int",
-					"x_test.go:1:46": "var A int",
-					"a_test.go:1:16": "var X int",
 					"a_test.go:1:20": "var A int",
 				},
 				wantSymbols: map[string][]string{
@@ -244,12 +221,8 @@ func TestServer(t *testing.T) {
 				"c/c.go":    `package c; import "test/pkg/b"; var X = b.B;`,
 			},
 			cases: lspTestCases{
-				overrideGodefHover: map[string]string{
-					"a_test.go:1:37": "var X = b.B",
-					"a_test.go:1:43": "var B int",
-				},
 				wantHover: map[string]string{
-					"a_test.go:1:37": "var X int",
+					"a_test.go:1:37": "var X = b.B",
 					"a_test.go:1:43": "var B int",
 				},
 				wantReferences: map[string][]string{
@@ -424,13 +397,9 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 					"a.go:1:40": "func Println(a ...interface{}) (n int, err error)",
 					// "a.go:1:53": "type int int",
 				},
-				overrideGodefDefinition: map[string]string{
-					"a.go:1:40": "/goroot/src/fmt/print.go:1:19-1:26",
-					"a.go:1:53": "/goroot/src/builtin/builtin.go:1:1-1:1", // TODO: accurate builtin positions
-				},
 				wantDefinition: map[string]string{
 					"a.go:1:40": "/goroot/src/fmt/print.go:1:19-1:26",
-					// "a.go:1:53": "/goroot/src/builtin/builtin.go:TODO:TODO", // TODO(sqs): support builtins
+					"a.go:1:53": "/goroot/src/builtin/builtin.go:1:1-1:1", // TODO: accurate builtin positions
 				},
 				wantXDefinition: map[string]string{
 					"a.go:1:40": "/goroot/src/fmt/print.go:1:19 id:fmt/-/Println name:Println package:fmt packageName:fmt recv: vendor:false",
@@ -695,12 +664,8 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 				},
 			},
 			cases: lspTestCases{
-				overrideGodefHover: map[string]string{
-					"a.go:1:53": "func D1() dep2.D2",
-					"a.go:1:59": "struct field D2 int",
-				},
 				wantHover: map[string]string{
-					"a.go:1:53": "func D1() D2",
+					"a.go:1:53": "func D1() dep2.D2",
 					"a.go:1:59": "struct field D2 int",
 				},
 				wantDefinition: map[string]string{
@@ -815,7 +780,7 @@ type Header struct {
 `,
 			},
 			cases: lspTestCases{
-				overrideGodefHover: map[string]string{
+				wantHover: map[string]string{
 					//"a.go:7:9": "package p; Package p is a package with lots of great things. \n\n", // TODO(slimsag): sub-optimal "no declaration found for p"
 					//"a.go:9:9": "", TODO: handle hovering on import statements (ast.BasicLit)
 					"a.go:12:5":  "var logit = pkg2.X; logit is pkg2.X \n\n",
@@ -827,19 +792,6 @@ type Header struct {
 					"a.go:20:4":  "package pkg2 (\"test/pkg/vendor/github.com/a/pkg2\"); Package pkg2 shows dependencies. \n\nHow to \n\n```\nExample Code!\n\n```\n",
 					"a.go:24:5":  "var Foo string; Foo is the best string. \n\n",
 					"a.go:31:2":  "var I2 = 3; I2 is an int \n\n",
-				},
-				wantHover: map[string]string{
-					"a.go:7:9": "package p; Package p is a package with lots of great things. \n\n",
-					//"a.go:9:9": "", TODO: handle hovering on import statements (ast.BasicLit)
-					"a.go:12:5":  "var logit func(); logit is pkg2.X \n\n",
-					"a.go:12:13": "package pkg2 (\"test/pkg/vendor/github.com/a/pkg2\"); Package pkg2 shows dependencies. \n\nHow to \n\n```\nExample Code!\n\n```\n",
-					"a.go:12:18": "func X(); X does the unknown. \n\n",
-					"a.go:15:6":  "type T struct; T is a struct. \n\n; struct {\n    F string\n    H Header\n}",
-					"a.go:17:2":  "struct field F string; F is a string field. \n\n",
-					"a.go:20:2":  "struct field H test/pkg/vendor/github.com/a/pkg2.Header; H is a header. \n\n",
-					"a.go:20:4":  "package pkg2 (\"test/pkg/vendor/github.com/a/pkg2\"); Package pkg2 shows dependencies. \n\nHow to \n\n```\nExample Code!\n\n```\n",
-					"a.go:24:5":  "var Foo string; Foo is the best string. \n\n",
-					"a.go:31:2":  "var I2 int; I2 is an int \n\n",
 				},
 			},
 		},
@@ -1011,15 +963,15 @@ func dialServer(t testing.TB, addr string) *jsonrpc2.Conn {
 }
 
 type lspTestCases struct {
-	wantHover, overrideGodefHover           map[string]string
-	wantDefinition, overrideGodefDefinition map[string]string
-	wantXDefinition                         map[string]string
-	wantReferences                          map[string][]string
-	wantSymbols                             map[string][]string
-	wantWorkspaceSymbols                    map[*lspext.WorkspaceSymbolParams][]string
-	wantSignatures                          map[string]string
-	wantWorkspaceReferences                 map[*lspext.WorkspaceReferencesParams][]string
-	wantFormatting                          map[string]string
+	wantHover               map[string]string
+	wantDefinition          map[string]string
+	wantXDefinition         map[string]string
+	wantReferences          map[string][]string
+	wantSymbols             map[string][]string
+	wantWorkspaceSymbols    map[*lspext.WorkspaceSymbolParams][]string
+	wantSignatures          map[string]string
+	wantWorkspaceReferences map[*lspext.WorkspaceReferencesParams][]string
+	wantFormatting          map[string]string
 }
 
 func copyFileToOS(ctx context.Context, fs *AtomicFS, targetFile, srcFile string) error {
@@ -1072,34 +1024,6 @@ func lspTests(t testing.TB, ctx context.Context, fs *AtomicFS, c *jsonrpc2.Conn,
 		tbRun(t, fmt.Sprintf("hover-%s", strings.Replace(pos, "/", "-", -1)), func(t testing.TB) {
 			hoverTest(t, ctx, c, rootPath, pos, want)
 		})
-	}
-
-	// Godef-based definition & hover testing
-	wantGodefDefinition := cases.overrideGodefDefinition
-	if len(wantGodefDefinition) == 0 {
-		wantGodefDefinition = cases.wantDefinition
-	}
-	wantGodefHover := cases.overrideGodefHover
-	if len(wantGodefHover) == 0 {
-		wantGodefHover = cases.wantHover
-	}
-
-	if len(wantGodefDefinition) > 0 || (len(wantGodefHover) > 0 && fs != nil) {
-		UseBinaryPkgCache = true
-
-		// Run the tests.
-		for pos, want := range wantGodefDefinition {
-			tbRun(t, fmt.Sprintf("godef-definition-%s", strings.Replace(pos, "/", "-", -1)), func(t testing.TB) {
-				definitionTest(t, ctx, c, rootPath, pos, want)
-			})
-		}
-		for pos, want := range wantGodefHover {
-			tbRun(t, fmt.Sprintf("godef-hover-%s", strings.Replace(pos, "/", "-", -1)), func(t testing.TB) {
-				hoverTest(t, ctx, c, rootPath, pos, want)
-			})
-		}
-
-		UseBinaryPkgCache = false
 	}
 
 	for pos, want := range cases.wantDefinition {

--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -1148,11 +1148,6 @@ func lspTests(t testing.TB, ctx context.Context, fs *AtomicFS, c *jsonrpc2.Conn,
 			definitionTest(t, ctx, c, rootPath, pos, want, "")
 		})
 	}
-	for pos, want := range cases.wantDefinition {
-		tbRun(t, fmt.Sprintf("definition-%s", strings.Replace(pos, "/", "-", -1)), func(t testing.TB) {
-			definitionTest(t, ctx, c, rootPath, pos, want, "")
-		})
-	}
 	for pos, want := range cases.wantXDefinition {
 		tbRun(t, fmt.Sprintf("xdefinition-%s", strings.Replace(pos, "/", "-", -1)), func(t testing.TB) {
 			xdefinitionTest(t, ctx, c, rootPath, pos, want)

--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -5,11 +5,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net"
 	"os"
 	"path"
-	"path/filepath"
 	"reflect"
 	"runtime"
 	"sort"
@@ -972,50 +970,6 @@ type lspTestCases struct {
 	wantSignatures          map[string]string
 	wantWorkspaceReferences map[*lspext.WorkspaceReferencesParams][]string
 	wantFormatting          map[string]string
-}
-
-func copyFileToOS(ctx context.Context, fs *AtomicFS, targetFile, srcFile string) error {
-	src, err := fs.Open(ctx, srcFile)
-	if err != nil {
-		return err
-	}
-	defer src.Close()
-
-	dst, err := os.Create(targetFile)
-	if err != nil {
-		return err
-	}
-	defer dst.Close()
-
-	_, err = io.Copy(dst, src)
-	return err
-}
-
-func copyDirToOS(ctx context.Context, fs *AtomicFS, targetDir, srcDir string) error {
-	if err := os.Mkdir(targetDir, 0777); err != nil && !os.IsExist(err) {
-		return err
-	}
-	files, err := fs.ReadDir(ctx, srcDir)
-	if err != nil {
-		return err
-	}
-	for _, fi := range files {
-		targetPath := filepath.Join(targetDir, fi.Name())
-		srcPath := path.Join(srcDir, fi.Name())
-		if fi.IsDir() {
-			err := copyDirToOS(ctx, fs, targetPath, srcPath)
-			if err != nil {
-				return err
-			}
-			continue
-		}
-
-		err := copyFileToOS(ctx, fs, targetPath, srcPath)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 // lspTests runs all test suites for LSP functionality.

--- a/main.go
+++ b/main.go
@@ -27,7 +27,7 @@ var (
 	printVersion      = flag.Bool("version", false, "print version and exit")
 	pprof             = flag.String("pprof", ":6060", "start a pprof http server (https://golang.org/pkg/net/http/pprof/)")
 	freeosmemory      = flag.Bool("freeosmemory", true, "aggressively free memory back to the OS")
-	usebinarypkgcache = flag.Bool("usebinarypkgcache", true, "use $GOPATH/pkg binary .a files (improves performance)")
+	usebinarypkgcache = flag.Bool("usebinarypkgcache", true, "deprecated / ignored")
 	maxparallelism    = flag.Int("maxparallelism", -1, "use at max N parallel goroutines to fulfill requests")
 )
 
@@ -52,7 +52,7 @@ func main() {
 	if *freeosmemory {
 		go freeOSMemory()
 	}
-	langserver.UseBinaryPkgCache = *usebinarypkgcache
+	langserver.UsePremptiveTypechecking = true
 
 	// Default max parallelism to half the CPU cores, but at least always one.
 	if *maxparallelism <= 0 {


### PR DESCRIPTION
Overview:

1. Remove unnecessary code / perform general cleanups.
2. Perform 100% of 'godef' hover/definition file IO through VFS. **Important: godef doesn't use .a files (and never has, I was wrong about this before).**
3. Unify our `textDocument/hover` and `textDocument/definition` endpoints: we used to have one of each based on godef (for editors), and another based on typechecking (for sourcegraph.com); we now just have the godef one for both cases. It's better all around, but especially in terms of performance.

Q&A

- Q: Why do some early commits reference a callback for 'go install'ing packages?
  - A: This was an early approach, but was removed later on (see more recent commits). I found out it wasn't needed, because godef doesn't use the `.a` files at all.
- Q: Does godef really not use .a files? What makes it fast?
  - A: Please see commit description https://github.com/sourcegraph/go-langserver/commit/c4e866ee63f1619581aa15b6fbb598023364d00b

Notes

- `textDocument/xdefinition` still uses typechecking, and can/should probably be updated to match this new approach.
- drawback: The godef-based hover implementation (which will be used on sourcegraph.com after this change) is based on `go/doc` which means it doesn't support e.g. hovering over a variable defined inside a function. We can fix this in the long run with a better pure AST implementation.