### PR TITLE
Add function snippets to code completion results

### DIFF
--- a/langserver/completion.go
+++ b/langserver/completion.go
@@ -14,6 +14,7 @@ import (
 var (
 	GocodeCompletionEnabled = false
 	CIKConstantSupported    = lsp.CIKVariable // or lsp.CIKConstant if client supported
+	FuncSnippetEnabled      = false
 	funcArgsRegexp          = regexp.MustCompile("func\\(([^)]+)\\)")
 )
 
@@ -87,7 +88,9 @@ func (h *LangHandler) handleTextDocumentCompletion(ctx context.Context, conn jso
 }
 
 func (h *LangHandler) getNewText(kind lsp.CompletionItemKind, name, detail string) (lsp.InsertTextFormat, string) {
-	if kind == lsp.CIKFunction && h.init.Capabilities.TextDocument.Completion.CompletionItem.SnippetSupport {
+	if FuncSnippetEnabled &&
+		kind == lsp.CIKFunction &&
+		h.init.Capabilities.TextDocument.Completion.CompletionItem.SnippetSupport {
 		args := genSnippetArgs(parseFuncArgs(detail))
 		text := fmt.Sprintf("%s(%s)$0", name, strings.Join(args, ", "))
 		return lsp.ITFSnippet, text

--- a/langserver/completion_test.go
+++ b/langserver/completion_test.go
@@ -1,0 +1,22 @@
+package langserver
+
+import (
+    "reflect"
+    "testing"
+)
+
+func TestParseFuncArgs(t *testing.T) {
+    got := parseFuncArgs("func(a int, b bool, c interface{}, d string...) ([]string, error)")
+    want := []string{"a int", "b bool", "c interface{}", "d string..."}
+    if !reflect.DeepEqual(got, want) {
+        t.Fatalf("Wrong function args parsed. got: %s want: %s", got, want)
+    }
+}
+
+func TestGenSnippetArgs(t *testing.T) {
+    got := genSnippetArgs([]string{"a int", "b bool", "c interface{}", "d string..."})
+    want := []string{"${1:a int}", "${2:b bool}", "${3:c interface{\\}}", "${4:d string...}"}
+    if !reflect.DeepEqual(got, want) {
+        t.Fatalf("Wrong snippet args. got: %s want: %s", got, want)
+    }
+}

--- a/main.go
+++ b/main.go
@@ -20,16 +20,17 @@ import (
 )
 
 var (
-	mode              = flag.String("mode", "stdio", "communication mode (stdio|tcp)")
-	addr              = flag.String("addr", ":4389", "server listen address (tcp)")
-	trace             = flag.Bool("trace", false, "print all requests and responses")
-	logfile           = flag.String("logfile", "", "also log to this file (in addition to stderr)")
-	printVersion      = flag.Bool("version", false, "print version and exit")
-	pprof             = flag.String("pprof", ":6060", "start a pprof http server (https://golang.org/pkg/net/http/pprof/)")
-	freeosmemory      = flag.Bool("freeosmemory", true, "aggressively free memory back to the OS")
-	usebinarypkgcache = flag.Bool("usebinarypkgcache", true, "use $GOPATH/pkg binary .a files (improves performance)")
-	maxparallelism    = flag.Int("maxparallelism", -1, "use at max N parallel goroutines to fulfill requests")
-	gocodecompletion  = flag.Bool("gocodecompletion", false, "enable completion (extra memory burden)")
+	mode               = flag.String("mode", "stdio", "communication mode (stdio|tcp)")
+	addr               = flag.String("addr", ":4389", "server listen address (tcp)")
+	trace              = flag.Bool("trace", false, "print all requests and responses")
+	logfile            = flag.String("logfile", "", "also log to this file (in addition to stderr)")
+	printVersion       = flag.Bool("version", false, "print version and exit")
+	pprof              = flag.String("pprof", ":6060", "start a pprof http server (https://golang.org/pkg/net/http/pprof/)")
+	freeosmemory       = flag.Bool("freeosmemory", true, "aggressively free memory back to the OS")
+	usebinarypkgcache  = flag.Bool("usebinarypkgcache", true, "use $GOPATH/pkg binary .a files (improves performance)")
+	maxparallelism     = flag.Int("maxparallelism", -1, "use at max N parallel goroutines to fulfill requests")
+	gocodecompletion   = flag.Bool("gocodecompletion", false, "enable completion (extra memory burden)")
+	funcSnippetEnabled = flag.Bool("func-snippet-enabled", true, "enable argument snippets on func completion")
 )
 
 // version is the version field we report back. If you are releasing a new version:
@@ -65,6 +66,8 @@ func main() {
 	langserver.MaxParallelism = *maxparallelism
 
 	langserver.GocodeCompletionEnabled = *gocodecompletion
+
+	langserver.FuncSnippetEnabled = *funcSnippetEnabled
 
 	if err := run(); err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/pkg/lsp/service.go
+++ b/pkg/lsp/service.go
@@ -57,6 +57,9 @@ type TextDocumentClientCapabilities struct {
 		CompletionItemKind struct {
 			ValueSet []CompletionItemKind `json:"valueSet,omitempty"`
 		} `json:"completionItemKind,omitempty"`
+		CompletionItem struct {
+			SnippetSupport bool `json:"snippetSupport,omitempty"`
+		} `json:"completionItem,omitempty"`
 	} `json:"completion,omitempty"`
 }
 
@@ -248,15 +251,16 @@ var completionItemKindName = map[CompletionItemKind]string{
 }
 
 type CompletionItem struct {
-	Label         string             `json:"label"`
-	Kind          CompletionItemKind `json:"kind,omitempty"`
-	Detail        string             `json:"detail,omitempty"`
-	Documentation string             `json:"documentation,omitempty"`
-	SortText      string             `json:"sortText,omitempty"`
-	FilterText    string             `json:"filterText,omitempty"`
-	InsertText    string             `json:"insertText,omitempty"`
-	TextEdit      *TextEdit          `json:"textEdit,omitempty"`
-	Data          interface{}        `json:"data,omitempty"`
+	Label            string             `json:"label"`
+	Kind             CompletionItemKind `json:"kind,omitempty"`
+	Detail           string             `json:"detail,omitempty"`
+	Documentation    string             `json:"documentation,omitempty"`
+	SortText         string             `json:"sortText,omitempty"`
+	FilterText       string             `json:"filterText,omitempty"`
+	InsertText       string             `json:"insertText,omitempty"`
+	InsertTextFormat InsertTextFormat   `json:"insertTextFormat,omitempty"`
+	TextEdit         *TextEdit          `json:"textEdit,omitempty"`
+	Data             interface{}        `json:"data,omitempty"`
 }
 
 type CompletionList struct {
@@ -269,6 +273,13 @@ type CompletionTriggerKind int
 const (
 	CTKInvoked          CompletionTriggerKind = 1
 	CTKTriggerCharacter                       = 2
+)
+
+type InsertTextFormat int
+
+const (
+	ITFPlainText InsertTextFormat = 1
+	ITFSnippet                    = 2
 )
 
 type CompletionContext struct {


### PR DESCRIPTION
This adds function args as a snippet when autocompleting function calls.

When a function call completion gets selected, the function args are included in the snippet to make it easier for a user to know what arguments need to be supplied.

Here's an example using Atom as the client:
![func-snippet](https://user-images.githubusercontent.com/307866/34473875-fcecdd10-ef45-11e7-876f-f5af89efd634.gif)

(The above is using a local dev build of [ide-go](https://github.com/ckaznocha/ide-go) with completion support added.  I will be submitting a PR to add this support to ide-go.)
