### PR TITLE
prefer rootUri field to rootPath

### DIFF
--- a/langserver/definition.go
+++ b/langserver/definition.go
@@ -91,7 +91,7 @@ func (h *LangHandler) handleXDefinition(ctx context.Context, conn jsonrpc2.JSONR
 		}
 	}
 
-	rootPath := h.FilePath(h.init.RootPath)
+	rootPath := h.FilePath(h.init.Root())
 	bctx := h.BuildContext(ctx)
 
 	fset, node, pathEnclosingInterval, _, pkg, _, err := h.typecheck(ctx, conn, params.TextDocument.URI, params.Position)

--- a/langserver/handler_common.go
+++ b/langserver/handler_common.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/sourcegraph/go-langserver/pkg/lsp"
 )
 
 // HandlerCommon contains functionality that both the build and lang
@@ -20,14 +21,14 @@ type HandlerCommon struct {
 	tracer     opentracing.Tracer
 }
 
-func (h *HandlerCommon) Reset(rootURI string) error {
+func (h *HandlerCommon) Reset(rootURI lsp.DocumentURI) error {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	if h.shutdown {
 		return errors.New("unable to reset a server that is shutting down")
 	}
 	if !isFileURI(rootURI) {
-		return fmt.Errorf("invalid root path %q: must be file:/// URI", rootURI)
+		return fmt.Errorf("invalid root URI %q: must be file:/// URI", rootURI)
 	}
 	h.RootFSPath = uriToFilePath(rootURI) // retain leading slash
 	return nil

--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -28,13 +28,13 @@ import (
 
 func TestServer(t *testing.T) {
 	tests := map[string]struct {
-		rootPath string
-		fs       map[string]string
-		mountFS  map[string]map[string]string // mount dir -> map VFS
-		cases    lspTestCases
+		rootURI lsp.DocumentURI
+		fs      map[string]string
+		mountFS map[string]map[string]string // mount dir -> map VFS
+		cases   lspTestCases
 	}{
 		"go basic": {
-			rootPath: "file:///src/test/pkg",
+			rootURI: "file:///src/test/pkg",
 			fs: map[string]string{
 				"a.go": "package p; func A() { A() }",
 				"b.go": "package p; func B() { A() }",
@@ -129,7 +129,7 @@ func TestServer(t *testing.T) {
 			},
 		},
 		"go detailed": {
-			rootPath: "file:///src/test/pkg",
+			rootURI: "file:///src/test/pkg",
 			fs: map[string]string{
 				"a.go": "package p; type T struct { F string }",
 			},
@@ -159,7 +159,7 @@ func TestServer(t *testing.T) {
 			},
 		},
 		"exported defs unexported type": {
-			rootPath: "file:///src/test/pkg",
+			rootURI: "file:///src/test/pkg",
 			fs: map[string]string{
 				"a.go": "package p; type t struct { F string }",
 			},
@@ -173,7 +173,7 @@ func TestServer(t *testing.T) {
 			},
 		},
 		"go xtest": {
-			rootPath: "file:///src/test/pkg",
+			rootURI: "file:///src/test/pkg",
 			fs: map[string]string{
 				"a.go":      "package p; var A int",
 				"x_test.go": `package p_test; import "test/pkg"; var X = p.A`,
@@ -239,7 +239,7 @@ func TestServer(t *testing.T) {
 			},
 		},
 		"go test": {
-			rootPath: "file:///src/test/pkg",
+			rootURI: "file:///src/test/pkg",
 			fs: map[string]string{
 				"a.go":      "package p; var A int",
 				"a_test.go": `package p; import "test/pkg/b"; var X = b.B; func TestB() {}`,
@@ -273,7 +273,7 @@ func TestServer(t *testing.T) {
 			},
 		},
 		"go subdirectory in repo": {
-			rootPath: "file:///src/test/pkg/d",
+			rootURI: "file:///src/test/pkg/d",
 			fs: map[string]string{
 				"a.go":    "package d; func A() { A() }",
 				"d2/b.go": `package d2; import "test/pkg/d"; func B() { d.A(); B() }`,
@@ -370,7 +370,7 @@ func TestServer(t *testing.T) {
 			},
 		},
 		"go multiple packages in dir": {
-			rootPath: "file:///src/test/pkg",
+			rootURI: "file:///src/test/pkg",
 			fs: map[string]string{
 				"a.go": "package p; func A() { A() }",
 				"main.go": `// +build ignore
@@ -412,7 +412,7 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 			},
 		},
 		"goroot": {
-			rootPath: "file:///src/test/pkg",
+			rootURI: "file:///src/test/pkg",
 			fs: map[string]string{
 				"a.go": `package p; import "fmt"; var _ = fmt.Println; var x int`,
 			},
@@ -465,7 +465,7 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 			},
 		},
 		"gopath": {
-			rootPath: "file:///src/test/pkg",
+			rootURI: "file:///src/test/pkg",
 			fs: map[string]string{
 				"a/a.go": `package a; func A() {}`,
 				"b/b.go": `package b; import "test/pkg/a"; var _ = a.A`,
@@ -516,7 +516,7 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 			},
 		},
 		"go vendored dep": {
-			rootPath: "file:///src/test/pkg",
+			rootURI: "file:///src/test/pkg",
 			fs: map[string]string{
 				"a.go": `package a; import "github.com/v/vendored"; var _ = vendored.V`,
 				"vendor/github.com/v/vendored/v.go": "package vendored; func V() {}",
@@ -558,7 +558,7 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 			},
 		},
 		"go vendor symbols with same name": {
-			rootPath: "file:///src/test/pkg",
+			rootURI: "file:///src/test/pkg",
 			fs: map[string]string{
 				"z.go": `package pkg; func x() bool { return true }`,
 				"vendor/github.com/a/pkg2/x.go": `package pkg2; func x() bool { return true }`,
@@ -596,7 +596,7 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 			},
 		},
 		"go external dep": {
-			rootPath: "file:///src/test/pkg",
+			rootURI: "file:///src/test/pkg",
 			fs: map[string]string{
 				"a.go": `package a; import "github.com/d/dep"; var _ = dep.D; var _ = dep.D`,
 			},
@@ -634,7 +634,7 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 			},
 		},
 		"external dep with vendor": {
-			rootPath: "file:///src/test/pkg",
+			rootURI: "file:///src/test/pkg",
 			fs: map[string]string{
 				"a.go": `package p; import "github.com/d/dep"; var _ = dep.D().F`,
 			},
@@ -661,7 +661,7 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 			},
 		},
 		"go external dep at subtree": {
-			rootPath: "file:///src/test/pkg",
+			rootURI: "file:///src/test/pkg",
 			fs: map[string]string{
 				"a.go": `package a; import "github.com/d/dep/subp"; var _ = subp.D`,
 			},
@@ -689,7 +689,7 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 			},
 		},
 		"go nested external dep": { // a depends on dep1, dep1 depends on dep2
-			rootPath: "file:///src/test/pkg",
+			rootURI: "file:///src/test/pkg",
 			fs: map[string]string{
 				"a.go": `package a; import "github.com/d/dep1"; var _ = dep1.D1().D2`,
 			},
@@ -728,7 +728,7 @@ package main; import "test/pkg"; func B() { p.A(); B() }`,
 			},
 		},
 		"go symbols": {
-			rootPath: "file:///src/test/pkg",
+			rootURI: "file:///src/test/pkg",
 			fs: map[string]string{
 				"abc.go": `package a
 
@@ -764,7 +764,7 @@ func yza() {}
 			},
 		},
 		"go hover docs": {
-			rootPath: "file:///src/test/pkg",
+			rootURI: "file:///src/test/pkg",
 			fs: map[string]string{
 				"a.go": `// Copyright 2015 someone.
 // Copyrights often span multiple lines.
@@ -851,7 +851,7 @@ type Header struct {
 			},
 		},
 		"workspace references multiple files": {
-			rootPath: "file:///src/test/pkg",
+			rootURI: "file:///src/test/pkg",
 			fs: map[string]string{
 				"a.go": `package p; import "fmt"; var _ = fmt.Println; var x int`,
 				"b.go": `package p; import "fmt"; var _ = fmt.Println; var y int`,
@@ -877,7 +877,7 @@ type Header struct {
 			},
 		},
 		"signatures": {
-			rootPath: "file:///src/test/pkg",
+			rootURI: "file:///src/test/pkg",
 			fs: map[string]string{
 				"a.go": `package p
 
@@ -909,7 +909,7 @@ type Header struct {
 		},
 		"unexpected paths": {
 			// notice the : and @ symbol
-			rootPath: "file:///src/t:est/@hello/pkg",
+			rootURI: "file:///src/t:est/@hello/pkg",
 			fs: map[string]string{
 				"a.go": "package p; func A() { A() }",
 			},
@@ -942,12 +942,12 @@ type Header struct {
 				}
 			}()
 
-			rootFSPath := uriToFilePath(test.rootPath)
+			rootFSPath := uriToFilePath(test.rootURI)
 
 			// Prepare the connection.
 			ctx := context.Background()
 			if err := conn.Call(ctx, "initialize", InitializeParams{
-				InitializeParams:     lsp.InitializeParams{RootPath: test.rootPath},
+				InitializeParams:     lsp.InitializeParams{RootURI: test.rootURI},
 				NoOSFileSystemAccess: true,
 				RootImportPath:       strings.TrimPrefix(rootFSPath, "/src/"),
 				BuildContext: &InitializeBuildContextParams{
@@ -968,7 +968,7 @@ type Header struct {
 			}
 			h.Mu.Unlock()
 
-			lspTests(t, ctx, h.FS, conn, rootFSPath, test.cases)
+			lspTests(t, ctx, h.FS, conn, test.rootURI, test.cases)
 		})
 	}
 }
@@ -1074,10 +1074,10 @@ func copyDirToOS(ctx context.Context, fs *AtomicFS, targetDir, srcDir string) er
 }
 
 // lspTests runs all test suites for LSP functionality.
-func lspTests(t testing.TB, ctx context.Context, fs *AtomicFS, c *jsonrpc2.Conn, rootPath string, cases lspTestCases) {
+func lspTests(t testing.TB, ctx context.Context, fs *AtomicFS, c *jsonrpc2.Conn, rootURI lsp.DocumentURI, cases lspTestCases) {
 	for pos, want := range cases.wantHover {
 		tbRun(t, fmt.Sprintf("hover-%s", strings.Replace(pos, "/", "-", -1)), func(t testing.TB) {
-			hoverTest(t, ctx, c, rootPath, pos, want)
+			hoverTest(t, ctx, c, rootURI, pos, want)
 		})
 	}
 
@@ -1109,7 +1109,7 @@ func lspTests(t testing.TB, ctx context.Context, fs *AtomicFS, c *jsonrpc2.Conn,
 		// look for $GOPATH/pkg .a files inside the $GOPATH that was set during
 		// 'go test' instead of our tmp directory.
 		build.Default.GOPATH = tmpDir
-		tmpRootPath := filepath.Join(tmpDir, rootPath)
+		tmpRootPath := filepath.Join(tmpDir, uriToFilePath(rootURI))
 
 		// Install all Go packages in the $GOPATH.
 		oldGOPATH := os.Getenv("GOPATH")
@@ -1131,12 +1131,12 @@ func lspTests(t testing.TB, ctx context.Context, fs *AtomicFS, c *jsonrpc2.Conn,
 				want = strings.Replace(want, "/goroot", build.Default.GOROOT, 1)
 			}
 			tbRun(t, fmt.Sprintf("godef-definition-%s", strings.Replace(pos, "/", "-", -1)), func(t testing.TB) {
-				definitionTest(t, ctx, c, tmpRootPath, pos, want, tmpDir)
+				definitionTest(t, ctx, c, pathToURI(tmpRootPath), pos, want, tmpDir)
 			})
 		}
 		for pos, want := range wantGodefHover {
 			tbRun(t, fmt.Sprintf("godef-hover-%s", strings.Replace(pos, "/", "-", -1)), func(t testing.TB) {
-				hoverTest(t, ctx, c, tmpRootPath, pos, want)
+				hoverTest(t, ctx, c, pathToURI(tmpRootPath), pos, want)
 			})
 		}
 
@@ -1145,53 +1145,53 @@ func lspTests(t testing.TB, ctx context.Context, fs *AtomicFS, c *jsonrpc2.Conn,
 
 	for pos, want := range cases.wantDefinition {
 		tbRun(t, fmt.Sprintf("definition-%s", strings.Replace(pos, "/", "-", -1)), func(t testing.TB) {
-			definitionTest(t, ctx, c, rootPath, pos, want, "")
+			definitionTest(t, ctx, c, rootURI, pos, want, "")
 		})
 	}
 	for pos, want := range cases.wantDefinition {
 		tbRun(t, fmt.Sprintf("definition-%s", strings.Replace(pos, "/", "-", -1)), func(t testing.TB) {
-			definitionTest(t, ctx, c, rootPath, pos, want, "")
+			definitionTest(t, ctx, c, rootURI, pos, want, "")
 		})
 	}
 	for pos, want := range cases.wantXDefinition {
 		tbRun(t, fmt.Sprintf("xdefinition-%s", strings.Replace(pos, "/", "-", -1)), func(t testing.TB) {
-			xdefinitionTest(t, ctx, c, rootPath, pos, want)
+			xdefinitionTest(t, ctx, c, rootURI, pos, want)
 		})
 	}
 
 	for pos, want := range cases.wantReferences {
 		tbRun(t, fmt.Sprintf("references-%s", pos), func(t testing.TB) {
-			referencesTest(t, ctx, c, rootPath, pos, want)
+			referencesTest(t, ctx, c, rootURI, pos, want)
 		})
 	}
 
 	for file, want := range cases.wantSymbols {
 		tbRun(t, fmt.Sprintf("symbols-%s", file), func(t testing.TB) {
-			symbolsTest(t, ctx, c, rootPath, file, want)
+			symbolsTest(t, ctx, c, rootURI, file, want)
 		})
 	}
 
 	for params, want := range cases.wantWorkspaceSymbols {
 		tbRun(t, fmt.Sprintf("workspaceSymbols(%v)", *params), func(t testing.TB) {
-			workspaceSymbolsTest(t, ctx, c, rootPath, *params, want)
+			workspaceSymbolsTest(t, ctx, c, rootURI, *params, want)
 		})
 	}
 
 	for pos, want := range cases.wantSignatures {
 		tbRun(t, fmt.Sprintf("signature-%s", strings.Replace(pos, "/", "-", -1)), func(t testing.TB) {
-			signatureTest(t, ctx, c, rootPath, pos, want)
+			signatureTest(t, ctx, c, rootURI, pos, want)
 		})
 	}
 
 	for params, want := range cases.wantWorkspaceReferences {
 		tbRun(t, fmt.Sprintf("workspaceReferences"), func(t testing.TB) {
-			workspaceReferencesTest(t, ctx, c, rootPath, *params, want)
+			workspaceReferencesTest(t, ctx, c, rootURI, *params, want)
 		})
 	}
 
 	for file, want := range cases.wantFormatting {
 		tbRun(t, fmt.Sprintf("formatting-%s", file), func(t testing.TB) {
-			formattingTest(t, ctx, c, rootPath, file, want)
+			formattingTest(t, ctx, c, rootURI, file, want)
 		})
 	}
 }
@@ -1208,12 +1208,16 @@ func tbRun(t testing.TB, name string, f func(testing.TB)) bool {
 	}
 }
 
-func hoverTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, rootPath string, pos, want string) {
+func uriJoin(base lsp.DocumentURI, file string) lsp.DocumentURI {
+	return lsp.DocumentURI(string(base) + "/" + file)
+}
+
+func hoverTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, rootURI lsp.DocumentURI, pos, want string) {
 	file, line, char, err := parsePos(pos)
 	if err != nil {
 		t.Fatal(err)
 	}
-	hover, err := callHover(ctx, c, pathToURI(path.Join(rootPath, file)), line, char)
+	hover, err := callHover(ctx, c, uriJoin(rootURI, file), line, char)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1222,16 +1226,16 @@ func hoverTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, rootPath str
 	}
 }
 
-func definitionTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, rootPath string, pos, want, trimPrefix string) {
+func definitionTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, rootURI lsp.DocumentURI, pos, want, trimPrefix string) {
 	file, line, char, err := parsePos(pos)
 	if err != nil {
 		t.Fatal(err)
 	}
-	definition, err := callDefinition(ctx, c, pathToURI(path.Join(rootPath, file)), line, char)
+	definition, err := callDefinition(ctx, c, uriJoin(rootURI, file), line, char)
 	if err != nil {
 		t.Fatal(err)
 	}
-	definition = uriToFilePath(definition)
+	definition = uriToFilePath(lsp.DocumentURI(definition))
 	if trimPrefix != "" {
 		definition = strings.TrimPrefix(definition, trimPrefix)
 	}
@@ -1240,32 +1244,32 @@ func definitionTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, rootPat
 	}
 }
 
-func xdefinitionTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, rootPath string, pos, want string) {
+func xdefinitionTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, rootURI lsp.DocumentURI, pos, want string) {
 	file, line, char, err := parsePos(pos)
 	if err != nil {
 		t.Fatal(err)
 	}
-	xdefinition, err := callXDefinition(ctx, c, pathToURI(path.Join(rootPath, file)), line, char)
+	xdefinition, err := callXDefinition(ctx, c, uriJoin(rootURI, file), line, char)
 	if err != nil {
 		t.Fatal(err)
 	}
-	xdefinition = uriToFilePath(xdefinition)
+	xdefinition = uriToFilePath(lsp.DocumentURI(xdefinition))
 	if xdefinition != want {
 		t.Errorf("\ngot  %q\nwant %q", xdefinition, want)
 	}
 }
 
-func referencesTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, rootPath string, pos string, want []string) {
+func referencesTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, rootURI lsp.DocumentURI, pos string, want []string) {
 	file, line, char, err := parsePos(pos)
 	if err != nil {
 		t.Fatal(err)
 	}
-	references, err := callReferences(ctx, c, pathToURI(path.Join(rootPath, file)), line, char)
+	references, err := callReferences(ctx, c, uriJoin(rootURI, file), line, char)
 	if err != nil {
 		t.Fatal(err)
 	}
 	for i := range references {
-		references[i] = uriToFilePath(references[i])
+		references[i] = uriToFilePath(lsp.DocumentURI(references[i]))
 	}
 	sort.Strings(references)
 	sort.Strings(want)
@@ -1274,38 +1278,38 @@ func referencesTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, rootPat
 	}
 }
 
-func symbolsTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, rootPath string, file string, want []string) {
-	symbols, err := callSymbols(ctx, c, pathToURI(path.Join(rootPath, file)))
+func symbolsTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, rootURI lsp.DocumentURI, file string, want []string) {
+	symbols, err := callSymbols(ctx, c, uriJoin(rootURI, file))
 	if err != nil {
 		t.Fatal(err)
 	}
 	for i := range symbols {
-		symbols[i] = uriToFilePath(symbols[i])
+		symbols[i] = uriToFilePath(lsp.DocumentURI(symbols[i]))
 	}
 	if !reflect.DeepEqual(symbols, want) {
 		t.Errorf("got %q, want %q", symbols, want)
 	}
 }
 
-func workspaceSymbolsTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, rootPath string, params lspext.WorkspaceSymbolParams, want []string) {
+func workspaceSymbolsTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, rootURI lsp.DocumentURI, params lspext.WorkspaceSymbolParams, want []string) {
 	symbols, err := callWorkspaceSymbols(ctx, c, params)
 	if err != nil {
 		t.Fatal(err)
 	}
 	for i := range symbols {
-		symbols[i] = uriToFilePath(symbols[i])
+		symbols[i] = uriToFilePath(lsp.DocumentURI(symbols[i]))
 	}
 	if !reflect.DeepEqual(symbols, want) {
 		t.Errorf("got %#v, want %q", symbols, want)
 	}
 }
 
-func signatureTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, rootPath string, pos, want string) {
+func signatureTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, rootURI lsp.DocumentURI, pos, want string) {
 	file, line, char, err := parsePos(pos)
 	if err != nil {
 		t.Fatal(err)
 	}
-	signature, err := callSignature(ctx, c, pathToURI(path.Join(rootPath, file)), line, char)
+	signature, err := callSignature(ctx, c, uriJoin(rootURI, file), line, char)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1314,7 +1318,7 @@ func signatureTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, rootPath
 	}
 }
 
-func workspaceReferencesTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, rootPath string, params lspext.WorkspaceReferencesParams, want []string) {
+func workspaceReferencesTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, rootURI lsp.DocumentURI, params lspext.WorkspaceReferencesParams, want []string) {
 	references, err := callWorkspaceReferences(ctx, c, params)
 	if err != nil {
 		t.Fatal(err)
@@ -1324,8 +1328,8 @@ func workspaceReferencesTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn
 	}
 }
 
-func formattingTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, rootPath string, file string, want string) {
-	edits, err := callFormatting(ctx, c, pathToURI(path.Join(rootPath, file)))
+func formattingTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, rootURI lsp.DocumentURI, file string, want string) {
+	edits, err := callFormatting(ctx, c, uriJoin(rootURI, file))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1367,7 +1371,7 @@ func parsePos(s string) (file string, line, char int, err error) {
 	return file, line - 1, char - 1, nil // LSP is 0-indexed
 }
 
-func callHover(ctx context.Context, c *jsonrpc2.Conn, uri string, line, char int) (string, error) {
+func callHover(ctx context.Context, c *jsonrpc2.Conn, uri lsp.DocumentURI, line, char int) (string, error) {
 	var res struct {
 		Contents markedStrings `json:"contents"`
 		lsp.Hover
@@ -1389,7 +1393,7 @@ func callHover(ctx context.Context, c *jsonrpc2.Conn, uri string, line, char int
 	return str, nil
 }
 
-func callDefinition(ctx context.Context, c *jsonrpc2.Conn, uri string, line, char int) (string, error) {
+func callDefinition(ctx context.Context, c *jsonrpc2.Conn, uri lsp.DocumentURI, line, char int) (string, error) {
 	var res locations
 	err := c.Call(ctx, "textDocument/definition", lsp.TextDocumentPositionParams{
 		TextDocument: lsp.TextDocumentIdentifier{URI: uri},
@@ -1411,7 +1415,7 @@ func callDefinition(ctx context.Context, c *jsonrpc2.Conn, uri string, line, cha
 	return str, nil
 }
 
-func callXDefinition(ctx context.Context, c *jsonrpc2.Conn, uri string, line, char int) (string, error) {
+func callXDefinition(ctx context.Context, c *jsonrpc2.Conn, uri lsp.DocumentURI, line, char int) (string, error) {
 	var res []lspext.SymbolLocationInformation
 	err := c.Call(ctx, "textDocument/xdefinition", lsp.TextDocumentPositionParams{
 		TextDocument: lsp.TextDocumentIdentifier{URI: uri},
@@ -1433,7 +1437,7 @@ func callXDefinition(ctx context.Context, c *jsonrpc2.Conn, uri string, line, ch
 	return str, nil
 }
 
-func callReferences(ctx context.Context, c *jsonrpc2.Conn, uri string, line, char int) ([]string, error) {
+func callReferences(ctx context.Context, c *jsonrpc2.Conn, uri lsp.DocumentURI, line, char int) ([]string, error) {
 	var res locations
 	err := c.Call(ctx, "textDocument/references", lsp.ReferenceParams{
 		Context: lsp.ReferenceContext{IncludeDeclaration: true},
@@ -1452,7 +1456,7 @@ func callReferences(ctx context.Context, c *jsonrpc2.Conn, uri string, line, cha
 	return str, nil
 }
 
-func callSymbols(ctx context.Context, c *jsonrpc2.Conn, uri string) ([]string, error) {
+func callSymbols(ctx context.Context, c *jsonrpc2.Conn, uri lsp.DocumentURI) ([]string, error) {
 	var symbols []lsp.SymbolInformation
 	err := c.Call(ctx, "textDocument/documentSymbol", lsp.DocumentSymbolParams{
 		TextDocument: lsp.TextDocumentIdentifier{URI: uri},
@@ -1503,7 +1507,7 @@ func callWorkspaceReferences(ctx context.Context, c *jsonrpc2.Conn, params lspex
 	return refs, nil
 }
 
-func callSignature(ctx context.Context, c *jsonrpc2.Conn, uri string, line, char int) (string, error) {
+func callSignature(ctx context.Context, c *jsonrpc2.Conn, uri lsp.DocumentURI, line, char int) (string, error) {
 	var res lsp.SignatureHelp
 	err := c.Call(ctx, "textDocument/signatureHelp", lsp.TextDocumentPositionParams{
 		TextDocument: lsp.TextDocumentIdentifier{URI: uri},
@@ -1526,7 +1530,7 @@ func callSignature(ctx context.Context, c *jsonrpc2.Conn, uri string, line, char
 	return str, nil
 }
 
-func callFormatting(ctx context.Context, c *jsonrpc2.Conn, uri string) ([]lsp.TextEdit, error) {
+func callFormatting(ctx context.Context, c *jsonrpc2.Conn, uri lsp.DocumentURI) ([]lsp.TextEdit, error) {
 	var edits []lsp.TextEdit
 	err := c.Call(ctx, "textDocument/formatting", lsp.DocumentFormattingParams{
 		TextDocument: lsp.TextDocumentIdentifier{URI: uri},

--- a/langserver/loader.go
+++ b/langserver/loader.go
@@ -21,7 +21,7 @@ import (
 	"golang.org/x/tools/go/loader"
 )
 
-func (h *LangHandler) typecheck(ctx context.Context, conn jsonrpc2.JSONRPC2, fileURI string, position lsp.Position) (*token.FileSet, *ast.Ident, []ast.Node, *loader.Program, *loader.PackageInfo, *token.Pos, error) {
+func (h *LangHandler) typecheck(ctx context.Context, conn jsonrpc2.JSONRPC2, fileURI lsp.DocumentURI, position lsp.Position) (*token.FileSet, *ast.Ident, []ast.Node, *loader.Program, *loader.PackageInfo, *token.Pos, error) {
 	parentSpan := opentracing.SpanFromContext(ctx)
 	span := parentSpan.Tracer().StartSpan("langserver-go: load program",
 		opentracing.Tags{"fileURI": fileURI},

--- a/langserver/loader_test.go
+++ b/langserver/loader_test.go
@@ -127,7 +127,7 @@ func TestLoaderDiagnostics(t *testing.T) {
 func setUpLoaderTest(fs map[string]string) (*token.FileSet, *build.Context, *build.Package) {
 	h := LangHandler{HandlerShared: new(HandlerShared)}
 	if err := h.reset(&InitializeParams{
-		InitializeParams:     lsp.InitializeParams{RootPath: "file:///src/p"},
+		InitializeParams:     lsp.InitializeParams{RootURI: "file:///src/p"},
 		NoOSFileSystemAccess: true,
 		BuildContext: &InitializeBuildContextParams{
 			GOPATH: "/",

--- a/langserver/partial.go
+++ b/langserver/partial.go
@@ -10,7 +10,7 @@ import "github.com/sourcegraph/go-langserver/pkg/lsp"
 type RewriteURIer interface {
 	// RewriteURI will update all URIs in the type using the rewrite
 	// function.
-	RewriteURI(rewrite func(string) string)
+	RewriteURI(rewrite func(lsp.DocumentURI) lsp.DocumentURI)
 }
 
 // referenceAddOp is a JSON Patch operation used by
@@ -25,7 +25,7 @@ type referenceAddOp struct {
 
 type referencePatch []referenceAddOp
 
-func (p referencePatch) RewriteURI(rewrite func(string) string) {
+func (p referencePatch) RewriteURI(rewrite func(lsp.DocumentURI) lsp.DocumentURI) {
 	for i := range p {
 		p[i].Value.URI = rewrite(p[i].Value.URI)
 	}
@@ -43,7 +43,7 @@ type xreferenceAddOp struct {
 
 type xreferencePatch []xreferenceAddOp
 
-func (p xreferencePatch) RewriteURI(rewrite func(string) string) {
+func (p xreferencePatch) RewriteURI(rewrite func(lsp.DocumentURI) lsp.DocumentURI) {
 	for i := range p {
 		p[i].Value.Reference.URI = rewrite(p[i].Value.Reference.URI)
 	}

--- a/langserver/references.go
+++ b/langserver/references.go
@@ -191,7 +191,7 @@ func (h *LangHandler) reverseImportGraph(ctx context.Context, conn jsonrpc2.JSON
 		// import graph across commits. We want this behaviour since
 		// we assume that they don't change drastically across
 		// commits.
-		cacheKey := "importgraph:" + h.init.RootPath
+		cacheKey := "importgraph:" + string(h.init.Root())
 
 		h.mu.Lock()
 		tryCache := h.importGraph == nil
@@ -219,7 +219,7 @@ func (h *LangHandler) reverseImportGraph(ctx context.Context, conn jsonrpc2.JSON
 			findPackage := func(bctx *build.Context, importPath, fromDir string, mode build.ImportMode) (*build.Package, error) {
 				return findPackageWithCtx(ctx, bctx, importPath, fromDir, mode)
 			}
-			g := tools.BuildReverseImportGraph(bctx, findPackage, h.FilePath(h.init.RootPath))
+			g := tools.BuildReverseImportGraph(bctx, findPackage, h.FilePath(h.init.Root()))
 			h.mu.Lock()
 			h.importGraph = g
 			h.mu.Unlock()

--- a/langserver/symbol.go
+++ b/langserver/symbol.go
@@ -324,7 +324,7 @@ func (h *LangHandler) handleWorkspaceSymbol(ctx context.Context, conn jsonrpc2.J
 		// id implicitly contains a dir hint. We can use that to
 		// reduce the number of files we have to parse.
 		importPath := strings.SplitN(id.(string), "/-/", 2)[0]
-		if isStdLib := PathHasPrefix(h.BuildContext(ctx).GOROOT, h.init.RootPath); isStdLib {
+		if isStdLib := PathHasPrefix(h.BuildContext(ctx).GOROOT, h.FilePath(h.init.Root())); isStdLib {
 			q.Dir = path.Join("/src", importPath)
 		} else {
 			q.Dir = importPath
@@ -349,7 +349,7 @@ var MaxParallelism = 8
 func (h *LangHandler) handleSymbol(ctx context.Context, conn jsonrpc2.JSONRPC2, req *jsonrpc2.Request, query Query, limit int) ([]lsp.SymbolInformation, error) {
 	results := resultSorter{Query: query, results: make([]scoredSymbol, 0)}
 	{
-		rootPath := h.FilePath(h.init.RootPath)
+		rootPath := h.FilePath(h.init.Root())
 		bctx := h.BuildContext(ctx)
 
 		par := parallel.NewRun(8)

--- a/langserver/util.go
+++ b/langserver/util.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"runtime"
 	"strings"
+
+	"github.com/sourcegraph/go-langserver/pkg/lsp"
 )
 
 func PathHasPrefix(s, prefix string) bool {
@@ -36,22 +38,22 @@ func IsVendorDir(dir string) bool {
 }
 
 // isFileURI tells if s denotes an absolute file URI.
-func isFileURI(s string) bool {
-	return strings.HasPrefix(s, "file:///")
+func isFileURI(s lsp.DocumentURI) bool {
+	return strings.HasPrefix(string(s), "file:///")
 }
 
 // pathToURI converts given absolute path to file URI
-func pathToURI(path string) string {
-	return "file://" + path
+func pathToURI(path string) lsp.DocumentURI {
+	return lsp.DocumentURI("file://" + path)
 }
 
 // uriToFilePath converts given absolute file URI to path. It panics if
 // uri does not begin with "file:///".
-func uriToFilePath(uri string) string {
+func uriToFilePath(uri lsp.DocumentURI) string {
 	if !isFileURI(uri) {
 		panic("not an absolute file URI: " + uri)
 	}
-	return strings.TrimPrefix(uri, "file://")
+	return strings.TrimPrefix(string(uri), "file://")
 }
 
 // panicf takes the return value of recover() and outputs data to the log with

--- a/langserver/workspace_refs.go
+++ b/langserver/workspace_refs.go
@@ -37,7 +37,7 @@ func (h *LangHandler) handleWorkspaceReferences(ctx context.Context, conn jsonrp
 	// See: https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md#cancelRequest
 	ctx, cancel := context.WithTimeout(ctx, workspaceReferencesTimeout)
 	defer cancel()
-	rootPath := h.FilePath(h.init.RootPath)
+	rootPath := h.FilePath(h.init.Root())
 	bctx := h.BuildContext(ctx)
 
 	// Perform typechecking.
@@ -60,7 +60,7 @@ func (h *LangHandler) handleWorkspaceReferences(ctx context.Context, conn jsonrp
 		if ok {
 			found := false
 			for _, dir := range dirs.([]interface{}) {
-				if pathToURI(bpkg.Dir) == dir.(string) {
+				if pathToURI(bpkg.Dir) == lsp.DocumentURI(dir.(string)) {
 					found = true
 					break
 				}

--- a/pkg/lsp/service.go
+++ b/pkg/lsp/service.go
@@ -9,11 +9,25 @@ import (
 type None struct{}
 
 type InitializeParams struct {
-	ProcessID             int                `json:"processId,omitempty"`
-	RootPath              string             `json:"rootPath,omitempty"`
+	ProcessID int `json:"processId,omitempty"`
+
+	// RootPath is DEPRECATED in favor of the RootURI field.
+	RootPath string `json:"rootPath,omitempty"`
+
+	RootURI               DocumentURI        `json:"rootUri,omitempty"`
 	InitializationOptions interface{}        `json:"initializationOptions,omitempty"`
 	Capabilities          ClientCapabilities `json:"capabilities"`
 }
+
+// Root returns the RootURI if set, or otherwise the RootPath with 'file://' prepended.
+func (p *InitializeParams) Root() DocumentURI {
+	if p.RootURI != "" {
+		return p.RootURI
+	}
+	return DocumentURI("file://" + p.RootPath)
+}
+
+type DocumentURI string
 
 type ClientCapabilities struct {
 	// Below are Sourcegraph extensions. They do not live in lspext since
@@ -447,8 +461,8 @@ const (
 )
 
 type FileEvent struct {
-	URI  string `json:"uri"`
-	Type int    `json:"type"`
+	URI  DocumentURI `json:"uri"`
+	Type int         `json:"type"`
 }
 
 type DidChangeWatchedFilesParams struct {
@@ -456,7 +470,7 @@ type DidChangeWatchedFilesParams struct {
 }
 
 type PublishDiagnosticsParams struct {
-	URI         string       `json:"uri"`
+	URI         DocumentURI  `json:"uri"`
 	Diagnostics []Diagnostic `json:"diagnostics"`
 }
 

--- a/pkg/lsp/structures.go
+++ b/pkg/lsp/structures.go
@@ -25,8 +25,8 @@ type Range struct {
 }
 
 type Location struct {
-	URI   string `json:"uri"`
-	Range Range  `json:"range"`
+	URI   DocumentURI `json:"uri"`
+	Range Range       `json:"range"`
 }
 
 type Diagnostic struct {
@@ -108,14 +108,14 @@ type TextDocumentIdentifier struct {
 	/**
 	 * The text document's URI.
 	 */
-	URI string `json:"uri"`
+	URI DocumentURI `json:"uri"`
 }
 
 type TextDocumentItem struct {
 	/**
 	 * The text document's URI.
 	 */
-	URI string `json:"uri"`
+	URI DocumentURI `json:"uri"`
 
 	/**
 	 * The text document's language identifier.


### PR DESCRIPTION
In LSP, rootPath is now deprecated, and rootUri is preferred. This commit refactors internal code to pass around URIs. In most cases we were already passing URI values in fields and vars named "xyzPath".

It also adds a new helper (*InitializeParams).Root() method that implements the rootUri-over-rootPath preference.

See https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md#initialize-request for the relevant LSP spec section.

Test plan:

* [x] Ran this repo's Go tests with `go1.8 linux/amd64`
* [x] Tested locally in VS Code with `"go.useLanguageServer": true`