### PR TITLE
Publish diagnostics

### DIFF
--- a/langserver/config.go
+++ b/langserver/config.go
@@ -18,6 +18,8 @@ type Config struct {
 	FuncSnippetEnabled bool
 	// GocodeCompletionEnabled enables code completion feature (using gocode)
 	GocodeCompletionEnabled bool
+	// DiagnosticsEnabled enables handling of diagnostics
+	DiagnosticsEnabled bool
 	// MaxParallelism controls the maximum number of goroutines that should be used
 	// to fulfill requests. This is useful in editor environments where users do
 	// not want results ASAP, but rather just semi quickly without eating all of

--- a/langserver/diagnostics_test.go
+++ b/langserver/diagnostics_test.go
@@ -1,0 +1,95 @@
+package langserver
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/sourcegraph/go-langserver/pkg/lsp"
+)
+
+type updateCachedDiagnosticsTestCase struct {
+	cache diagnostics
+	diags diagnostics
+	files []string
+
+	expectedCache diagnostics
+	expectedDiags diagnostics
+}
+
+var updateCachedDiagnosticsTestCases = map[string]updateCachedDiagnosticsTestCase{
+	"add to cache": updateCachedDiagnosticsTestCase{
+		cache: diagnostics{},
+		diags: diagnostics{"a.go": []*lsp.Diagnostic{{Message: "foo"}}},
+		files: []string{"a.go"},
+
+		expectedCache: diagnostics{"a.go": []*lsp.Diagnostic{{Message: "foo"}}},
+		expectedDiags: diagnostics{"a.go": []*lsp.Diagnostic{{Message: "foo"}}},
+	},
+	"update cache": updateCachedDiagnosticsTestCase{
+		cache: diagnostics{"a.go": []*lsp.Diagnostic{{Message: "foo"}}},
+		diags: diagnostics{"a.go": []*lsp.Diagnostic{{Message: "bar"}}},
+		files: []string{"a.go"},
+
+		expectedCache: diagnostics{"a.go": []*lsp.Diagnostic{{Message: "bar"}}},
+		expectedDiags: diagnostics{"a.go": []*lsp.Diagnostic{{Message: "bar"}}},
+	},
+	"remove from cache": updateCachedDiagnosticsTestCase{
+		cache: diagnostics{"a.go": []*lsp.Diagnostic{{Message: "foo"}}},
+		diags: diagnostics{},
+		files: []string{"a.go"},
+
+		expectedCache: diagnostics{},
+		expectedDiags: diagnostics{"a.go": nil}, // clears the client cache
+	},
+	"add, change and remove from cache": updateCachedDiagnosticsTestCase{
+		cache: diagnostics{
+			"a.go": []*lsp.Diagnostic{{Message: "same"}},
+			"b.go": []*lsp.Diagnostic{{Message: "will be updated"}},
+			"c.go": []*lsp.Diagnostic{{Message: "will be removed"}},
+			// d.go no diagnostics yet
+		},
+		diags: diagnostics{
+			"a.go": []*lsp.Diagnostic{{Message: "same"}},
+			"b.go": []*lsp.Diagnostic{{Message: "updated"}},
+			// c.go no diagnostics anymore
+			"d.go": []*lsp.Diagnostic{{Message: "added"}},
+		},
+		files: []string{"a.go", "c.go", "d.go"},
+
+		expectedCache: diagnostics{
+			"a.go": []*lsp.Diagnostic{{Message: "same"}},
+			"b.go": []*lsp.Diagnostic{{Message: "updated"}},
+			"d.go": []*lsp.Diagnostic{{Message: "added"}},
+		},
+		expectedDiags: diagnostics{
+			"a.go": []*lsp.Diagnostic{{Message: "same"}},
+			"b.go": []*lsp.Diagnostic{{Message: "updated"}},
+			"c.go": nil, // clears the client cache
+			"d.go": []*lsp.Diagnostic{{Message: "added"}},
+		},
+	},
+	"do not set nil if not in cache": updateCachedDiagnosticsTestCase{
+		cache: diagnostics{},
+		diags: diagnostics{},
+		files: []string{"a.go", "b.go"},
+
+		expectedCache: diagnostics{},
+		expectedDiags: diagnostics{}, // nothing, because a.go and b.go are not part of the cache
+	},
+}
+
+func TestUpdateCachedDiagnosticsTestCases(t *testing.T) {
+	for label, test := range updateCachedDiagnosticsTestCases {
+		t.Run(label, func(t *testing.T) {
+			updatedCache := updateCachedDiagnostics(test.cache, test.diags, test.files)
+
+			if !reflect.DeepEqual(test.expectedCache, updatedCache) {
+				t.Errorf("Cached diagnostics does not match\nExpected: %v\nActual: %v", test.expectedCache, updatedCache)
+			}
+
+			if !reflect.DeepEqual(test.expectedDiags, test.diags) {
+				t.Errorf("Reported diagnostics does not match\nExpected: %v\nActual: %v", test.expectedDiags, test.diags)
+			}
+		})
+	}
+}

