### PR TITLE
Add config struct

### DIFF
--- a/langserver/completion.go
+++ b/langserver/completion.go
@@ -13,7 +13,6 @@ import (
 )
 
 var (
-	GocodeCompletionEnabled = false
 	CIKConstantSupported    = lsp.CIKVariable // or lsp.CIKConstant if client supported
 	FuncSnippetEnabled      = false
 	funcArgsRegexp          = regexp.MustCompile(`func\(([^)]+)\)`)

--- a/langserver/completion.go
+++ b/langserver/completion.go
@@ -14,7 +14,6 @@ import (
 
 var (
 	CIKConstantSupported    = lsp.CIKVariable // or lsp.CIKConstant if client supported
-	FuncSnippetEnabled      = false
 	funcArgsRegexp          = regexp.MustCompile(`func\(([^)]+)\)`)
 )
 
@@ -90,7 +89,7 @@ func (h *LangHandler) handleTextDocumentCompletion(ctx context.Context, conn jso
 }
 
 func (h *LangHandler) getNewText(kind lsp.CompletionItemKind, name, detail string) (lsp.InsertTextFormat, string) {
-	if FuncSnippetEnabled &&
+	if h.config.FuncSnippetEnabled &&
 		kind == lsp.CIKFunction &&
 		h.init.Capabilities.TextDocument.Completion.CompletionItem.SnippetSupport {
 		args := genSnippetArgs(parseFuncArgs(detail))

--- a/langserver/config.go
+++ b/langserver/config.go
@@ -12,4 +12,9 @@ var (
 )
 
 type Config struct {
+	// MaxParallelism controls the maximum number of goroutines that should be used
+	// to fulfill requests. This is useful in editor environments where users do
+	// not want results ASAP, but rather just semi quickly without eating all of
+	// their CPU.
+	MaxParallelism int
 }

--- a/langserver/config.go
+++ b/langserver/config.go
@@ -23,4 +23,7 @@ type Config struct {
 	// not want results ASAP, but rather just semi quickly without eating all of
 	// their CPU.
 	MaxParallelism int
+	// UseBinaryPkgCache controls whether or not $GOPATH/pkg binary .a files should
+	// be used.
+	UseBinaryPkgCache bool
 }

--- a/langserver/config.go
+++ b/langserver/config.go
@@ -12,6 +12,8 @@ var (
 )
 
 type Config struct {
+	// GocodeCompletionEnabled enables code completion feature (using gocode)
+	GocodeCompletionEnabled bool
 	// MaxParallelism controls the maximum number of goroutines that should be used
 	// to fulfill requests. This is useful in editor environments where users do
 	// not want results ASAP, but rather just semi quickly without eating all of

--- a/langserver/config.go
+++ b/langserver/config.go
@@ -10,3 +10,6 @@ var (
 	// worth it.
 	envWarmupOnInitialize = os.Getenv("GOLSP_WARMUP_ON_INITIALIZE")
 )
+
+type Config struct {
+}

--- a/langserver/config.go
+++ b/langserver/config.go
@@ -12,6 +12,10 @@ var (
 )
 
 type Config struct {
+	// FuncSnippetEnabled enables the returning of enable argument snippets
+	// on `func` completions, eg. func(foo string, arg2 bar).
+	// Requires code completion to be enabled.
+	FuncSnippetEnabled bool
 	// GocodeCompletionEnabled enables code completion feature (using gocode)
 	GocodeCompletionEnabled bool
 	// MaxParallelism controls the maximum number of goroutines that should be used

--- a/langserver/config.go
+++ b/langserver/config.go
@@ -27,3 +27,9 @@ type Config struct {
 	// be used.
 	UseBinaryPkgCache bool
 }
+
+func NewDefaultConfig() Config {
+	return Config{
+		MaxParallelism: 8,
+	}
+}

--- a/langserver/definition.go
+++ b/langserver/definition.go
@@ -17,12 +17,8 @@ import (
 	"github.com/sourcegraph/jsonrpc2"
 )
 
-// UseBinaryPkgCache controls whether or not $GOPATH/pkg binary .a files should
-// be used.
-var UseBinaryPkgCache = false
-
 func (h *LangHandler) handleDefinition(ctx context.Context, conn jsonrpc2.JSONRPC2, req *jsonrpc2.Request, params lsp.TextDocumentPositionParams) ([]lsp.Location, error) {
-	if UseBinaryPkgCache {
+	if h.config.UseBinaryPkgCache {
 		_, _, locs, err := h.definitionGodef(ctx, params)
 		if err == godef.ErrNoIdentifierFound {
 			// This is expected to happen when j2d over

--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -392,7 +392,7 @@ func (h *LangHandler) Handle(ctx context.Context, conn jsonrpc2.JSONRPC2, req *j
 				// a user is viewing this path, hint to add it to the cache
 				// (unless we're primarily using binary package cache .a
 				// files).
-				if !UseBinaryPkgCache {
+				if !h.config.UseBinaryPkgCache {
 					go h.typecheck(ctx, conn, uri, lsp.Position{})
 				}
 			}

--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -24,8 +24,9 @@ import (
 )
 
 // NewHandler creates a Go language server handler.
-func NewHandler() jsonrpc2.Handler {
+func NewHandler(cfg Config) jsonrpc2.Handler {
 	return lspHandler{jsonrpc2.HandlerWithError((&LangHandler{
+		config:        cfg,
 		HandlerShared: &HandlerShared{},
 	}).handle)}
 }
@@ -71,6 +72,8 @@ type LangHandler struct {
 	importGraph     importgraph.Graph
 
 	cancel *cancel
+
+	config Config
 }
 
 // reset clears all internal state in h.

--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -208,7 +208,7 @@ func (h *LangHandler) Handle(ctx context.Context, conn jsonrpc2.JSONRPC2, req *j
 		if err := h.reset(&params); err != nil {
 			return nil, err
 		}
-		if GocodeCompletionEnabled {
+		if h.config.GocodeCompletionEnabled {
 			gocode.InitDaemon(h.BuildContext(ctx))
 		}
 
@@ -226,7 +226,7 @@ func (h *LangHandler) Handle(ctx context.Context, conn jsonrpc2.JSONRPC2, req *j
 
 		kind := lsp.TDSKIncremental
 		var completionOp *lsp.CompletionOptions
-		if GocodeCompletionEnabled {
+		if h.config.GocodeCompletionEnabled {
 			completionOp = &lsp.CompletionOptions{TriggerCharacters: []string{"."}}
 		}
 		return lsp.InitializeResult{

--- a/langserver/hover.go
+++ b/langserver/hover.go
@@ -22,7 +22,7 @@ import (
 )
 
 func (h *LangHandler) handleHover(ctx context.Context, conn jsonrpc2.JSONRPC2, req *jsonrpc2.Request, params lsp.TextDocumentPositionParams) (*lsp.Hover, error) {
-	if UseBinaryPkgCache {
+	if h.config.UseBinaryPkgCache {
 		return h.handleHoverGodef(ctx, conn, req, params)
 	}
 

--- a/langserver/integration_test.go
+++ b/langserver/integration_test.go
@@ -29,7 +29,7 @@ func TestIntegration_FileSystem(t *testing.T) {
 		build.Default = orig
 	}()
 
-	h := NewHandler()
+	h := NewHandler(Config{})
 
 	addr, done := startServer(t, h)
 	defer done()

--- a/langserver/integration_test.go
+++ b/langserver/integration_test.go
@@ -29,7 +29,7 @@ func TestIntegration_FileSystem(t *testing.T) {
 		build.Default = orig
 	}()
 
-	h := NewHandler(Config{})
+	h := NewHandler(NewDefaultConfig())
 
 	addr, done := startServer(t, h)
 	defer done()

--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -1038,8 +1038,6 @@ func (h *Hello) Bye() int {
 }
 
 func TestServer(t *testing.T) {
-	GocodeCompletionEnabled = true
-
 	for label, test := range serverTestCases {
 		t.Run(label, func(t *testing.T) {
 			if test.skip {
@@ -1047,7 +1045,10 @@ func TestServer(t *testing.T) {
 				return
 			}
 
-			h := &LangHandler{HandlerShared: &HandlerShared{}}
+			h := &LangHandler{
+				config:        Config{GocodeCompletionEnabled: true},
+				HandlerShared: &HandlerShared{},
+			}
 
 			addr, done := startServer(t, jsonrpc2.HandlerWithError(h.handle))
 			defer done()

--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -1045,11 +1045,12 @@ func TestServer(t *testing.T) {
 				return
 			}
 
+			cfg := NewDefaultConfig()
+			cfg.FuncSnippetEnabled = true
+			cfg.GocodeCompletionEnabled = true
+
 			h := &LangHandler{
-				config: Config{
-					FuncSnippetEnabled:      true,
-					GocodeCompletionEnabled: true,
-				},
+				config:        cfg,
 				HandlerShared: &HandlerShared{},
 			}
 

--- a/langserver/symbol.go
+++ b/langserver/symbol.go
@@ -336,12 +336,6 @@ func (h *LangHandler) handleWorkspaceSymbol(ctx context.Context, conn jsonrpc2.J
 	return h.handleSymbol(ctx, conn, req, q, params.Limit)
 }
 
-// MaxParallelism controls the maximum number of goroutines that should be used
-// to fulfill requests. This is useful in editor environments where users do
-// not want results ASAP, but rather just semi quickly without eating all of
-// their CPU.
-var MaxParallelism = 8
-
 func (h *LangHandler) handleSymbol(ctx context.Context, conn jsonrpc2.JSONRPC2, req *jsonrpc2.Request, query Query, limit int) ([]lsp.SymbolInformation, error) {
 	results := resultSorter{Query: query, results: make([]scoredSymbol, 0)}
 	{

--- a/langserver/symbol.go
+++ b/langserver/symbol.go
@@ -342,7 +342,7 @@ func (h *LangHandler) handleSymbol(ctx context.Context, conn jsonrpc2.JSONRPC2, 
 		rootPath := h.FilePath(h.init.Root())
 		bctx := h.BuildContext(ctx)
 
-		par := parallel.NewRun(8)
+		par := parallel.NewRun(h.config.MaxParallelism)
 		for _, pkg := range tools.ListPkgsUnderDir(bctx, rootPath) {
 			// If we're restricting results to a single file or dir, ensure the
 			// package dir matches to avoid doing unnecessary work.

--- a/main.go
+++ b/main.go
@@ -54,7 +54,6 @@ func main() {
 	if *freeosmemory {
 		go freeOSMemory()
 	}
-	langserver.UseBinaryPkgCache = *usebinarypkgcache
 
 	// Default max parallelism to half the CPU cores, but at least always one.
 	if *maxparallelism <= 0 {
@@ -68,6 +67,7 @@ func main() {
 		FuncSnippetEnabled:      *funcSnippetEnabled,
 		GocodeCompletionEnabled: *gocodecompletion,
 		MaxParallelism:          *maxparallelism,
+		UseBinaryPkgCache:       *usebinarypkgcache,
 	}
 
 	if err := run(cfg); err != nil {

--- a/main.go
+++ b/main.go
@@ -64,12 +64,11 @@ func main() {
 		}
 	}
 
-	langserver.GocodeCompletionEnabled = *gocodecompletion
-
 	langserver.FuncSnippetEnabled = *funcSnippetEnabled
 
 	cfg := langserver.Config{
-		MaxParallelism: *maxparallelism,
+		GocodeCompletionEnabled: *gocodecompletion,
+		MaxParallelism:          *maxparallelism,
 	}
 
 	if err := run(cfg); err != nil {

--- a/main.go
+++ b/main.go
@@ -64,9 +64,8 @@ func main() {
 		}
 	}
 
-	langserver.FuncSnippetEnabled = *funcSnippetEnabled
-
 	cfg := langserver.Config{
+		FuncSnippetEnabled:      *funcSnippetEnabled,
 		GocodeCompletionEnabled: *gocodecompletion,
 		MaxParallelism:          *maxparallelism,
 	}

--- a/main.go
+++ b/main.go
@@ -63,12 +63,11 @@ func main() {
 		}
 	}
 
-	cfg := langserver.Config{
-		FuncSnippetEnabled:      *funcSnippetEnabled,
-		GocodeCompletionEnabled: *gocodecompletion,
-		MaxParallelism:          *maxparallelism,
-		UseBinaryPkgCache:       *usebinarypkgcache,
-	}
+	cfg := langserver.NewDefaultConfig()
+	cfg.FuncSnippetEnabled = *funcSnippetEnabled
+	cfg.GocodeCompletionEnabled = *gocodecompletion
+	cfg.MaxParallelism = *maxparallelism
+	cfg.UseBinaryPkgCache = *usebinarypkgcache
 
 	if err := run(cfg); err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/main.go
+++ b/main.go
@@ -63,13 +63,14 @@ func main() {
 			*maxparallelism = 1
 		}
 	}
-	langserver.MaxParallelism = *maxparallelism
 
 	langserver.GocodeCompletionEnabled = *gocodecompletion
 
 	langserver.FuncSnippetEnabled = *funcSnippetEnabled
 
-	cfg := langserver.Config{}
+	cfg := langserver.Config{
+		MaxParallelism: *maxparallelism,
+	}
 
 	if err := run(cfg); err != nil {
 		fmt.Fprintln(os.Stderr, err)


### PR DESCRIPTION
Following up on https://github.com/sourcegraph/go-langserver/pull/221#discussion_r160032897, this PR adds an explicit `Config` struct for grouping `langserver` config settings, and removes global config vars.