### PR TITLE
Don't treat go 1.10 as go 1.8

### DIFF
--- a/langserver/internal/godef/go/parser/parser_go18.go
+++ b/langserver/internal/godef/go/parser/parser_go18.go
@@ -1,4 +1,4 @@
-// +build !go1.9
+// +build !go1.9,!go1.10
 
 package parser
 

--- a/langserver/internal/godef/go/parser/parser_go19.go
+++ b/langserver/internal/godef/go/parser/parser_go19.go
@@ -1,4 +1,4 @@
-// +build go1.9
+// +build go1.9 go1.10
 
 package parser
 


### PR DESCRIPTION
go1.10 has the same parseTypeSpec as go1.9 (checked with golang
sources), so fix build flags.

Signed-off-by: Seebs <seebs@seebs.net>

A more nuanced fix would distinguish between "go used to build go-langserver" and "go used by the code being edited", but that's probably a significantly harder problem. It might be wiser to change this to invert the sense of the build tags, and check for 1.8-or-earlier, but I'm not sure how much earlier to go, and this simple fix at least postpones the decision for a couple of months.