### PR TITLE
support textDocument/implementation (Go interface impls queries)

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-Portions of code are adapted from go/types and github.com/golang/gddo:
+Portions of code are adapted from go/types, golang.org/x/tools, and github.com/golang/gddo:
 
 Copyright (c) 2013 The Go Authors. All rights reserved.
 

--- a/langserver/ast.go
+++ b/langserver/ast.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 	"go/ast"
 	"go/token"
+	"go/types"
 
 	"github.com/sourcegraph/go-langserver/pkg/lsp"
+	"golang.org/x/tools/go/loader"
 
 	"github.com/sourcegraph/go-langserver/langserver/util"
 )
@@ -67,4 +69,221 @@ func goRangeToLSPLocation(fset *token.FileSet, pos token.Pos, end token.Pos) lsp
 		Range: rangeForNode(fset, fakeNode{p: pos, e: end}),
 	}
 
+}
+
+type action int
+
+const (
+	actionUnknown action = iota // None of the below
+	actionExpr                  // FuncDecl, true Expr or Ident(types.{Const,Var})
+	actionType                  // type Expr or Ident(types.TypeName).
+	actionStmt                  // Stmt or Ident(types.Label)
+	actionPackage               // Ident(types.Package) or ImportSpec
+)
+
+// findInterestingNode classifies the syntax node denoted by path as one of:
+//    - an expression, part of an expression or a reference to a constant
+//      or variable;
+//    - a type, part of a type, or a reference to a named type;
+//    - a statement, part of a statement, or a label referring to a statement;
+//    - part of a package declaration or import spec.
+//    - none of the above.
+// and returns the most "interesting" associated node, which may be
+// the same node, an ancestor or a descendent.
+//
+// Adapted from golang.org/x/tools/cmd/guru (Copyright (c) 2013 The Go Authors). All rights
+// reserved. See NOTICE for full license.
+func findInterestingNode(pkginfo *loader.PackageInfo, path []ast.Node) ([]ast.Node, action) {
+	// TODO(adonovan): integrate with go/types/stdlib_test.go and
+	// apply this to every AST node we can find to make sure it
+	// doesn't crash.
+
+	// TODO(adonovan): audit for ParenExpr safety, esp. since we
+	// traverse up and down.
+
+	// TODO(adonovan): if the users selects the "." in
+	// "fmt.Fprintf()", they'll get an ambiguous selection error;
+	// we won't even reach here.  Can we do better?
+
+	// TODO(adonovan): describing a field within 'type T struct {...}'
+	// describes the (anonymous) struct type and concludes "no methods".
+	// We should ascend to the enclosing type decl, if any.
+
+	for len(path) > 0 {
+		switch n := path[0].(type) {
+		case *ast.GenDecl:
+			if len(n.Specs) == 1 {
+				// Descend to sole {Import,Type,Value}Spec child.
+				path = append([]ast.Node{n.Specs[0]}, path...)
+				continue
+			}
+			return path, actionUnknown // uninteresting
+
+		case *ast.FuncDecl:
+			// Descend to function name.
+			path = append([]ast.Node{n.Name}, path...)
+			continue
+
+		case *ast.ImportSpec:
+			return path, actionPackage
+
+		case *ast.ValueSpec:
+			if len(n.Names) == 1 {
+				// Descend to sole Ident child.
+				path = append([]ast.Node{n.Names[0]}, path...)
+				continue
+			}
+			return path, actionUnknown // uninteresting
+
+		case *ast.TypeSpec:
+			// Descend to type name.
+			path = append([]ast.Node{n.Name}, path...)
+			continue
+
+		case ast.Stmt:
+			return path, actionStmt
+
+		case *ast.ArrayType,
+			*ast.StructType,
+			*ast.FuncType,
+			*ast.InterfaceType,
+			*ast.MapType,
+			*ast.ChanType:
+			return path, actionType
+
+		case *ast.Comment, *ast.CommentGroup, *ast.File, *ast.KeyValueExpr, *ast.CommClause:
+			return path, actionUnknown // uninteresting
+
+		case *ast.Ellipsis:
+			// Continue to enclosing node.
+			// e.g. [...]T in ArrayType
+			//      f(x...) in CallExpr
+			//      f(x...T) in FuncType
+
+		case *ast.Field:
+			// TODO(adonovan): this needs more thought,
+			// since fields can be so many things.
+			if len(n.Names) == 1 {
+				// Descend to sole Ident child.
+				path = append([]ast.Node{n.Names[0]}, path...)
+				continue
+			}
+			// Zero names (e.g. anon field in struct)
+			// or multiple field or param names:
+			// continue to enclosing field list.
+
+		case *ast.FieldList:
+			// Continue to enclosing node:
+			// {Struct,Func,Interface}Type or FuncDecl.
+
+		case *ast.BasicLit:
+			if _, ok := path[1].(*ast.ImportSpec); ok {
+				return path[1:], actionPackage
+			}
+			return path, actionExpr
+
+		case *ast.SelectorExpr:
+			// TODO(adonovan): use Selections info directly.
+			if pkginfo.Uses[n.Sel] == nil {
+				// TODO(adonovan): is this reachable?
+				return path, actionUnknown
+			}
+			// Descend to .Sel child.
+			path = append([]ast.Node{n.Sel}, path...)
+			continue
+
+		case *ast.Ident:
+			switch pkginfo.ObjectOf(n).(type) {
+			case *types.PkgName:
+				return path, actionPackage
+
+			case *types.Const:
+				return path, actionExpr
+
+			case *types.Label:
+				return path, actionStmt
+
+			case *types.TypeName:
+				return path, actionType
+
+			case *types.Var:
+				// For x in 'struct {x T}', return struct type, for now.
+				if _, ok := path[1].(*ast.Field); ok {
+					_ = path[2].(*ast.FieldList) // assertion
+					if _, ok := path[3].(*ast.StructType); ok {
+						return path[3:], actionType
+					}
+				}
+				return path, actionExpr
+
+			case *types.Func:
+				return path, actionExpr
+
+			case *types.Builtin:
+				// For reference to built-in function, return enclosing call.
+				path = path[1:] // ascend to enclosing function call
+				continue
+
+			case *types.Nil:
+				return path, actionExpr
+			}
+
+			// No object.
+			switch path[1].(type) {
+			case *ast.SelectorExpr:
+				// Return enclosing selector expression.
+				return path[1:], actionExpr
+
+			case *ast.Field:
+				// TODO(adonovan): test this.
+				// e.g. all f in:
+				//  struct { f, g int }
+				//  interface { f() }
+				//  func (f T) method(f, g int) (f, g bool)
+				//
+				// switch path[3].(type) {
+				// case *ast.FuncDecl:
+				// case *ast.StructType:
+				// case *ast.InterfaceType:
+				// }
+				//
+				// return path[1:], actionExpr
+				//
+				// Unclear what to do with these.
+				// Struct.Fields             -- field
+				// Interface.Methods         -- field
+				// FuncType.{Params.Results} -- actionExpr
+				// FuncDecl.Recv             -- actionExpr
+
+			case *ast.File:
+				// 'package foo'
+				return path, actionPackage
+
+			case *ast.ImportSpec:
+				return path[1:], actionPackage
+
+			default:
+				// e.g. blank identifier
+				// or y in "switch y := x.(type)"
+				// or code in a _test.go file that's not part of the package.
+				return path, actionUnknown
+			}
+
+		case *ast.StarExpr:
+			if pkginfo.Types[n].IsType() {
+				return path, actionType
+			}
+			return path, actionExpr
+
+		case ast.Expr:
+			// All Expr but {BasicLit,Ident,StarExpr} are
+			// "true" expressions that evaluate to a value.
+			return path, actionExpr
+		}
+
+		// Ascend to parent.
+		path = path[1:]
+	}
+
+	return nil, actionUnknown // unreachable
 }

