### PR TITLE
completion: gracefully handle unexpected request

### DIFF
--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -312,6 +312,10 @@ func (h *LangHandler) Handle(ctx context.Context, conn jsonrpc2.JSONRPC2, req *j
 		return h.handleXDefinition(ctx, conn, req, params)
 
 	case "textDocument/completion":
+		if !h.Config.GocodeCompletionEnabled {
+			return nil, &jsonrpc2.Error{Code: jsonrpc2.CodeMethodNotFound,
+				Message: fmt.Sprintf("completion is disabled. Enable with flag `-gocodecompletion`")}
+		}
 		if req.Params == nil {
 			return nil, &jsonrpc2.Error{Code: jsonrpc2.CodeInvalidParams}
 		}


### PR DESCRIPTION
Panic occurs when a mistakenly implemented client requests for a completion despite the langserver had set `InitializeResult.capabilities.completionProvider` to false. (see onivim/oni#1378)

This change prohibits the langserver from processing the request with an uninitiated gocode daemon and offers helpful error message.