### PR TITLE
wire connection through

### DIFF
--- a/langserver/definition.go
+++ b/langserver/definition.go
@@ -138,7 +138,7 @@ func (h *LangHandler) handleXDefinition(ctx context.Context, conn jsonrpc2.JSONR
 
 		// Determine metadata information for the node.
 		if def, err := refs.DefInfo(pkg.Pkg, &pkg.Info, pathEnclosingInterval, node.Pos()); err == nil {
-			symDesc, err := defSymbolDescriptor(ctx, bctx, rootPath, *def, findPackage)
+			symDesc, err := defSymbolDescriptor(ctx, bctx, conn, rootPath, *def, findPackage)
 			if err != nil {
 				// TODO: tracing
 				log.Println("refs.DefInfo:", err)

--- a/langserver/handler_shared.go
+++ b/langserver/handler_shared.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/sourcegraph/ctxvfs"
+	"github.com/sourcegraph/jsonrpc2"
 )
 
 // HandlerShared contains data structures that a build server and its
@@ -25,9 +26,9 @@ type HandlerShared struct {
 
 // FindPackageFunc matches the signature of loader.Config.FindPackage, except
 // also takes a context.Context.
-type FindPackageFunc func(ctx context.Context, bctx *build.Context, importPath, fromDir string, mode build.ImportMode) (*build.Package, error)
+type FindPackageFunc func(ctx context.Context, bctx *build.Context, conn jsonrpc2.JSONRPC2, importPath, fromDir string, mode build.ImportMode) (*build.Package, error)
 
-func defaultFindPackageFunc(ctx context.Context, bctx *build.Context, importPath, fromDir string, mode build.ImportMode) (*build.Package, error) {
+func defaultFindPackageFunc(ctx context.Context, bctx *build.Context, conn jsonrpc2.JSONRPC2, importPath, fromDir string, mode build.ImportMode) (*build.Package, error) {
 	return bctx.Import(importPath, fromDir, mode)
 }
 

--- a/langserver/loader_test.go
+++ b/langserver/loader_test.go
@@ -45,7 +45,7 @@ func TestLoader(t *testing.T) {
 	for label, tc := range loaderCases {
 		t.Run(label, func(t *testing.T) {
 			fset, bctx, bpkg := setUpLoaderTest(tc.fs)
-			p, _, err := typecheck(ctx, fset, bctx, bpkg, defaultFindPackageFunc)
+			p, _, err := typecheck(ctx, fset, bctx, bpkg, nil, defaultFindPackageFunc)
 			if err != nil {
 				t.Error(err)
 			} else if len(p.Created) == 0 {
@@ -70,7 +70,7 @@ func BenchmarkLoader(b *testing.B) {
 			fset, bctx, bpkg := setUpLoaderTest(tc.fs)
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				if _, _, err := typecheck(ctx, fset, bctx, bpkg, defaultFindPackageFunc); err != nil {
+				if _, _, err := typecheck(ctx, fset, bctx, bpkg, nil, defaultFindPackageFunc); err != nil {
 					b.Error(err)
 				}
 			}
@@ -111,7 +111,7 @@ func TestLoaderDiagnostics(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
 			fset, bctx, bpkg := setUpLoaderTest(tc.FS)
-			_, diag, err := typecheck(ctx, fset, bctx, bpkg, defaultFindPackageFunc)
+			_, diag, err := typecheck(ctx, fset, bctx, bpkg, nil, defaultFindPackageFunc)
 			if err != nil {
 				t.Error(err)
 			}

--- a/langserver/references.go
+++ b/langserver/references.go
@@ -218,7 +218,7 @@ func (h *LangHandler) reverseImportGraph(ctx context.Context, conn jsonrpc2.JSON
 			bctx := h.BuildContext(ctx)
 			findPackageWithCtx := h.getFindPackageFunc()
 			findPackage := func(bctx *build.Context, importPath, fromDir string, mode build.ImportMode) (*build.Package, error) {
-				return findPackageWithCtx(ctx, bctx, importPath, fromDir, mode)
+				return findPackageWithCtx(ctx, bctx, conn, importPath, fromDir, mode)
 			}
 			g := tools.BuildReverseImportGraph(bctx, findPackage, h.FilePath(h.init.Root()))
 			h.mu.Lock()

--- a/langserver/symbol.go
+++ b/langserver/symbol.go
@@ -380,7 +380,7 @@ func (h *LangHandler) handleSymbol(ctx context.Context, conn jsonrpc2.JSONRPC2, 
 					par.Release()
 					_ = util.Panicf(recover(), "%v for pkg %v", req.Method, pkg)
 				}()
-				h.collectFromPkg(ctx, bctx, pkg, rootPath, &results)
+				h.collectFromPkg(ctx, bctx, conn, pkg, rootPath, &results)
 			}(pkg)
 		}
 		_ = par.Wait()
@@ -401,10 +401,10 @@ type pkgSymResult struct {
 // collectFromPkg collects all the symbols from the specified package
 // into the results. It uses LangHandler's package symbol cache to
 // speed up repeated calls.
-func (h *LangHandler) collectFromPkg(ctx context.Context, bctx *build.Context, pkg string, rootPath string, results *resultSorter) {
+func (h *LangHandler) collectFromPkg(ctx context.Context, bctx *build.Context, conn jsonrpc2.JSONRPC2, pkg string, rootPath string, results *resultSorter) {
 	symbols := h.symbolCache.Get(pkg, func() interface{} {
 		findPackage := h.getFindPackageFunc()
-		buildPkg, err := findPackage(ctx, bctx, pkg, rootPath, 0)
+		buildPkg, err := findPackage(ctx, bctx, conn, pkg, rootPath, 0)
 		if err != nil {
 			maybeLogImportError(pkg, err)
 			return nil


### PR DESCRIPTION
The goal of this PR is to pass the JSONRPC2 connection through to `langserver.FindPackageFunc` which allows implementations of `FindPackageFunc` to use the JSONRPC2 connection to access the `xcache` extension.