### PR TITLE
fixed the unnecessary panic in lint

### DIFF
--- a/langserver/lint.go
+++ b/langserver/lint.go
@@ -150,7 +150,7 @@ func (l golint) Lint(ctx context.Context, bctx *build.Context, args ...string) (
 	}
 
 	if errBuff.Len() > 0 {
-		log.Panicf("warning: lint command stderr: %q", errBuff.String())
+		log.Printf("warning: lint command stderr: %q", errBuff.String())
 	}
 
 	return diags, nil


### PR DESCRIPTION
an unnecessary panic:

https://github.com/sourcegraph/go-langserver/blob/e1b4a1b1f25a0e70582780a7da7c2c85b21614e0/langserver/lint.go#L152-L154

If source file is saved with wrong syntax, go-langserver will panic. Just printing it is enough.