### PR TITLE
langserver: fix workspace/symbol query of stdlib symbols by ID

### DIFF
--- a/langserver/symbol.go
+++ b/langserver/symbol.go
@@ -323,12 +323,7 @@ func (h *LangHandler) handleWorkspaceSymbol(ctx context.Context, conn jsonrpc2.J
 	if id, ok := q.Symbol["id"]; ok {
 		// id implicitly contains a dir hint. We can use that to
 		// reduce the number of files we have to parse.
-		importPath := strings.SplitN(id.(string), "/-/", 2)[0]
-		if isStdLib := PathHasPrefix(h.BuildContext(ctx).GOROOT, h.FilePath(h.init.Root())); isStdLib {
-			q.Dir = path.Join("/src", importPath)
-		} else {
-			q.Dir = importPath
-		}
+		q.Dir = strings.SplitN(id.(string), "/-/", 2)[0]
 		q.Filter = FilterDir
 	}
 	if params.Limit == 0 {


### PR DESCRIPTION
Prefixing the import path of `workspace/symbol` queries to the stdlib
like:

```
git://github.com/golang/go?9d3d370632ef56c1966afc67b796fa950cb347c5 "1:1" workspace/symbol {"limit":0,"symbol":{"id":"bytes/-/TrimPrefix"}}
```

Means that we end up with `/src/bytes` which is dependent upon the build
server GOROOT in use. This means that such queries would incorrectly fail
to locate symbols.

I believe (but have not 100% confirmed) that this issue was introduced
accidentally via https://github.com/sourcegraph/go-langserver/pull/198/files#diff-41a3fbc5d9dbf547085a3235ea31fd2aL329