### PR TITLE
lsp: Do not marshal a nil hover contents

### DIFF
--- a/pkg/lsp/service.go
+++ b/pkg/lsp/service.go
@@ -309,6 +309,18 @@ type Hover struct {
 	Range    *Range         `json:"range,omitempty"`
 }
 
+type hover Hover
+
+func (h Hover) MarshalJSON() ([]byte, error) {
+	if h.Contents == nil {
+		return json.Marshal(hover{
+			Contents: []MarkedString{},
+			Range:    h.Range,
+		})
+	}
+	return json.Marshal(hover(h))
+}
+
 type MarkedString markedString
 
 type markedString struct {

--- a/pkg/lsp/service_test.go
+++ b/pkg/lsp/service_test.go
@@ -94,3 +94,44 @@ func TestMarkedString_MarshalUnmarshalJSON(t *testing.T) {
 		}
 	}
 }
+
+func TestHover(t *testing.T) {
+	tests := []struct {
+		data          []byte
+		want          Hover
+		skipUnmarshal bool
+		skipMarshal   bool
+	}{{
+		data: []byte(`{"contents":[{"language":"go","value":"foo"}]}`),
+		want: Hover{Contents: []MarkedString{{Language: "go", Value: "foo", isRawString: false}}},
+	}, {
+		data:          []byte(`{"contents":[]}`),
+		want:          Hover{Contents: nil},
+		skipUnmarshal: true, // testing we don't marshal nil
+	}}
+
+	for _, test := range tests {
+		if !test.skipUnmarshal {
+			var h Hover
+			if err := json.Unmarshal(test.data, &h); err != nil {
+				t.Errorf("json.Unmarshal error: %s", err)
+				continue
+			}
+			if !reflect.DeepEqual(test.want, h) {
+				t.Errorf("Unmarshaled %q, expected %+v, but got %+v", string(test.data), test.want, h)
+				continue
+			}
+		}
+
+		if !test.skipMarshal {
+			marshaled, err := json.Marshal(&test.want)
+			if err != nil {
+				t.Errorf("json.Marshal error: %s", err)
+				continue
+			}
+			if string(marshaled) != string(test.data) {
+				t.Errorf("Marshaled result expected %s, but got %s", string(test.data), string(marshaled))
+			}
+		}
+	}
+}


### PR DESCRIPTION
An empty slice in Go can be nil, but we don't want to marshal nil since the spec
doesn't allow it.

Fixes https://github.com/sourcegraph/go-langserver/issues/284