### PR TITLE
concatenate line comments to field documentation

### DIFF
--- a/langserver/hover.go
+++ b/langserver/hover.go
@@ -125,19 +125,14 @@ func (h *LangHandler) handleHover(ctx context.Context, conn jsonrpc2.JSONRPC2, r
 			switch v := path[i].(type) {
 			case *ast.Field:
 				doc = v.Doc
+				// Fallback to inline comments when there is no associated documentation
 				if doc == nil {
 					doc = v.Comment
 				}
 			case *ast.ValueSpec:
 				doc = v.Doc
-				if doc == nil {
-					doc = v.Comment
-				}
 			case *ast.TypeSpec:
 				doc = v.Doc
-				if doc == nil {
-					doc = v.Comment
-				}
 			case *ast.GenDecl:
 				doc = v.Doc
 			case *ast.FuncDecl:
@@ -494,7 +489,14 @@ func fmtDocObject(fset *token.FileSet, x interface{}, target token.Position) ([]
 				if fset.Position(field.Pos()).Offset == target.Offset {
 					// An exact match.
 					value := fmt.Sprintf("struct field %s %s", field.Names[0], fmtNode(fset, field.Type))
-					return maybeAddComments(field.Doc.Text(), []lsp.MarkedString{{Language: "go", Value: value}}), field
+					doc := field.Doc
+
+					// Fallback to inline comments when there is no associated documentation
+					if doc == nil {
+						doc = field.Comment
+					}
+
+					return maybeAddComments(doc.Text(), []lsp.MarkedString{{Language: "go", Value: value}}), field
 				}
 			}
 		}

--- a/langserver/hover.go
+++ b/langserver/hover.go
@@ -125,10 +125,19 @@ func (h *LangHandler) handleHover(ctx context.Context, conn jsonrpc2.JSONRPC2, r
 			switch v := path[i].(type) {
 			case *ast.Field:
 				doc = v.Doc
+				if doc == nil {
+					doc = v.Comment
+				}
 			case *ast.ValueSpec:
 				doc = v.Doc
+				if doc == nil {
+					doc = v.Comment
+				}
 			case *ast.TypeSpec:
 				doc = v.Doc
+				if doc == nil {
+					doc = v.Comment
+				}
 			case *ast.GenDecl:
 				doc = v.Doc
 			case *ast.FuncDecl:

--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -912,6 +912,23 @@ type Header struct {
 			},
 		},
 	},
+	"go hover docs special cases": {
+		rootURI: "file:///src/test/pkg",
+		fs: map[string]string{
+			"q.go": `package p
+type T struct {
+	Q string // Q is a string field.
+	// X is confusing!
+	X int // This is a trap.
+}`,
+		},
+		cases: lspTestCases{
+			wantHover: map[string]string{
+				"q.go:3:2": "struct field Q string; Q is a string field. \n\n",
+				"q.go:5:2": "struct field X int; X is confusing! \n\n",
+			},
+		},
+	},
 	"workspace references multiple files": {
 		rootURI: "file:///src/test/pkg",
 		fs: map[string]string{

--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -918,14 +918,14 @@ type Header struct {
 			"q.go": `package p
 type T struct {
 	Q string // Q is a string field.
-	// X is confusing!
-	X int // This is a trap.
+	// X is documented.
+	X int // X has comments.
 }`,
 		},
 		cases: lspTestCases{
 			wantHover: map[string]string{
 				"q.go:3:2": "struct field Q string; Q is a string field. \n\n",
-				"q.go:5:2": "struct field X int; X is confusing! \n\n",
+				"q.go:5:2": "struct field X int; X is documented. \n\nX has comments. \n\n",
 			},
 		},
 	},

--- a/langserver/util/util.go
+++ b/langserver/util/util.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"fmt"
+	"go/ast"
 	"log"
 	"net/url"
 	"path/filepath"
@@ -13,6 +14,19 @@ import (
 
 func trimFilePrefix(s string) string {
 	return strings.TrimPrefix(s, "file://")
+}
+
+// ConcatCommentGroups joins the resultant comment text from two CommentGroups with a newline.
+func ConcatCommentGroups(a, b *ast.CommentGroup) string {
+	a_text := a.Text()
+	b_text := b.Text()
+	if len(a_text) == 0 {
+		return b_text
+	} else if len(b_text) == 0 {
+		return a_text
+	} else {
+		return a_text + "\n" + b_text
+	}
 }
 
 // PathHasPrefix returns true if s is starts with the given prefix


### PR DESCRIPTION
This might address issue [269](https://github.com/sourcegraph/go-langserver/issues/269). This was a quick fix, so I'm totally open to feedback on the proper way to go about contributing here. Hope this helps!