### PR TITLE
Reorder log/fatal in langserver_test. (Addresses issue #259.)

### DIFF
--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -1304,10 +1304,10 @@ func lspTests(t testing.TB, ctx context.Context, h *LangHandler, c *jsonrpc2.Con
 		os.Setenv("GOPATH", tmpDir)
 		out, err := exec.Command("go", "install", "-v", "all").CombinedOutput()
 		os.Setenv("GOPATH", oldGOPATH)
+		t.Logf("$ GOPATH='%s' go install -v all\n%s", tmpDir, out)
 		if err != nil {
 			t.Fatal(err)
 		}
-		t.Logf("$ go install -v all\n%s", out)
 
 		testOSToVFSPath = func(osPath string) string {
 			return strings.TrimPrefix(osPath, util.UriToPath(util.PathToURI(tmpDir)))


### PR DESCRIPTION
Under circumstances I have not adequately debugged, the
	GOPATH=[tmpdir] go install -v all
used to set up test cases can fail. In my particular case, this appears
to be because something has convinced it that it absolutely has to
rewrite cmd/pprof in $GOROOT.

Reordering these (and adding the GOPATH=...) means that, if the test
fails for this reason, we get a diagnostic more specific than "exit code 1".

Signed-off-by: Seebs <seebs@seebs.net>