### PR TITLE
hover: Do not return range for godef

### DIFF
--- a/langserver/hover.go
+++ b/langserver/hover.go
@@ -336,11 +336,9 @@ func (h *LangHandler) handleHoverGodef(ctx context.Context, conn jsonrpc2.JSONRP
 		return nil, fmt.Errorf("failed to find doc object for %s", target)
 	}
 
-	contents, node := fmtDocObject(fset, docObject, target)
-	r := rangeForNode(fset, node)
+	contents, _ := fmtDocObject(fset, docObject, target)
 	return &lsp.Hover{
 		Contents: contents,
-		Range:    &r,
 	}, nil
 }
 


### PR DESCRIPTION
The optional range returned should be the range of the token the user is
hovering over. Instead we are returning the range of the definition. It isn't
trivial to return the correct range, so rather lets return nothing at all
which is more correct.

Fixes https://github.com/sourcegraph/go-langserver/issues/200