### PR TITLE
Add a diagnosticsEnabled initialization option

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,13 @@ interface GoInitializationOptions {
    * Defaults to true if not specified.
    */
   useBinaryPkgCache?: boolean;
+
+  /**
+   * DiagnosticsEnabled enables handling of diagnostics.
+   *
+   * Defaults to false if not specified.
+   */
+  diagnosticsEnabled?: boolean;
 }
 ```
 

--- a/langserver/config.go
+++ b/langserver/config.go
@@ -112,6 +112,7 @@ func NewDefaultConfig() Config {
 		GocodeCompletionEnabled: false,
 		FormatTool:              formatToolGoimports,
 		LintTool:                lintToolNone,
+		DiagnosticsEnabled:      false,
 		MaxParallelism:          maxparallelism,
 		UseBinaryPkgCache:       true,
 	}

--- a/langserver/config.go
+++ b/langserver/config.go
@@ -92,6 +92,9 @@ func (c Config) Apply(o *InitializationOptions) Config {
 	if o.UseBinaryPkgCache != nil {
 		c.UseBinaryPkgCache = *o.UseBinaryPkgCache
 	}
+	if o.DiagnosticsEnabled != nil {
+		c.DiagnosticsEnabled = *o.DiagnosticsEnabled
+	}
 	return c
 }
 

--- a/langserver/lspx.go
+++ b/langserver/lspx.go
@@ -30,6 +30,10 @@ type InitializationOptions struct {
 	// Config.GoimportsLocalPrefix
 	GoimportsLocalPrefix *string `json:"goimportsLocalPrefix"`
 
+	// DiagnosticsEnabled enables is an optional version of
+	// Config.DiagnosticsEnabled
+	DiagnosticsEnabled *bool `json:"diagnosticsEnabled"`
+
 	// MaxParallelism is an optional version of Config.MaxParallelism
 	MaxParallelism *int `json:"maxParallelism"`
 


### PR DESCRIPTION
This PR adds an initialization option to enable diagnostics.  I didn't see a straightforward way to use the existing command line flag from my client.