--- a/langserver/fs.go
+++ b/langserver/fs.go
@@ -90,8 +90,12 @@ func (h *HandlerShared) handleFileSystemRequest(ctx context.Context, req *jsonrp
 		})
 
 	case "textDocument/didSave":
+		var params lsp.DidSaveTextDocumentParams
+		if err := json.Unmarshal(*req.Params, &params); err != nil {
+			return "", false, err
+		}
 		// no-op
-		return "", false, nil
+		return params.TextDocument.URI, false, nil
 
 	default:
 		panic("unexpected file system request method: " + req.Method)

--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -397,7 +397,7 @@ func (h *LangHandler) Handle(ctx context.Context, conn jsonrpc2.JSONRPC2, req *j
 				// a user is viewing this path, hint to add it to the cache
 				// (unless we're primarily using binary package cache .a
 				// files).
-				if h.Config.DiagnosticsEnabled && (!h.Config.UseBinaryPkgCache || req.Method == "textDocument/didSave") {
+				if !h.Config.UseBinaryPkgCache || (h.Config.DiagnosticsEnabled && req.Method == "textDocument/didSave") {
 					go h.typecheck(ctx, conn, uri, lsp.Position{})
 				}
 			}

--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -397,7 +397,7 @@ func (h *LangHandler) Handle(ctx context.Context, conn jsonrpc2.JSONRPC2, req *j
 				// a user is viewing this path, hint to add it to the cache
 				// (unless we're primarily using binary package cache .a
 				// files).
-				if !h.Config.UseBinaryPkgCache || req.Method == "textDocument/didSave" {
+				if h.Config.DiagnosticsEnabled && (!h.Config.UseBinaryPkgCache || req.Method == "textDocument/didSave") {
 					go h.typecheck(ctx, conn, uri, lsp.Position{})
 				}
 			}

--- a/langserver/integration_test.go
+++ b/langserver/integration_test.go
@@ -202,6 +202,7 @@ func TestIntegration_FileSystem_Diagnostics(t *testing.T) {
 	// make the test more deterministic and only receive
 	// diagnostics when sending "textDocument/didSave"
 	cfg.UseBinaryPkgCache = true
+	cfg.DiagnosticsEnabled = true
 
 	integrationTest(t, files, &cfg, func(ctx context.Context, rootURI lsp.DocumentURI, conn *jsonrpc2.Conn, notifies chan *jsonrpc2.Request) {
 		uriA := uriJoin(rootURI, "A.go")

--- a/langserver/integration_test.go
+++ b/langserver/integration_test.go
@@ -355,10 +355,10 @@ func integrationTest(
 	defer done()
 
 	notifies := make(chan *jsonrpc2.Request)
-	conn := dialServer(t, addr, func(_ context.Context, _ *jsonrpc2.Conn, req *jsonrpc2.Request) (interface{}, error) {
+	conn := dialServer(t, addr, jsonrpc2.HandlerWithError(func(_ context.Context, _ *jsonrpc2.Conn, req *jsonrpc2.Request) (interface{}, error) {
 		notifies <- req
 		return nil, nil
-	})
+	}))
 	defer func() {
 		if err := conn.Close(); err != nil {
 			t.Fatal("conn.Close:", err)

--- a/langserver/integration_test.go
+++ b/langserver/integration_test.go
@@ -199,6 +199,8 @@ func TestIntegration_FileSystem_Diagnostics(t *testing.T) {
 	}
 
 	cfg := NewDefaultConfig()
+	// make the test more deterministic and only receive
+	// diagnostics when sending "textDocument/didSave"
 	cfg.UseBinaryPkgCache = true
 
 	integrationTest(t, files, &cfg, func(ctx context.Context, rootURI lsp.DocumentURI, conn *jsonrpc2.Conn, notifies chan *jsonrpc2.Request) {
@@ -343,6 +345,8 @@ func integrationTest(
 
 	if cfg == nil {
 		c := NewDefaultConfig()
+		// do not use the pkg cache because integration tests won't install any pkgs
+		c.UseBinaryPkgCache = false
 		cfg = &c
 	}
 	h := NewHandler(*cfg)

--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -1149,7 +1149,7 @@ func serve(ctx context.Context, lis net.Listener, h jsonrpc2.Handler, opt ...jso
 	}
 }
 
-func dialServer(t testing.TB, addr string, h ...jsonrpc2.HandlerWithError) *jsonrpc2.Conn {
+func dialServer(t testing.TB, addr string, h ...*jsonrpc2.HandlerWithErrorConfigurer) *jsonrpc2.Conn {
 	conn, err := (&net.Dialer{}).Dial("tcp", addr)
 	if err != nil {
 		t.Fatal(err)

--- a/langserver/loader.go
+++ b/langserver/loader.go
@@ -66,13 +66,13 @@ func (h *LangHandler) typecheck(ctx context.Context, conn jsonrpc2.JSONRPC2, fil
 		return nil, nil, nil, nil, nil, nil, err
 	}
 
-	if len(diags) > 0 {
-		go func() {
-			if err := h.publishDiagnostics(ctx, conn, diags); err != nil {
-				log.Printf("warning: failed to send diagnostics: %s.", err)
-			}
-		}()
-	}
+	// collect all loaded files, required to remove existing diagnostics from our cache
+	files := fsetToFiles(fset)
+	go func() {
+		if err := h.publishDiagnostics(ctx, conn, diags, files); err != nil {
+			log.Printf("warning: failed to send diagnostics: %s.", err)
+		}
+	}()
 
 	start := posForFileOffset(fset, filename, offset)
 	if start == token.NoPos {
@@ -308,4 +308,12 @@ func clearInfoFields(info *loader.PackageInfo) {
 func isMultiplePackageError(err error) bool {
 	_, ok := err.(*build.MultiplePackageError)
 	return ok
+}
+
+func fsetToFiles(fset *token.FileSet) (files []string) {
+	fset.Iterate(func(f *token.File) bool {
+		files = append(files, f.Name())
+		return true
+	})
+	return files
 }

--- a/langserver/loader.go
+++ b/langserver/loader.go
@@ -68,11 +68,9 @@ func (h *LangHandler) typecheck(ctx context.Context, conn jsonrpc2.JSONRPC2, fil
 
 	// collect all loaded files, required to remove existing diagnostics from our cache
 	files := fsetToFiles(fset)
-	go func() {
-		if err := h.publishDiagnostics(ctx, conn, diags, files); err != nil {
-			log.Printf("warning: failed to send diagnostics: %s.", err)
-		}
-	}()
+	if err := h.publishDiagnostics(ctx, conn, diags, files); err != nil {
+		log.Printf("warning: failed to send diagnostics: %s.", err)
+	}
 
 	start := posForFileOffset(fset, filename, offset)
 	if start == token.NoPos {

--- a/langserver/workspace_refs.go
+++ b/langserver/workspace_refs.go
@@ -270,11 +270,9 @@ func (h *LangHandler) workspaceRefsTypecheck(ctx context.Context, bctx *build.Co
 
 	// collect all loaded files, required to remove existing diagnostics from our cache
 	files := fsetToFiles(prog.Fset)
-	go func() {
-		if err := h.publishDiagnostics(ctx, conn, diags, files); err != nil {
-			log.Printf("warning: failed to send diagnostics: %s.", err)
-		}
-	}()
+	if err := h.publishDiagnostics(ctx, conn, diags, files); err != nil {
+		log.Printf("warning: failed to send diagnostics: %s.", err)
+	}
 
 	return prog, nil
 }

--- a/langserver/workspace_refs.go
+++ b/langserver/workspace_refs.go
@@ -267,13 +267,15 @@ func (h *LangHandler) workspaceRefsTypecheck(ctx context.Context, bctx *build.Co
 	if err != nil {
 		return nil, err
 	}
-	if len(diags) > 0 {
-		go func() {
-			if err := h.publishDiagnostics(ctx, conn, diags); err != nil {
-				log.Printf("warning: failed to send diagnostics: %s.", err)
-			}
-		}()
-	}
+
+	// collect all loaded files, required to remove existing diagnostics from our cache
+	files := fsetToFiles(prog.Fset)
+	go func() {
+		if err := h.publishDiagnostics(ctx, conn, diags, files); err != nil {
+			log.Printf("warning: failed to send diagnostics: %s.", err)
+		}
+	}()
+
 	return prog, nil
 }
 

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ var (
 	usebinarypkgcache  = flag.Bool("usebinarypkgcache", true, "use $GOPATH/pkg binary .a files (improves performance)")
 	maxparallelism     = flag.Int("maxparallelism", -1, "use at max N parallel goroutines to fulfill requests")
 	gocodecompletion   = flag.Bool("gocodecompletion", false, "enable completion (extra memory burden)")
+	diagnostics        = flag.Bool("diagnostics", false, "enable diagnostics (extra memory burden)")
 	funcSnippetEnabled = flag.Bool("func-snippet-enabled", true, "enable argument snippets on func completion")
 )
 
@@ -66,6 +67,7 @@ func main() {
 	cfg := langserver.NewDefaultConfig()
 	cfg.FuncSnippetEnabled = *funcSnippetEnabled
 	cfg.GocodeCompletionEnabled = *gocodecompletion
+	cfg.DiagnosticsEnabled = *diagnostics
 	cfg.MaxParallelism = *maxparallelism
 	cfg.UseBinaryPkgCache = *usebinarypkgcache
 


### PR DESCRIPTION
This PR adds a very basic cache that holds diagnostics for each checked file. A file entry is removed once no more diagnostics exist for it.
An async `typecheck` now also happens on every save requests.

A simple unit test asserts the cache updating and an integration test modifies and saves files and then asserts certain diagnostics to be sent to the client.

Unfortunately it's currently based on #248 because it contains some changes that are necessary to work on my _windows_ machine 😞 

This is probably not 100% ready to be merged yet, but I think it is a good starting point 😁 