### PR TITLE
hover: Ignore missing docs for godef based hover

### DIFF
--- a/langserver/hover.go
+++ b/langserver/hover.go
@@ -333,7 +333,8 @@ func (h *LangHandler) handleHoverGodef(ctx context.Context, conn jsonrpc2.JSONRP
 	target := fset.Position(res.Start)
 	docObject := findDocTarget(fset, target, docPkg)
 	if docObject == nil {
-		return nil, fmt.Errorf("failed to find doc object for %s", target)
+		// probably a local variable, so just ignore.
+		return &lsp.Hover{}, nil
 	}
 
 	contents, _ := fmtDocObject(fset, docObject, target)

--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -1092,6 +1092,33 @@ func (h *Hello) Bye() int {
 			},
 		},
 	},
+	"godoc fail issue 261": {
+		rootURI: "file:///src/test/pkg",
+		fs: map[string]string{
+			"main.go": `package main
+
+import "fmt"
+
+type T string
+type TM map[string]T
+
+func main() {
+	var tm TM
+	for _, t := range tm {
+		fmt.Println(t)
+	}
+}
+`,
+		},
+		cases: lspTestCases{
+			overrideGodefHover: map[string]string{
+				"main.go:11:15": "",
+			},
+			wantHover: map[string]string{
+				"main.go:11:15": "var t T",
+			},
+		},
+	},
 }
 
 func TestServer(t *testing.T) {


### PR DESCRIPTION
Our godef based implementation relies on a user hovering over a token whose
def can be reported by godoc. However, this fails for variables in local
scope (very common!). I am unsure how to fix this right now other than
ignoring the error. I assume we can use the AST to construct this
information. For our other hover implementation we build this using the type
information.

Fixes https://github.com/sourcegraph/go-langserver/issues/261