### PR TITLE
Use TextDocumentSyncKind.Incremental instead of Full

### DIFF
--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -202,7 +202,7 @@ func (h *LangHandler) Handle(ctx context.Context, conn jsonrpc2.JSONRPC2, req *j
 			}()
 		}
 
-		kind := lsp.TDSKFull
+		kind := lsp.TDSKIncremental
 		return lsp.InitializeResult{
 			Capabilities: lsp.ServerCapabilities{
 				TextDocumentSync: lsp.TextDocumentSyncOptionsOrKind{


### PR DESCRIPTION
Since #172 the server is able to process `textDocument/didChange` notifications in correct order, we can apply the patches without concerning that older request might overwrite a later one. This also reverts #160 .

Closes #210 .