### PR TITLE
set gocode Autobuild to true, allows completion of vendor packages

### DIFF
--- a/langserver/internal/gocode/export.go
+++ b/langserver/internal/gocode/export.go
@@ -9,6 +9,7 @@ var bctx go_build_context
 func InitDaemon(bc *build.Context) {
 	bctx = pack_build_context(bc)
 	g_config.ProposeBuiltins = true
+	g_config.Autobuild = true
 	g_daemon = new(daemon)
 	g_daemon.drop_cache()
 }


### PR DESCRIPTION
Setting autobuild to true will allow gocode to autobuild package cache for vendor packages. I couldn't get dep vendored packages to work without this.