### PR TITLE
Adds format-tool cli flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ var (
 	gocodecompletion   = flag.Bool("gocodecompletion", false, "enable completion (extra memory burden). Can be overridden by InitializationOptions.")
 	diagnostics        = flag.Bool("diagnostics", false, "enable diagnostics (extra memory burden). Can be overridden by InitializationOptions.")
 	funcSnippetEnabled = flag.Bool("func-snippet-enabled", true, "enable argument snippets on func completion. Can be overridden by InitializationOptions.")
+	formatTool         = flag.String("format-tool", "goimports", "which tool is used to format documents. Supported: goimports and gofmt. Can be overridden by InitializationOptions.")
 )
 
 // version is the version field we report back. If you are releasing a new version:
@@ -62,6 +63,7 @@ func main() {
 	cfg.GocodeCompletionEnabled = *gocodecompletion
 	cfg.DiagnosticsEnabled = *diagnostics
 	cfg.UseBinaryPkgCache = *usebinarypkgcache
+	cfg.FormatTool = *formatTool
 
 	if *maxparallelism > 0 {
 		cfg.MaxParallelism = *maxparallelism


### PR DESCRIPTION
Now that multiple format tools are available, I'd like to be able to set one from the CLI!
This PR adds a flag to set the format tool with `goimports` as the default.