### PR TITLE
langserver: remove duplicate test call (mistakenly added)

### DIFF
--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -1300,11 +1300,7 @@ func lspTests(t testing.TB, ctx context.Context, h *LangHandler, c *jsonrpc2.Con
 			definitionTest(t, ctx, c, rootURI, pos, want, "")
 		})
 	}
-	for pos, want := range cases.wantDefinition {
-		tbRun(t, fmt.Sprintf("definition-%s", strings.Replace(pos, "/", "-", -1)), func(t testing.TB) {
-			definitionTest(t, ctx, c, rootURI, pos, want, "")
-		})
-	}
+
 	for pos, want := range cases.wantXDefinition {
 		tbRun(t, fmt.Sprintf("xdefinition-%s", strings.Replace(pos, "/", "-", -1)), func(t testing.TB) {
 			xdefinitionTest(t, ctx, c, rootURI, pos, want)


### PR DESCRIPTION
This block of code seems to have been accidentally duplicated. There is no comment explaining why it is necessary to run these tests twice.

@keegancsmith @slimsag Are you aware of any reason why these must be run twice? Just checking. If not, then it was probably a mistake.