--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -241,6 +241,7 @@ func (h *LangHandler) Handle(ctx context.Context, conn jsonrpc2.JSONRPC2, req *j
 				HoverProvider:                true,
 				ReferencesProvider:           true,
 				WorkspaceSymbolProvider:      true,
+				ImplementationProvider:       true,
 				XWorkspaceReferencesProvider: true,
 				XDefinitionProvider:          true,
 				XWorkspaceSymbolByProperties: true,
@@ -334,6 +335,16 @@ func (h *LangHandler) Handle(ctx context.Context, conn jsonrpc2.JSONRPC2, req *j
 			return nil, err
 		}
 		return h.handleTextDocumentReferences(ctx, conn, req, params)
+
+	case "textDocument/implementation":
+		if req.Params == nil {
+			return nil, &jsonrpc2.Error{Code: jsonrpc2.CodeInvalidParams}
+		}
+		var params lsp.TextDocumentPositionParams
+		if err := json.Unmarshal(*req.Params, &params); err != nil {
+			return nil, err
+		}
+		return h.handleTextDocumentImplementation(ctx, conn, req, params)
 
 	case "textDocument/documentSymbol":
 		if req.Params == nil {

--- a/langserver/implementation.go
+++ b/langserver/implementation.go
@@ -1,0 +1,227 @@
+package langserver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"go/ast"
+	"go/token"
+	"go/types"
+	"sort"
+
+	"github.com/sourcegraph/go-langserver/langserver/util"
+	"github.com/sourcegraph/go-langserver/pkg/lsp"
+	"github.com/sourcegraph/go-langserver/pkg/lspext"
+	"github.com/sourcegraph/jsonrpc2"
+	"golang.org/x/tools/go/loader"
+	"golang.org/x/tools/go/types/typeutil"
+	"golang.org/x/tools/refactor/importgraph"
+)
+
+func (h *LangHandler) handleTextDocumentImplementation(ctx context.Context, conn jsonrpc2.JSONRPC2, req *jsonrpc2.Request, params lsp.TextDocumentPositionParams) ([]*lspext.ImplementationLocation, error) {
+	if !util.IsURI(params.TextDocument.URI) {
+		return nil, &jsonrpc2.Error{
+			Code:    jsonrpc2.CodeInvalidParams,
+			Message: fmt.Sprintf("textDocument/implementation not yet supported for out-of-workspace URI (%q)", params.TextDocument.URI),
+		}
+	}
+
+	// Do initial cached, standard typecheck pass to get position arg.
+	fset0, _, _, _, pkg, pos0, err := h.typecheck(ctx, conn, params.TextDocument.URI, params.Position)
+	if err != nil {
+		// Invalid nodes means we tried to click on something which is
+		// not an ident (eg comment/string/etc). Return no information.
+		if _, ok := err.(*invalidNodeError); ok {
+			return []*lspext.ImplementationLocation{}, nil
+		}
+		return nil, err
+	}
+
+	// Now typecheck again, but with a larger analysis scope.
+	lconf := loader.Config{
+		Build: h.BuildContext(ctx),
+	}
+	allowErrors(&lconf)
+	// Inspect the forward and reverse transitive closure of the selected package. (In theory even
+	// this is incomplete.)
+	_, rev, _ := importgraph.Build(lconf.Build)
+	for path := range rev.Search(pkg.Pkg.Path()) {
+		lconf.ImportWithTests(path)
+	}
+	// Type-check the program.
+	lprog, err := lconf.Load()
+	if err != nil {
+		return nil, err
+	}
+	pos := posForFileOffset(lconf.Fset, fset0.Position(*pos0).Filename, fset0.Position(*pos0).Offset)
+	pkg, path, _ := lprog.PathEnclosingInterval(pos, pos)
+	path, action := findInterestingNode(pkg, path)
+
+	return implements(lconf.Fset, lprog, pkg, path, action)
+}
+
+// Adapted from golang.org/x/tools/cmd/guru (Copyright (c) 2013 The Go Authors). All rights
+// reserved. See NOTICE for full license.
+func implements(fset *token.FileSet, lprog *loader.Program, pkgInfo *loader.PackageInfo, path []ast.Node, action action) ([]*lspext.ImplementationLocation, error) {
+	var method *types.Func
+	var T types.Type // selected type (receiver if method != nil)
+
+	switch action {
+	case actionExpr:
+		// method?
+		if id, ok := path[0].(*ast.Ident); ok {
+			if obj, ok := pkgInfo.ObjectOf(id).(*types.Func); ok {
+				recv := obj.Type().(*types.Signature).Recv()
+				if recv == nil {
+					return nil, errors.New("this function is not a method")
+				}
+				method = obj
+				T = recv.Type()
+			}
+		}
+
+		// If not a method, use the expression's type.
+		if T == nil {
+			T = pkgInfo.TypeOf(path[0].(ast.Expr))
+		}
+
+	case actionType:
+		T = pkgInfo.TypeOf(path[0].(ast.Expr))
+	}
+	if T == nil {
+		return nil, errors.New("not a type, method, or value")
+	}
+
+	// Find all named types, even local types (which can have
+	// methods due to promotion) and the built-in "error".
+	// We ignore aliases 'type M = N' to avoid duplicate
+	// reporting of the Named type N.
+	var allNamed []*types.Named
+	for _, info := range lprog.AllPackages {
+		for _, obj := range info.Defs {
+			if obj, ok := obj.(*types.TypeName); ok && !isAlias(obj) {
+				if named, ok := obj.Type().(*types.Named); ok {
+					allNamed = append(allNamed, named)
+				}
+			}
+		}
+	}
+	allNamed = append(allNamed, types.Universe.Lookup("error").Type().(*types.Named))
+
+	var msets typeutil.MethodSetCache
+
+	// Test each named type.
+	var to, from, fromPtr []types.Type
+	for _, U := range allNamed {
+		if isInterface(T) {
+			if msets.MethodSet(T).Len() == 0 {
+				continue // empty interface
+			}
+			if isInterface(U) {
+				if msets.MethodSet(U).Len() == 0 {
+					continue // empty interface
+				}
+
+				// T interface, U interface
+				if !types.Identical(T, U) {
+					if types.AssignableTo(U, T) {
+						to = append(to, U)
+					}
+					if types.AssignableTo(T, U) {
+						from = append(from, U)
+					}
+				}
+			} else {
+				// T interface, U concrete
+				if types.AssignableTo(U, T) {
+					to = append(to, U)
+				} else if pU := types.NewPointer(U); types.AssignableTo(pU, T) {
+					to = append(to, pU)
+				}
+			}
+		} else if isInterface(U) {
+			if msets.MethodSet(U).Len() == 0 {
+				continue // empty interface
+			}
+
+			// T concrete, U interface
+			if types.AssignableTo(T, U) {
+				from = append(from, U)
+			} else if pT := types.NewPointer(T); types.AssignableTo(pT, U) {
+				fromPtr = append(fromPtr, U)
+			}
+		}
+	}
+
+	// Sort types (arbitrarily) to ensure test determinism.
+	sort.Sort(typesByString(to))
+	sort.Sort(typesByString(from))
+	sort.Sort(typesByString(fromPtr))
+
+	seen := map[types.Object]struct{}{}
+	toLocation := func(t types.Type, method *types.Func) *lspext.ImplementationLocation {
+		var obj types.Object
+		if method == nil {
+			// t is a type
+			nt, ok := deref(t).(*types.Named)
+			if !ok {
+				return nil // t is non-named
+			}
+			obj = nt.Obj()
+		} else {
+			// t is a method
+			tm := types.NewMethodSet(t).Lookup(method.Pkg(), method.Name())
+			if tm == nil {
+				return nil // method not found
+			}
+			obj = tm.Obj()
+			if _, seen := seen[obj]; seen {
+				return nil // already saw this method, via other embedding path
+			}
+			seen[obj] = struct{}{}
+		}
+
+		pos := obj.Pos()
+		end := obj.Pos() + token.Pos(len(obj.Name()))
+		return &lspext.ImplementationLocation{
+			Location: goRangeToLSPLocation(fset, pos, end),
+			Method:   method != nil,
+		}
+	}
+
+	locs := make([]*lspext.ImplementationLocation, 0, len(to)+len(from)+len(fromPtr))
+	for _, t := range to {
+		loc := toLocation(t, method)
+		if loc == nil {
+			continue
+		}
+		loc.Type = "to"
+		locs = append(locs, loc)
+	}
+	for _, t := range from {
+		loc := toLocation(t, method)
+		if loc == nil {
+			continue
+		}
+		loc.Type = "from"
+		locs = append(locs, loc)
+	}
+	for _, t := range fromPtr {
+		loc := toLocation(t, method)
+		if loc == nil {
+			continue
+		}
+		loc.Type = "from"
+		loc.Ptr = true
+		locs = append(locs, loc)
+	}
+	return locs, nil
+}
+
+func isInterface(T types.Type) bool { return types.IsInterface(T) }
+
+type typesByString []types.Type
+
+func (p typesByString) Len() int           { return len(p) }
+func (p typesByString) Less(i, j int) bool { return p[i].String() < p[j].String() }
+func (p typesByString) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }

