### PR TITLE
langserver: fix case order in a type switch

### DIFF
--- a/langserver/ast.go
+++ b/langserver/ast.go
@@ -143,6 +143,9 @@ func findInterestingNode(pkginfo *loader.PackageInfo, path []ast.Node) ([]ast.No
 			path = append([]ast.Node{n.Name}, path...)
 			continue
 
+		case *ast.Comment, *ast.CommentGroup, *ast.File, *ast.KeyValueExpr, *ast.CommClause:
+			return path, actionUnknown // uninteresting
+
 		case ast.Stmt:
 			return path, actionStmt
 
@@ -153,9 +156,6 @@ func findInterestingNode(pkginfo *loader.PackageInfo, path []ast.Node) ([]ast.No
 			*ast.MapType,
 			*ast.ChanType:
 			return path, actionType
-
-		case *ast.Comment, *ast.CommentGroup, *ast.File, *ast.KeyValueExpr, *ast.CommClause:
-			return path, actionUnknown // uninteresting
 
 		case *ast.Ellipsis:
 			// Continue to enclosing node.


### PR DESCRIPTION
Concrete types should go before interfaces they
implement, otherwise control will never reach them,
since type switch matching is performen sequentially,
from first case to the last one.

Found using gocritic "caseOrder" diagnostic.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>