### PR TITLE
Initial implementation for textdocument/typeDefinition

### DIFF
--- a/langserver/definition.go
+++ b/langserver/definition.go
@@ -119,10 +119,9 @@ func (h *LangHandler) typeLookup(prog *loader.Program, typ types.Type) *types.Ty
 	}
 	switch t := typ.(type) {
 	case *types.Pointer:
-		for base, ok := typ.(*types.Pointer); ok; base, ok = typ.(*types.Pointer) {
-			typ = base.Elem()
-		}
-		return h.typeLookup(prog, typ)
+		return h.typeLookup(prog, t.Elem())
+	case *types.Slice:
+		return h.typeLookup(prog, t.Elem())
 	case *types.Named:
 		return t.Obj()
 	}

--- a/langserver/definition.go
+++ b/langserver/definition.go
@@ -122,7 +122,7 @@ type dereferencable interface {
 // which have an unambiguous base type. If no named type is
 // found, we are not interested, because this is only used
 // for finding a type's definition.
-func (h *LangHandler) typeLookup(prog *loader.Program, typ types.Type) *types.TypeName {
+func typeLookup(prog *loader.Program, typ types.Type) *types.TypeName {
 	if typ == nil {
 		return nil
 	}
@@ -170,7 +170,7 @@ func (h *LangHandler) handleXDefinition(ctx context.Context, conn jsonrpc2.JSONR
 		if p := obj.Pos(); p.IsValid() {
 			nodes = append(nodes, foundNode{
 				ident: &ast.Ident{NamePos: p, Name: obj.Name()},
-				typ: h.typeLookup(prog, pkg.TypeOf(node)),
+				typ: typeLookup(prog, pkg.TypeOf(node)),
 			})
 		} else {
 			// Builtins have an invalid Pos. Just don't emit a definition for

--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -236,6 +236,7 @@ func (h *LangHandler) Handle(ctx context.Context, conn jsonrpc2.JSONRPC2, req *j
 				},
 				CompletionProvider:           completionOp,
 				DefinitionProvider:           true,
+				TypeDefinitionProvider:       true,
 				DocumentFormattingProvider:   true,
 				DocumentSymbolProvider:       true,
 				HoverProvider:                true,
@@ -301,6 +302,16 @@ func (h *LangHandler) Handle(ctx context.Context, conn jsonrpc2.JSONRPC2, req *j
 			return nil, err
 		}
 		return h.handleDefinition(ctx, conn, req, params)
+
+	case "textDocument/typeDefinition":
+		if req.Params == nil {
+			return nil, &jsonrpc2.Error{Code: jsonrpc2.CodeInvalidParams}
+		}
+		var params lsp.TextDocumentPositionParams
+		if err := json.Unmarshal(*req.Params, &params); err != nil {
+			return nil, err
+		}
+		return h.handleTypeDefinition(ctx, conn, req, params)
 
 	case "textDocument/xdefinition":
 		if req.Params == nil {

--- a/langserver/internal/refs/refs.go
+++ b/langserver/internal/refs/refs.go
@@ -300,14 +300,30 @@ func deepRecvType(sel *types.Selection) types.Type {
 	return typ
 }
 
-func dereferenceType(typ types.Type) types.Type {
-	if typ, ok := typ.(*types.Pointer); ok {
-		return dereferenceType(typ.Elem())
+// Every types.Type with an Elem() is a dereferencable type,
+// such as slice, array, chan, pointer. In every case but
+// types.Map, it is unambiguous which type you would want to
+// look up if you were asked to look up the derived type.
+type dereferencable interface {
+	Elem() types.Type
+}
+
+// dereferenceType finds the "root" type of a thing, meaning
+// the type pointed-to by a pointer, the element type of
+// a slice or array, or the object type of a chan. The special
+// case for Map is because a Map would also have a key, and
+// you might be interested in either of those.
+func dereferenceType(otyp types.Type) types.Type {
+	for {
+		switch typ := otyp.(type) {
+			case *types.Map:
+				return otyp
+			case dereferencable:
+				otyp = typ.Elem()
+			default:
+				return otyp
+		}
 	}
-	if typ, ok := typ.(*types.Slice); ok {
-		return dereferenceType(typ.Elem())
-	}
-	return typ
 }
 
 func typeName(typ types.Type) (pkg, pkgName, name string, ok bool) {

--- a/langserver/internal/refs/refs.go
+++ b/langserver/internal/refs/refs.go
@@ -302,7 +302,10 @@ func deepRecvType(sel *types.Selection) types.Type {
 
 func dereferenceType(typ types.Type) types.Type {
 	if typ, ok := typ.(*types.Pointer); ok {
-		return typ.Elem()
+		return dereferenceType(typ.Elem())
+	}
+	if typ, ok := typ.(*types.Slice); ok {
+		return dereferenceType(typ.Elem())
 	}
 	return typ
 }

--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -1124,6 +1124,8 @@ func main() {
 		fs: map[string]string{
 			"a/a.go": `package a; type A int; func A1() A { var A A = 1; return A }`,
 			"b/b.go": `package b; import "test/pkg/a"; func Dummy() a.A { x := a.A1(); return x }`,
+			"c/c.go": `package c; import "test/pkg/a"; func Dummy() *a.A { var x *a.A; return x }`,
+			"d/d.go": `package d; import "test/pkg/a"; func Dummy() []a.A { var x []a.A; return x }`,
 		},
 		cases: lspTestCases{
 			wantDefinition: map[string]string{
@@ -1132,6 +1134,8 @@ func main() {
 			wantTypeDefinition: map[string]string{
 				"a/a.go:1:58": "/src/test/pkg/a/a.go:1:17-1:19", // declaration of A's type, a.A.
 				"b/b.go:1:72": "/src/test/pkg/a/a.go:1:17-1:19", // declaration of x's type, a.A.
+				"c/c.go:1:72": "/src/test/pkg/a/a.go:1:17-1:19", // declaration of *x's type, a.A.
+				"d/d.go:1:74": "",                               // no lookup for slice
 			},
 		},
 	},

--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -1124,8 +1124,8 @@ func main() {
 		fs: map[string]string{
 			"a/a.go": `package a; type A int; func A1() A { var A A = 1; return A }`,
 			"b/b.go": `package b; import "test/pkg/a"; func Dummy() a.A { x := a.A1(); return x }`,
-			"c/c.go": `package c; import "test/pkg/a"; func Dummy() *a.A { var x *a.A; return x }`,
-			"d/d.go": `package d; import "test/pkg/a"; func Dummy() []a.A { var x []a.A; return x }`,
+			"c/c.go": `package c; import "test/pkg/a"; func Dummy() **a.A { var x **a.A; return x }`,
+			"d/d.go": `package d; import "test/pkg/a"; func Dummy() map[string]a.A { var x map[string]a.A; return x }`,
 		},
 		cases: lspTestCases{
 			wantDefinition: map[string]string{
@@ -1134,8 +1134,8 @@ func main() {
 			wantTypeDefinition: map[string]string{
 				"a/a.go:1:58": "/src/test/pkg/a/a.go:1:17-1:19", // declaration of A's type, a.A.
 				"b/b.go:1:72": "/src/test/pkg/a/a.go:1:17-1:19", // declaration of x's type, a.A.
-				"c/c.go:1:72": "/src/test/pkg/a/a.go:1:17-1:19", // declaration of *x's type, a.A.
-				"d/d.go:1:74": "",                               // no lookup for slice
+				"c/c.go:1:74": "/src/test/pkg/a/a.go:1:17-1:19", // declaration of **x's type, a.A.
+				"d/d.go:1:92": "",                               // no lookup for slice
 			},
 		},
 	},

--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -1132,9 +1132,9 @@ func main() {
 				"b/b.go:1:72": "/src/test/pkg/b/b.go:1:52-1:53", // declaration of x
 			},
 			wantTypeDefinition: map[string]string{
-				"a/a.go:1:58": "/src/test/pkg/a/a.go:1:17-1:19", // declaration of A's type, a.A.
-				"b/b.go:1:72": "/src/test/pkg/a/a.go:1:17-1:19", // declaration of x's type, a.A.
-				"c/c.go:1:74": "/src/test/pkg/a/a.go:1:17-1:19", // declaration of **x's type, a.A.
+				"a/a.go:1:58": "/src/test/pkg/a/a.go:1:17-1:18", // declaration of A's type, a.A.
+				"b/b.go:1:72": "/src/test/pkg/a/a.go:1:17-1:18", // declaration of x's type, a.A.
+				"c/c.go:1:74": "/src/test/pkg/a/a.go:1:17-1:18", // declaration of **x's type, a.A.
 				"d/d.go:1:92": "",                               // no lookup for slice
 			},
 		},

--- a/langserver/lsp.go
+++ b/langserver/lsp.go
@@ -59,9 +59,11 @@ func (a *symbolDescriptor) Contains(b lspext.SymbolDescriptor) bool {
 // our custom symbolDescriptor
 type symbolLocationInformation struct {
 	// A concrete location at which the definition is located, if any.
-	Location lsp.Location `json:"location,omitempty"`
+	Location     lsp.Location      `json:"location,omitempty"`
 	// Metadata about the definition.
-	Symbol *symbolDescriptor `json:"symbol"`
+	Symbol       *symbolDescriptor `json:"symbol"`
+	// the location of a type declaration, if one is available
+	TypeLocation lsp.Location      `json:"-"`
 }
 
 // referenceInformation is lspext.ReferenceInformation using our custom symbolDescriptor

--- a/pkg/lsp/service.go
+++ b/pkg/lsp/service.go
@@ -154,6 +154,7 @@ type ServerCapabilities struct {
 	CompletionProvider               *CompletionOptions               `json:"completionProvider,omitempty"`
 	SignatureHelpProvider            *SignatureHelpOptions            `json:"signatureHelpProvider,omitempty"`
 	DefinitionProvider               bool                             `json:"definitionProvider,omitempty"`
+	TypeDefinitionProvider           bool                             `json:"typeDefinitionProvider,omitempty"`
 	ReferencesProvider               bool                             `json:"referencesProvider,omitempty"`
 	DocumentHighlightProvider        bool                             `json:"documentHighlightProvider,omitempty"`
 	DocumentSymbolProvider           bool                             `json:"documentSymbolProvider,omitempty"`


### PR DESCRIPTION
This adds a test case for `textdocument/typeDefinition`, and also an initial implementation.