--- a/langserver/isAlias18.go
+++ b/langserver/isAlias18.go
@@ -1,0 +1,15 @@
+// Copyright 2017 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !go1.9
+
+package langserver
+
+import "go/types"
+
+func isAlias(obj *types.TypeName) bool {
+	return false // there are no type aliases before Go 1.9
+}
+
+const HasAlias = false

--- a/langserver/isAlias19.go
+++ b/langserver/isAlias19.go
@@ -1,0 +1,15 @@
+// Copyright 2017 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build go1.9
+
+package langserver
+
+import "go/types"
+
+func isAlias(obj *types.TypeName) bool {
+	return obj.IsAlias()
+}
+
+const HasAlias = true

--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -938,6 +938,46 @@ type Header struct {
 			},
 		},
 	},
+	"interfaces and implementations": {
+		rootURI: "file:///src/test/pkg",
+		fs: map[string]string{
+			"i0.go":    "package p; type I0 interface { M0() }",
+			"i1.go":    "package p; type I1 interface { M1() }",
+			"i2.go":    "package p; type I2 interface { M1(); M2() }",
+			"t0.go":    "package p; type T0 struct{}",
+			"t1.go":    "package p; type T1 struct {}; func (T1) M1() {}; func (T1) M3()",
+			"t1e.go":   "package p; type T1E struct { T1 }; var _ = (T1E{}).M1",
+			"t1p.go":   "package p; type T1P struct {}; func (*T1P) M1() {}",
+			"p2/p2.go": "package p2; type T2 struct{}; func (t2) M1() {}",
+		},
+		cases: lspTestCases{
+			wantImplementation: map[string][]string{
+				"i0.go:1:17": []string{}, // I0
+				"i0.go:1:32": []string{}, // (I0).M0
+				"i1.go:1:17": /* I1 */ []string{
+					"/src/test/pkg/i2.go:1:17:to",
+					"/src/test/pkg/t1.go:1:17:to",
+					"/src/test/pkg/t1e.go:1:17:to",
+					"/src/test/pkg/t1p.go:1:17:to",
+				},
+				"i1.go:1:32": /* I1.(M1)*/ []string{
+					"/src/test/pkg/i2.go:1:32:to:method",
+					"/src/test/pkg/t1.go:1:41:to:method",
+					"/src/test/pkg/t1p.go:1:44:to:method",
+				},
+				"i2.go:1:32":/* I2.(M1)*/ []string{"/src/test/pkg/i1.go:1:32:from:method"},
+				"i2.go:1:38":/* I2.(M2)*/ []string{},
+				"t0.go:1:17":/* T0 */ []string{},
+				"t1.go:1:17":/* T1 */ []string{"/src/test/pkg/i1.go:1:17:from"},
+				"t1.go:1:41":/* (T1).M1 */ []string{"/src/test/pkg/i1.go:1:32:from:method"},
+				"t1.go:1:59":/* (T1).M3 */ []string{},
+				"t1e.go:1:17":/* (T1E) */ []string{"/src/test/pkg/i1.go:1:17:from"},
+				"t1e.go:1:52":/* (T1E).M1 */ []string{"/src/test/pkg/i1.go:1:32:from:method"},
+				"t1p.go:1:17":/* T1P */ []string{"/src/test/pkg/i1.go:1:17:from:ptr"},
+				"t1p.go:1:44":/* (T1P).M1 */ []string{"/src/test/pkg/i1.go:1:32:from:method"},
+			},
+		},
+	},
 	"signatures": {
 		rootURI: "file:///src/test/pkg",
 		fs: map[string]string{
@@ -1168,6 +1208,7 @@ type lspTestCases struct {
 	wantXDefinition                         map[string]string
 	wantCompletion                          map[string]string
 	wantReferences                          map[string][]string
+	wantImplementation                      map[string][]string
 	wantSymbols                             map[string][]string
 	wantWorkspaceSymbols                    map[*lspext.WorkspaceSymbolParams][]string
 	wantSignatures                          map[string]string
@@ -1313,6 +1354,12 @@ func lspTests(t testing.TB, ctx context.Context, h *LangHandler, c *jsonrpc2.Con
 		})
 	}
 
+	for pos, want := range cases.wantImplementation {
+		tbRun(t, fmt.Sprintf("implementation-%s", pos), func(t testing.TB) {
+			implementationTest(t, ctx, c, rootURI, pos, want)
+		})
+	}
+
 	for file, want := range cases.wantSymbols {
 		tbRun(t, fmt.Sprintf("symbols-%s", file), func(t testing.TB) {
 			symbolsTest(t, ctx, c, rootURI, file, want)
@@ -1447,6 +1494,25 @@ func referencesTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, rootURI
 	sort.Strings(want)
 	if !reflect.DeepEqual(references, want) {
 		t.Errorf("\ngot\n\t%q\nwant\n\t%q", references, want)
+	}
+}
+
+func implementationTest(t testing.TB, ctx context.Context, c *jsonrpc2.Conn, rootURI lsp.DocumentURI, pos string, want []string) {
+	file, line, char, err := parsePos(pos)
+	if err != nil {
+		t.Fatal(err)
+	}
+	impls, err := callImplementation(ctx, c, uriJoin(rootURI, file), line, char)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := range impls {
+		impls[i] = util.UriToPath(lsp.DocumentURI(impls[i]))
+	}
+	sort.Strings(impls)
+	sort.Strings(want)
+	if !reflect.DeepEqual(impls, want) {
+		t.Errorf("\ngot\n\t%q\nwant\n\t%q", impls, want)
 	}
 }
 
@@ -1646,6 +1712,29 @@ func callReferences(ctx context.Context, c *jsonrpc2.Conn, uri lsp.DocumentURI, 
 	str := make([]string, len(res))
 	for i, loc := range res {
 		str[i] = fmt.Sprintf("%s:%d:%d", loc.URI, loc.Range.Start.Line+1, loc.Range.Start.Character+1)
+	}
+	return str, nil
+}
+
+func callImplementation(ctx context.Context, c *jsonrpc2.Conn, uri lsp.DocumentURI, line, char int) ([]string, error) {
+	var res []lspext.ImplementationLocation
+	err := c.Call(ctx, "textDocument/implementation", lsp.TextDocumentPositionParams{
+		TextDocument: lsp.TextDocumentIdentifier{URI: uri},
+		Position:     lsp.Position{Line: line, Character: char},
+	}, &res)
+	if err != nil {
+		return nil, err
+	}
+	str := make([]string, len(res))
+	for i, loc := range res {
+		extra := []string{loc.Type}
+		if loc.Ptr {
+			extra = append(extra, "ptr")
+		}
+		if loc.Method {
+			extra = append(extra, "method")
+		}
+		str[i] = fmt.Sprintf("%s:%d:%d:%s", loc.URI, loc.Range.Start.Line+1, loc.Range.Start.Character+1, strings.Join(extra, ":"))
 	}
 	return str, nil
 }

--- a/langserver/types.go
+++ b/langserver/types.go
@@ -1,0 +1,11 @@
+package langserver
+
+import "go/types"
+
+// deref returns a pointer's element type; otherwise it returns typ.
+func deref(typ types.Type) types.Type {
+	if p, ok := typ.Underlying().(*types.Pointer); ok {
+		return p.Elem()
+	}
+	return typ
+}

--- a/pkg/lsp/service.go
+++ b/pkg/lsp/service.go
@@ -64,6 +64,10 @@ type TextDocumentClientCapabilities struct {
 			SnippetSupport bool `json:"snippetSupport,omitempty"`
 		} `json:"completionItem,omitempty"`
 	} `json:"completion,omitempty"`
+
+	Implementation *struct {
+		DynamicRegistration bool `json:"dynamicRegistration,omitempty"`
+	} `json:"implementation,omitempty"`
 }
 
 type InitializeResult struct {
@@ -151,6 +155,7 @@ type ServerCapabilities struct {
 	DocumentHighlightProvider        bool                             `json:"documentHighlightProvider,omitempty"`
 	DocumentSymbolProvider           bool                             `json:"documentSymbolProvider,omitempty"`
 	WorkspaceSymbolProvider          bool                             `json:"workspaceSymbolProvider,omitempty"`
+	ImplementationProvider           bool                             `json:"implementationProvider,omitempty"`
 	CodeActionProvider               bool                             `json:"codeActionProvider,omitempty"`
 	CodeLensProvider                 *CodeLensOptions                 `json:"codeLensProvider,omitempty"`
 	DocumentFormattingProvider       bool                             `json:"documentFormattingProvider,omitempty"`

--- a/pkg/lspext/implementation.go
+++ b/pkg/lspext/implementation.go
@@ -1,0 +1,31 @@
+package lspext
+
+import "github.com/sourcegraph/go-langserver/pkg/lsp"
+
+// ImplementationLocation is a superset of lsp.Location with additional Go-specific information
+// about the implementation.
+type ImplementationLocation struct {
+	lsp.Location // the location of the implementation
+
+	// Type is the type of implementation relationship described by this location.
+	//
+	// If a type T was queried, the set of possible values are:
+	//
+	// - "to": named or ptr-to-named types assignable to interface T
+	// - "from": named interfaces assignable from T (or only from *T if Ptr == true)
+	//
+	// If a method M on type T was queried, the same set of values above is used, except they refer
+	// to methods on the described type (not the described type itself).
+	//
+	// (This type description is taken from golang.org/x/tools/cmd/guru.)
+	Type string `json:"type,omitempty"`
+
+	// Ptr is whether this implementation location is only assignable from a pointer *T (where T is
+	// the queried type).
+	Ptr bool `json:"ptr,omitempty"`
+
+	// Method is whether a method was queried. If so, then the implementation locations refer to the
+	// corresponding methods on the types found by the implementation query (not the types
+	// themselves).
+	Method bool `json:"method"`
+}


### PR DESCRIPTION
This PR is based on master, not no-godef as in #250.

This implements the LSP textDocument/implementation method; see https://microsoft.github.io/language-server-protocol/specification#textDocument_implementation.

It adds the following functionality:

- on an interface, shows the types that implement it
- on a non-interface type, shows the interfaces it implements
- on an interface method, shows the methods (in implementing types) that implement it
- on a non-interface method, shows the interface methods it implements

Known problems:

- It copies a lot more code from guru.
- It could also be made more efficient in the future (it does some duplicate work right now).
- It does not let the user specify the analysis scope (as they can in guru). It uses the forward/reverse import graph.