### PR TITLE
Add support for linting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ go_import_path: github.com/sourcegraph/go-langserver
 
 install:
   - go get -d -t ./...
+  - go get golang.org/x/lint/golint
   - go test -i ./...
 
 script:

--- a/README.md
+++ b/README.md
@@ -49,6 +49,16 @@ interface GoInitializationOptions {
    */
   formatTool?: "goimports" | "gofmt";
 
+
+  /**
+   * lintTool decides which tool is used for linting documents. Supported: none and golint
+   *
+   * Diagnostics must be enable for linting to work.
+   *
+   * Defaults to none if not specified.
+   */
+  formatTool?: "none" | "golint";
+
   /**
    * goimportsLocalPrefix sets the local prefix (comma-separated string) that goimports will use.
    *

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ interface GoInitializationOptions {
    *
    * Defaults to none if not specified.
    */
-  formatTool?: "none" | "golint";
+  lintTool?: "none" | "golint";
 
   /**
    * goimportsLocalPrefix sets the local prefix (comma-separated string) that goimports will use.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ interface GoInitializationOptions {
   /**
    * lintTool decides which tool is used for linting documents. Supported: none and golint
    *
-   * Diagnostics must be enable for linting to work.
+   * Diagnostics must be enabled for linting to work.
    *
    * Defaults to none if not specified.
    */

--- a/langserver/config.go
+++ b/langserver/config.go
@@ -34,6 +34,13 @@ type Config struct {
 	// Defaults to goimports if not specified.
 	FormatTool string
 
+	// LintTool decides which tool is used for linting documents. Supported: golint and none
+	//
+	// Diagnostics must be enable for linting to work.
+	//
+	// Defaults to none if not specified.
+	LintTool string
+
 	// GoimportsLocalPrefix sets the local prefix (comma-separated string) that goimports will use
 	//
 	// Defaults to empty string if not specified.
@@ -73,6 +80,9 @@ func (c Config) Apply(o *InitializationOptions) Config {
 	if o.FormatTool != nil {
 		c.FormatTool = *o.FormatTool
 	}
+	if o.LintTool != nil {
+		c.LintTool = *o.LintTool
+	}
 	if o.GoimportsLocalPrefix != nil {
 		c.GoimportsLocalPrefix = *o.GoimportsLocalPrefix
 	}
@@ -98,6 +108,7 @@ func NewDefaultConfig() Config {
 		FuncSnippetEnabled:      true,
 		GocodeCompletionEnabled: false,
 		FormatTool:              formatToolGoimports,
+		LintTool:                lintToolNone,
 		MaxParallelism:          maxparallelism,
 		UseBinaryPkgCache:       true,
 	}

--- a/langserver/config.go
+++ b/langserver/config.go
@@ -36,7 +36,7 @@ type Config struct {
 
 	// LintTool decides which tool is used for linting documents. Supported: golint and none
 	//
-	// Diagnostics must be enable for linting to work.
+	// Diagnostics must be enabled for linting to work.
 	//
 	// Defaults to none if not specified.
 	LintTool string

--- a/langserver/diagnostics.go
+++ b/langserver/diagnostics.go
@@ -75,7 +75,7 @@ func syncCachedDiagnostics(cachedDiagnostics diagnostics, newDiagnostics diagnos
 	for _, file := range files {
 		_, fileInCache := cachedDiagnostics[file]
 
-		//remove all of the diagnostics for the given source/file combinations and add the new diagnostics to the cache.
+		// remove all of the diagnostics for the given source/file combinations and add the new diagnostics to the cache.
 		i := 0
 		for _, diag := range cachedDiagnostics[file] {
 			if diag.Source != source {

--- a/langserver/diagnostics.go
+++ b/langserver/diagnostics.go
@@ -24,21 +24,33 @@ type diagnosticsCache struct {
 	cache diagnostics
 }
 
-// update the cached diagnostics. In order to keep the cache in good shape it
-// is required that only one go routine is able to modify the cache at a time.
-func (p *diagnosticsCache) update(fn func(diagnostics) diagnostics) {
-	p.mu.Lock()
-	if p.cache == nil {
-		p.cache = diagnostics{}
-	}
-	p.cache = fn(p.cache)
-	p.mu.Unlock()
-}
-
 func newDiagnosticsCache() *diagnosticsCache {
 	return &diagnosticsCache{
 		cache: diagnostics{},
 	}
+}
+
+// sync updates the diagnosticsCache and returns diagnostics need to be
+// published.
+//
+// When a file no longer has any diagnostics the file will be removed from
+// the cache. The removed file will be included in the returned diagnostics
+// in order to clear the client.
+//
+// sync is thread safe and will only allow one go routine to modify the cache
+// at a time.
+func (p *diagnosticsCache) sync(update func(diagnostics) diagnostics, compare func(oldDiagnostics, newDiagnostics diagnostics) (publish diagnostics)) (publish diagnostics) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.cache == nil {
+		p.cache = diagnostics{}
+	}
+
+	newCache := update(p.cache)
+	publish = compare(p.cache, newCache)
+	p.cache = newCache
+	return publish
 }
 
 // publishDiagnostics sends diagnostic information (such as compile
@@ -52,11 +64,16 @@ func (h *LangHandler) publishDiagnostics(ctx context.Context, conn jsonrpc2.JSON
 		diags = diagnostics{}
 	}
 
-	h.diagnosticsCache.update(func(cached diagnostics) diagnostics {
-		return syncCachedDiagnostics(cached, diags, source, files)
-	})
+	publish := h.diagnosticsCache.sync(
+		func(cached diagnostics) diagnostics {
+			return updateCachedDiagnostics(cached, diags, source, files)
+		},
+		func(oldDiagnostics, newDiagnostics diagnostics) (publish diagnostics) {
+			return compareCachedDiagnostics(oldDiagnostics, newDiagnostics, files)
+		},
+	)
 
-	for filename, diags := range diags {
+	for filename, diags := range publish {
 		params := lsp.PublishDiagnosticsParams{
 			URI:         util.PathToURI(filename),
 			Diagnostics: make([]lsp.Diagnostic, len(diags)),
@@ -71,37 +88,53 @@ func (h *LangHandler) publishDiagnostics(ctx context.Context, conn jsonrpc2.JSON
 	return nil
 }
 
-func syncCachedDiagnostics(cachedDiagnostics diagnostics, newDiagnostics diagnostics, source string, files []string) diagnostics {
+func updateCachedDiagnostics(cachedDiagnostics diagnostics, newDiagnostics diagnostics, source string, files []string) diagnostics {
+	// copy cachedDiagnostics so we don't mutate it
+	cache := make(diagnostics, len(cachedDiagnostics))
+	for k, v := range cachedDiagnostics {
+		cache[k] = v
+	}
+
 	for _, file := range files {
-		_, fileInCache := cachedDiagnostics[file]
 
 		// remove all of the diagnostics for the given source/file combinations and add the new diagnostics to the cache.
 		i := 0
-		for _, diag := range cachedDiagnostics[file] {
+		for _, diag := range cache[file] {
 			if diag.Source != source {
-				cachedDiagnostics[file][i] = diag
+				cache[file][i] = diag
 				i++
 			}
 		}
-		cachedDiagnostics[file] = append(cachedDiagnostics[file][:i], newDiagnostics[file]...)
-
-		// if the file was already in the cache, the existing diagnostics need sent to the client along with the new
-		if fileInCache {
-			newDiagnostics[file] = cachedDiagnostics[file]
-		}
+		cache[file] = append(cache[file][:i], newDiagnostics[file]...)
 
 		// clear out empty cache
-		if len(cachedDiagnostics[file]) == 0 {
-			delete(cachedDiagnostics, file)
-
-			// clear out the client cache
-			if fileInCache {
-				newDiagnostics[file] = nil
-			}
+		if len(cache[file]) == 0 {
+			delete(cache, file)
 		}
 	}
 
-	return cachedDiagnostics
+	return cache
+}
+
+// compareCachedDiagnostics compares new and old diagnostics to determine
+// what needs to be published.
+func compareCachedDiagnostics(oldDiagnostics, newDiagnostics diagnostics, files []string) (publish diagnostics) {
+	publish = diagnostics{}
+	for _, f := range files {
+		_, inOld := oldDiagnostics[f]
+		diags, inNew := newDiagnostics[f]
+
+		if inOld && !inNew {
+			publish[f] = nil
+			continue
+		}
+
+		if inNew {
+			publish[f] = diags
+		}
+	}
+
+	return publish
 }
 
 func errsToDiagnostics(typeErrs []error, prog *loader.Program) (diagnostics, error) {

--- a/langserver/diagnostics_test.go
+++ b/langserver/diagnostics_test.go
@@ -7,72 +7,72 @@ import (
 	"github.com/sourcegraph/go-langserver/pkg/lsp"
 )
 
-type updateCachedDiagnosticsTestCase struct {
+type syncCachedDiagnosticsTestCase struct {
 	cache  diagnostics
 	diags  diagnostics
 	source string
 	files  []string
 
-	expectedCache diagnostics
-	expectedDiags diagnostics
+	expectedCache   diagnostics
+	expectedPublish diagnostics
 }
 
-var updateCachedDiagnosticsTestCases = map[string]updateCachedDiagnosticsTestCase{
-	"add to cache": updateCachedDiagnosticsTestCase{
+var syncCachedDiagnosticsTestCases = map[string]syncCachedDiagnosticsTestCase{
+	"add to cache": syncCachedDiagnosticsTestCase{
 		cache:  diagnostics{},
 		diags:  diagnostics{"a.go": []*lsp.Diagnostic{{Message: "foo", Source: "go"}}},
 		source: "go",
 		files:  []string{"a.go"},
 
-		expectedCache: diagnostics{"a.go": []*lsp.Diagnostic{{Message: "foo", Source: "go"}}},
-		expectedDiags: diagnostics{"a.go": []*lsp.Diagnostic{{Message: "foo", Source: "go"}}},
+		expectedCache:   diagnostics{"a.go": []*lsp.Diagnostic{{Message: "foo", Source: "go"}}},
+		expectedPublish: diagnostics{"a.go": []*lsp.Diagnostic{{Message: "foo", Source: "go"}}},
 	},
-	"add to cache multi source": updateCachedDiagnosticsTestCase{
+	"add to cache multi source": syncCachedDiagnosticsTestCase{
 		cache:  diagnostics{"a.go": []*lsp.Diagnostic{{Message: "foo", Source: "lint"}}},
 		diags:  diagnostics{"a.go": []*lsp.Diagnostic{{Message: "bar", Source: "go"}}},
 		source: "go",
 		files:  []string{"a.go"},
 
-		expectedCache: diagnostics{"a.go": []*lsp.Diagnostic{{Message: "foo", Source: "lint"}, {Message: "bar", Source: "go"}}},
-		expectedDiags: diagnostics{"a.go": []*lsp.Diagnostic{{Message: "foo", Source: "lint"}, {Message: "bar", Source: "go"}}},
+		expectedCache:   diagnostics{"a.go": []*lsp.Diagnostic{{Message: "foo", Source: "lint"}, {Message: "bar", Source: "go"}}},
+		expectedPublish: diagnostics{"a.go": []*lsp.Diagnostic{{Message: "foo", Source: "lint"}, {Message: "bar", Source: "go"}}},
 	},
-	"update cache": updateCachedDiagnosticsTestCase{
+	"update cache": syncCachedDiagnosticsTestCase{
 		cache:  diagnostics{"a.go": []*lsp.Diagnostic{{Message: "foo", Source: "go"}}},
 		diags:  diagnostics{"a.go": []*lsp.Diagnostic{{Message: "bar", Source: "go"}}},
 		source: "go",
 		files:  []string{"a.go"},
 
-		expectedCache: diagnostics{"a.go": []*lsp.Diagnostic{{Message: "bar", Source: "go"}}},
-		expectedDiags: diagnostics{"a.go": []*lsp.Diagnostic{{Message: "bar", Source: "go"}}},
+		expectedCache:   diagnostics{"a.go": []*lsp.Diagnostic{{Message: "bar", Source: "go"}}},
+		expectedPublish: diagnostics{"a.go": []*lsp.Diagnostic{{Message: "bar", Source: "go"}}},
 	},
-	"update cache multi source": updateCachedDiagnosticsTestCase{
+	"update cache multi source": syncCachedDiagnosticsTestCase{
 		cache:  diagnostics{"a.go": []*lsp.Diagnostic{{Message: "foo", Source: "lint"}, {Message: "will be updated", Source: "go"}}},
 		diags:  diagnostics{"a.go": []*lsp.Diagnostic{{Message: "updated", Source: "go"}}},
 		source: "go",
 		files:  []string{"a.go"},
 
-		expectedCache: diagnostics{"a.go": []*lsp.Diagnostic{{Message: "foo", Source: "lint"}, {Message: "updated", Source: "go"}}},
-		expectedDiags: diagnostics{"a.go": []*lsp.Diagnostic{{Message: "foo", Source: "lint"}, {Message: "updated", Source: "go"}}},
+		expectedCache:   diagnostics{"a.go": []*lsp.Diagnostic{{Message: "foo", Source: "lint"}, {Message: "updated", Source: "go"}}},
+		expectedPublish: diagnostics{"a.go": []*lsp.Diagnostic{{Message: "foo", Source: "lint"}, {Message: "updated", Source: "go"}}},
 	},
-	"remove from cache": updateCachedDiagnosticsTestCase{
+	"remove from cache": syncCachedDiagnosticsTestCase{
 		cache:  diagnostics{"a.go": []*lsp.Diagnostic{{Message: "foo", Source: "go"}}},
 		diags:  diagnostics{},
 		source: "go",
 		files:  []string{"a.go"},
 
-		expectedCache: diagnostics{},
-		expectedDiags: diagnostics{"a.go": nil}, // clears the client cache
+		expectedCache:   diagnostics{},
+		expectedPublish: diagnostics{"a.go": nil}, // clears the client cache
 	},
-	"remove from cache  multi source": updateCachedDiagnosticsTestCase{
+	"remove from cache  multi source": syncCachedDiagnosticsTestCase{
 		cache:  diagnostics{"a.go": []*lsp.Diagnostic{{Message: "foo", Source: "lint"}, {Message: "bar", Source: "go"}}},
 		diags:  diagnostics{},
 		source: "go",
 		files:  []string{"a.go"},
 
-		expectedCache: diagnostics{"a.go": []*lsp.Diagnostic{{Message: "foo", Source: "lint"}}},
-		expectedDiags: diagnostics{"a.go": []*lsp.Diagnostic{{Message: "foo", Source: "lint"}}},
+		expectedCache:   diagnostics{"a.go": []*lsp.Diagnostic{{Message: "foo", Source: "lint"}}},
+		expectedPublish: diagnostics{"a.go": []*lsp.Diagnostic{{Message: "foo", Source: "lint"}}},
 	},
-	"add, change and remove from cache": updateCachedDiagnosticsTestCase{
+	"add, change and remove from cache": syncCachedDiagnosticsTestCase{
 		cache: diagnostics{
 			"a.go": []*lsp.Diagnostic{{Message: "same", Source: "go"}},
 			"b.go": []*lsp.Diagnostic{{Message: "will be updated", Source: "go"}},
@@ -93,14 +93,14 @@ var updateCachedDiagnosticsTestCases = map[string]updateCachedDiagnosticsTestCas
 			"b.go": []*lsp.Diagnostic{{Message: "updated", Source: "go"}},
 			"d.go": []*lsp.Diagnostic{{Message: "added", Source: "go"}},
 		},
-		expectedDiags: diagnostics{
+		expectedPublish: diagnostics{
 			"a.go": []*lsp.Diagnostic{{Message: "same", Source: "go"}},
 			"b.go": []*lsp.Diagnostic{{Message: "updated", Source: "go"}},
 			"c.go": nil, // clears the client cache
 			"d.go": []*lsp.Diagnostic{{Message: "added", Source: "go"}},
 		},
 	},
-	"add, change and remove from cache multi source": updateCachedDiagnosticsTestCase{
+	"add, change and remove from cache multi source": syncCachedDiagnosticsTestCase{
 		cache: diagnostics{
 			"a.go": []*lsp.Diagnostic{{Message: "same", Source: "go"}, {Message: "same", Source: "lint"}},
 			"b.go": []*lsp.Diagnostic{{Message: "will be updated", Source: "go"}, {Message: "same", Source: "lint"}},
@@ -124,7 +124,7 @@ var updateCachedDiagnosticsTestCases = map[string]updateCachedDiagnosticsTestCas
 			"c.go": []*lsp.Diagnostic{{Message: "same", Source: "lint"}},
 			"d.go": []*lsp.Diagnostic{{Message: "added", Source: "go"}},
 		},
-		expectedDiags: diagnostics{
+		expectedPublish: diagnostics{
 			"a.go": []*lsp.Diagnostic{{Message: "same", Source: "lint"}, {Message: "same", Source: "go"}},
 			"b.go": []*lsp.Diagnostic{{Message: "same", Source: "lint"}, {Message: "updated", Source: "go"}},
 			"c.go": []*lsp.Diagnostic{{Message: "same", Source: "lint"}},
@@ -132,28 +132,29 @@ var updateCachedDiagnosticsTestCases = map[string]updateCachedDiagnosticsTestCas
 			"e.go": nil, // clears the client cache
 		},
 	},
-	"do not set nil if not in cache": updateCachedDiagnosticsTestCase{
+	"do not set nil if not in cache": syncCachedDiagnosticsTestCase{
 		cache:  diagnostics{},
 		diags:  diagnostics{},
 		source: "go",
 		files:  []string{"a.go", "b.go"},
 
-		expectedCache: diagnostics{},
-		expectedDiags: diagnostics{}, // nothing, because a.go and b.go are not part of the cache
+		expectedCache:   diagnostics{},
+		expectedPublish: diagnostics{}, // nothing, because a.go and b.go are not part of the cache
 	},
 }
 
 func TestSyncCachedDiagnosticsTestCases(t *testing.T) {
-	for label, test := range updateCachedDiagnosticsTestCases {
+	for label, test := range syncCachedDiagnosticsTestCases {
 		t.Run(label, func(t *testing.T) {
-			updatedCache := syncCachedDiagnostics(test.cache, test.diags, test.source, test.files)
+			updatedCache := updateCachedDiagnostics(test.cache, test.diags, test.source, test.files)
+			publish := compareCachedDiagnostics(test.cache, updatedCache, test.files)
 
 			if !reflect.DeepEqual(test.expectedCache, updatedCache) {
 				t.Errorf("Cached diagnostics does not match\nExpected: %v\nActual: %v", test.expectedCache, updatedCache)
 			}
 
-			if !reflect.DeepEqual(test.expectedDiags, test.diags) {
-				t.Errorf("Reported diagnostics does not match\nExpected: %v\nActual: %v", test.expectedDiags, test.diags)
+			if !reflect.DeepEqual(test.expectedPublish, publish) {
+				t.Errorf("Publish diagnostics does not match\nExpected: %v\nActual: %v", test.expectedPublish, publish)
 			}
 		})
 	}

--- a/langserver/lint.go
+++ b/langserver/lint.go
@@ -149,8 +149,8 @@ func (l golint) Lint(ctx context.Context, bctx *build.Context, args ...string) (
 		return nil, fmt.Errorf("lint command error: %s", err)
 	}
 
-	if errString := errBuff.String(); errString != "" {
-		log.Panicf("warning: lint command stdErr: %q", errString)
+	if errBuff.Len() > 0 {
+		log.Panicf("warning: lint command stderr: %q", errBuff.String())
 	}
 
 	return diags, nil

--- a/langserver/lint.go
+++ b/langserver/lint.go
@@ -1,0 +1,199 @@
+package langserver
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"go/build"
+	"io"
+	"log"
+	"os/exec"
+	"path"
+	"strconv"
+	"strings"
+
+	"github.com/sourcegraph/go-langserver/pkg/lsp"
+	"github.com/sourcegraph/go-langserver/pkg/tools"
+	"github.com/sourcegraph/jsonrpc2"
+)
+
+const (
+	lintToolGolint = "golint"
+	lintToolNone   = "none"
+)
+
+// Linter defines an interface for linting
+type Linter interface {
+	IsInstalled(ctx context.Context, bctx *build.Context) error
+	Lint(ctx context.Context, bctx *build.Context, args ...string) (diagnostics, error)
+}
+
+// lint runs the configured lint command with the given arguments then published the
+// results as diagnostics.
+func (h *LangHandler) lint(ctx context.Context, bctx *build.Context, conn jsonrpc2.JSONRPC2, args []string, files []string) error {
+	if h.linter == nil {
+		return nil
+	}
+
+	diags, err := h.linter.Lint(ctx, bctx, args...)
+	if err != nil {
+		return err
+	}
+
+	return h.publishDiagnostics(ctx, conn, diags, h.config.LintTool, files)
+}
+
+// lintPackage runs LangHandler.lint for the package containing the uri.
+func (h *LangHandler) lintPackage(ctx context.Context, bctx *build.Context, conn jsonrpc2.JSONRPC2, uri lsp.DocumentURI) error {
+	pkg, err := ContainingPackage(h.BuildContext(ctx), h.FilePath(uri))
+	if err != nil {
+		return err
+	}
+
+	files := make([]string, 0, len(pkg.GoFiles))
+	for _, f := range pkg.GoFiles {
+		files = append(files, path.Join(pkg.Dir, f))
+	}
+
+	return h.lint(ctx, bctx, conn, []string{pkg.ImportPath}, files)
+}
+
+// lintWorkspace runs LangHandler.lint for the entire workspace
+func (h *LangHandler) lintWorkspace(ctx context.Context, bctx *build.Context, conn jsonrpc2.JSONRPC2) error {
+	rootPkg, err := ContainingPackage(h.BuildContext(ctx), h.RootFSPath)
+	if err != nil {
+		return err
+	}
+
+	var files []string
+	pkgs := tools.ListPkgsUnderDir(bctx, h.RootFSPath)
+	for _, pkg := range pkgs {
+		p, err := bctx.Import(pkg, h.RootFSPath, 0)
+		if err != nil {
+			return err
+		}
+
+		for _, f := range p.GoFiles {
+			files = append(files, path.Join(p.Dir, f))
+		}
+	}
+
+	return h.lint(ctx, bctx, conn, []string{path.Join(rootPkg.ImportPath, "/...")}, files)
+}
+
+// golint is a wrapper around the golint command that implements the
+// linter interface.
+type golint struct{}
+
+func (l golint) IsInstalled(ctx context.Context, bctx *build.Context) error {
+	cmd := exec.CommandContext(ctx, "golint", "--help")
+	cmd.Env = []string{
+		"GOPATH=" + bctx.GOPATH,
+		"GOROOT=" + bctx.GOROOT,
+	}
+
+	buff := new(bytes.Buffer)
+	cmd.Stdout = buff
+	cmd.Stderr = buff
+
+	err := cmd.Run()
+
+	if err == nil {
+		return nil
+	}
+	if _, ok := err.(*exec.ExitError); ok {
+		return nil
+	}
+
+	return fmt.Errorf("linter check failed: %s (%q)", err, buff.String())
+}
+
+func (l golint) Lint(ctx context.Context, bctx *build.Context, args ...string) (diagnostics, error) {
+	cmd := exec.CommandContext(ctx, "golint", args...)
+	cmd.Env = []string{
+		"GOPATH=" + bctx.GOPATH,
+		"GOROOT=" + bctx.GOROOT,
+	}
+
+	buff := new(bytes.Buffer)
+	cmd.Stdout = buff
+	cmd.Stderr = buff
+
+	err := cmd.Run()
+	if err != nil {
+		switch err.(type) {
+		case *exec.ExitError:
+			// do nothing
+		default:
+			return nil, fmt.Errorf("lint command error: %s", err)
+		}
+	}
+
+	diags := diagnostics{}
+	for {
+		l, err := buff.ReadString('\n')
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("could not read lint command output: %s", err)
+		}
+
+		l = strings.TrimSuffix(l, "\n")
+		file, line, _, message, err := parseLintResult(l)
+		if err != nil {
+			// If there is an error parsing a line still try to parse the remaining lines
+			log.Printf("warning: error failed to parse lint result: %v", err)
+			continue
+		}
+
+		diags[file] = append(diags[file], &lsp.Diagnostic{
+			Message:  message,
+			Severity: lsp.Warning,
+			Source:   lintToolGolint,
+			Range: lsp.Range{ // currently only supporting line level errors
+				Start: lsp.Position{
+					Line:      line,
+					Character: 0,
+				},
+				End: lsp.Position{
+					Line:      line,
+					Character: 0,
+				},
+			},
+		})
+	}
+
+	return diags, nil
+}
+
+func parseLintResult(l string) (file string, line, char int, message string, err error) {
+	parts := strings.SplitN(l, " ", 2)
+	if len(parts) != 2 {
+		err = fmt.Errorf("invalid result %q", l)
+		return
+	}
+	location := parts[0]
+	message = parts[1]
+
+	parts = strings.Split(location, ":")
+	if l := len(parts); l < 3 || l > 4 {
+		err = fmt.Errorf("invalid file location %q in %q", location, l)
+		return
+	}
+	file = parts[0]
+	line, err = strconv.Atoi(parts[1])
+	if err != nil {
+		err = fmt.Errorf("invalid line number in %q: %s", l, err)
+		return
+	}
+	if parts[2] != "" {
+		char, err = strconv.Atoi(parts[2])
+		if err != nil {
+			err = fmt.Errorf("invalid char number in %q: %s", l, err)
+			return
+		}
+	}
+
+	return file, line - 1, char - 1, message, nil // LSP is 0-indexed
+}

--- a/langserver/lint_test.go
+++ b/langserver/lint_test.go
@@ -1,0 +1,211 @@
+package langserver
+
+import (
+	"context"
+	"go/build"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/sourcegraph/go-langserver/langserver/util"
+	"github.com/sourcegraph/go-langserver/pkg/lsp"
+)
+
+func TestParseLintLine(t *testing.T) {
+	tests := []struct {
+		l       string
+		file    string
+		line    int
+		char    int
+		message string
+	}{
+		{
+			l:       "A.go:1: message contents",
+			file:    "A.go",
+			line:    0,
+			char:    -1,
+			message: "message contents",
+		},
+		{
+			l:       "A.go:1:2 message contents",
+			file:    "A.go",
+			line:    0,
+			char:    1,
+			message: "message contents",
+		},
+		{
+			l:       "A.go:1:2: message contents",
+			file:    "A.go",
+			line:    0,
+			char:    1,
+			message: "message contents",
+		},
+	}
+
+	for _, test := range tests {
+		file, line, char, message, err := parseLintResult(test.l)
+		if err != nil {
+			t.Errorf("unexpected error parsing %q: %v", test.l, err)
+		}
+		if file != test.file {
+			t.Errorf("unexpected file parsing %q: want %q, have %q", test.l, test.file, file)
+		}
+		if line != test.line {
+			t.Errorf("unexpected line parsing %q: want %d, have %d", test.l, test.line, line)
+		}
+		if char != test.char {
+			t.Errorf("unexpected char parsing %q: want %d, have %d", test.l, test.char, char)
+		}
+		if message != test.message {
+			t.Errorf("unexpected message parsing %q: want %q, have %q", test.l, test.message, message)
+		}
+
+	}
+}
+
+func TestLinterGolint(t *testing.T) {
+	files := map[string]string{
+		"A.go": strings.Join([]string{
+			"package p",
+			"",
+			"func A(){}",
+			"",
+			"func AA(){}",
+		}, "\n"),
+		"B.go": strings.Join([]string{
+			"package p",
+			"",
+			"func B(){}",
+		}, "\n"),
+		"C.go": strings.Join([]string{
+			"package p",
+			"",
+			`import "test/p/sub"`,
+			"",
+			"// C is a function",
+			"func C(){",
+			"	sub.D()",
+			"}",
+		}, "\n"),
+		"sub/D.go": strings.Join([]string{
+			"package sub",
+			"",
+			"func D(){}",
+		}, "\n"),
+	}
+
+	linterTest(t, files, func(ctx context.Context, bctx *build.Context, rootURI lsp.DocumentURI) {
+		uriA := uriJoin(rootURI, "A.go")
+		uriB := uriJoin(rootURI, "B.go")
+		uriD := uriJoin(rootURI, "sub/D.go")
+
+		l := &golint{}
+
+		// skip tests if the golint command is not found
+		err := l.IsInstalled(ctx, bctx)
+		if err != nil {
+			t.Skipf("lint command 'golint' not found: %s", err)
+		}
+
+		// Lint the package "test/p" and look for correct results
+		actual, err := l.Lint(ctx, bctx, "test/p")
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		}
+		expected := diagnostics{
+			util.UriToPath(uriA): []*lsp.Diagnostic{
+				{
+					Message:  "exported function A should have comment or be unexported",
+					Severity: lsp.Warning,
+					Source:   "golint",
+					Range: lsp.Range{
+						Start: lsp.Position{Line: 2, Character: 0},
+						End:   lsp.Position{Line: 2, Character: 0},
+					},
+				},
+				{
+					Message:  "exported function AA should have comment or be unexported",
+					Severity: lsp.Warning,
+					Source:   "golint",
+					Range: lsp.Range{
+						Start: lsp.Position{Line: 4, Character: 0},
+						End:   lsp.Position{Line: 4, Character: 0},
+					},
+				},
+			},
+			util.UriToPath(uriB): []*lsp.Diagnostic{
+				{
+					Message:  "exported function B should have comment or be unexported",
+					Severity: lsp.Warning,
+					Source:   "golint",
+					Range: lsp.Range{
+						Start: lsp.Position{Line: 2, Character: 0},
+						End:   lsp.Position{Line: 2, Character: 0},
+					},
+				},
+			},
+		}
+		if !reflect.DeepEqual(actual, expected) {
+			t.Errorf("Expected diagnostics %v but got %v", actual, expected)
+		}
+
+		// Lint the package and subpackages "test/p/..." look for correct lint results
+		actual, err = l.Lint(ctx, bctx, "test/p/...")
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		}
+		expected[util.UriToPath(uriD)] = []*lsp.Diagnostic{
+			{
+				Message:  "exported function D should have comment or be unexported",
+				Severity: lsp.Warning,
+				Source:   "golint",
+				Range: lsp.Range{ // currently only supporting line level errors
+					Start: lsp.Position{Line: 2, Character: 0},
+					End:   lsp.Position{Line: 2, Character: 0},
+				},
+			},
+		}
+		if !reflect.DeepEqual(actual, expected) {
+			t.Errorf("Expected diagnostics %v but got %v", actual, expected)
+		}
+	})
+}
+
+func linterTest(t *testing.T, files map[string]string, fn func(ctx context.Context, bctx *build.Context, rootURI lsp.DocumentURI)) {
+	tmpDir, err := ioutil.TempDir("", "langserver-go-linter")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	GOPATH := filepath.Join(tmpDir, "gopath")
+	GOROOT := filepath.Join(tmpDir, "goroot")
+	rootFSPath := filepath.Join(GOPATH, "src/test/p")
+
+	if err := os.MkdirAll(GOROOT, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(rootFSPath, 0700); err != nil {
+		t.Fatal(err)
+	}
+	for filename, contents := range files {
+		path := filepath.Join(rootFSPath, filename)
+		if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+			t.Fatal(err)
+		}
+		if err := ioutil.WriteFile(path, []byte(contents), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	ctx := context.Background()
+	bctx := &build.Context{
+		GOPATH: GOPATH,
+		GOROOT: GOROOT,
+	}
+
+	fn(ctx, bctx, util.PathToURI(rootFSPath))
+}

--- a/langserver/loader.go
+++ b/langserver/loader.go
@@ -74,7 +74,7 @@ func (h *LangHandler) typecheck(ctx context.Context, conn jsonrpc2.JSONRPC2, fil
 
 	// collect all loaded files, required to remove existing diagnostics from our cache
 	files := fsetToFiles(fset)
-	if err := h.publishDiagnostics(ctx, conn, diags, files); err != nil {
+	if err := h.publishDiagnostics(ctx, conn, diags, "go", files); err != nil {
 		log.Printf("warning: failed to send diagnostics: %s.", err)
 	}
 

--- a/langserver/lspx.go
+++ b/langserver/lspx.go
@@ -22,6 +22,10 @@ type InitializationOptions struct {
 	// Config.FormatTool
 	FormatTool *string `json:"formatTool"`
 
+	// LintTool is an optional version of
+	// Config.LintTool
+	LintTool *string `json:"lintTool"`
+
 	// GoimportsLocalPrefix is an optional version of
 	// Config.GoimportsLocalPrefix
 	GoimportsLocalPrefix *string `json:"goimportsLocalPrefix"`

--- a/langserver/workspace_refs.go
+++ b/langserver/workspace_refs.go
@@ -270,7 +270,7 @@ func (h *LangHandler) workspaceRefsTypecheck(ctx context.Context, bctx *build.Co
 
 	// collect all loaded files, required to remove existing diagnostics from our cache
 	files := fsetToFiles(prog.Fset)
-	if err := h.publishDiagnostics(ctx, conn, diags, files); err != nil {
+	if err := h.publishDiagnostics(ctx, conn, diags, "go", files); err != nil {
 		log.Printf("warning: failed to send diagnostics: %s.", err)
 	}
 

--- a/main.go
+++ b/main.go
@@ -34,6 +34,7 @@ var (
 	diagnostics        = flag.Bool("diagnostics", false, "enable diagnostics (extra memory burden). Can be overridden by InitializationOptions.")
 	funcSnippetEnabled = flag.Bool("func-snippet-enabled", true, "enable argument snippets on func completion. Can be overridden by InitializationOptions.")
 	formatTool         = flag.String("format-tool", "goimports", "which tool is used to format documents. Supported: goimports and gofmt. Can be overridden by InitializationOptions.")
+	lintTool           = flag.String("lint-tool", "none", "which tool is used to linting. Supported: none and golint. Can be overridden by InitializationOptions.")
 )
 
 // version is the version field we report back. If you are releasing a new version:
@@ -64,6 +65,7 @@ func main() {
 	cfg.DiagnosticsEnabled = *diagnostics
 	cfg.UseBinaryPkgCache = *usebinarypkgcache
 	cfg.FormatTool = *formatTool
+	cfg.LintTool = *lintTool
 
 	if *maxparallelism > 0 {
 		cfg.MaxParallelism = *maxparallelism


### PR DESCRIPTION
This pull requests adds basic support for linting.

- supports the `golint` command
- linting results are published via the diagnostics system
- entire workspace linted on initialization
- current package linted on save