### PR TITLE
Support private dependencies

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -26,6 +26,14 @@
   revision = "f89ea99a4e435defb7c85e4e5cc5030e7cbae0dd"
 
 [[projects]]
+  digest = "1:e9fd9fdb68a32484b36fd855dcceb8938c285d12868d36b5518f36aa5e01139a"
+  name = "github.com/fhs/go-netrc"
+  packages = ["netrc"]
+  pruneopts = "NUT"
+  revision = "4ffed54ee5c32ebfb1b8c7c72fc90bb08dc3ff43"
+  version = "v1.0.0"
+
+[[projects]]
   digest = "1:a1efdbc2762667c8a41cbf02b19a0549c846bf2c1d08cad4f445e3344089f1f0"
   name = "github.com/go-stack/stack"
   packages = ["."]
@@ -459,6 +467,7 @@
   analyzer-version = 1
   input-imports = [
     "github.com/die-net/lrucache",
+    "github.com/fhs/go-netrc/netrc",
     "github.com/gorilla/websocket",
     "github.com/gregjones/httpcache",
     "github.com/hashicorp/golang-lru",

--- a/buildserver/deps.go
+++ b/buildserver/deps.go
@@ -496,9 +496,9 @@ func FetchCommonDeps() {
 var NewDepRepoVFS = func(ctx context.Context, cloneURL *url.URL, rev string, zipURLTemplate *string) (ctxvfs.FileSystem, error) {
 	if zipURLTemplate != nil {
 		zipURL := fmt.Sprintf(*zipURLTemplate, path.Join(cloneURL.Host, cloneURL.Path), rev)
-		response, err := http.Head(zipURL)
-		if err == nil && response.StatusCode == http.StatusOK {
-			return vfsutil.NewZipVFS(zipURL, depZipFetch.Inc, depZipFetchFailed.Inc, false)
+		archive, err := vfsutil.NewZipVFS(zipURL, depZipFetch.Inc, depZipFetchFailed.Inc, false)
+		if archive != nil && err == nil {
+			return archive, nil
 		}
 	}
 
@@ -506,7 +506,10 @@ var NewDepRepoVFS = func(ctx context.Context, cloneURL *url.URL, rev string, zip
 	// GitHub's repo .zip archive download endpoint.
 	if cloneURL.Host == "github.com" {
 		fullName := cloneURL.Host + strings.TrimSuffix(cloneURL.Path, ".git") // of the form "github.com/foo/bar"
-		return vfsutil.NewGitHubRepoVFS(fullName, rev)
+		archive, err := vfsutil.NewGitHubRepoVFS(fullName, rev)
+		if archive != nil && err == nil {
+			return archive, nil
+		}
 	}
 
 	// Fall back to a full git clone for non-github.com repos.

--- a/buildserver/deps.go
+++ b/buildserver/deps.go
@@ -496,7 +496,7 @@ func FetchCommonDeps() {
 var NewDepRepoVFS = func(ctx context.Context, cloneURL *url.URL, rev string, zipURLTemplate *string) (ctxvfs.FileSystem, error) {
 	if zipURLTemplate != nil {
 		zipURL := fmt.Sprintf(*zipURLTemplate, path.Join(cloneURL.Host, cloneURL.Path), rev)
-		archive, err := vfsutil.NewZipVFS(zipURL, depZipFetch.Inc, depZipFetchFailed.Inc, false)
+		archive, err := vfsutil.NewZipVFS(ctx, zipURL, depZipFetch.Inc, depZipFetchFailed.Inc, false)
 		if archive != nil && err == nil {
 			return archive, nil
 		}
@@ -506,7 +506,7 @@ var NewDepRepoVFS = func(ctx context.Context, cloneURL *url.URL, rev string, zip
 	// GitHub's repo .zip archive download endpoint.
 	if cloneURL.Host == "github.com" {
 		fullName := cloneURL.Host + strings.TrimSuffix(cloneURL.Path, ".git") // of the form "github.com/foo/bar"
-		archive, err := vfsutil.NewGitHubRepoVFS(fullName, rev)
+		archive, err := vfsutil.NewGitHubRepoVFS(ctx, fullName, rev)
 		if archive != nil && err == nil {
 			return archive, nil
 		}

--- a/buildserver/integration_test.go
+++ b/buildserver/integration_test.go
@@ -275,7 +275,7 @@ func useGithubForVFS() func() {
 		if u.Rev() == "" {
 			return nil, errors.Errorf("rev is required in uri: %s", initializeParams.OriginalRootURI)
 		}
-		return vfsutil.NewGitHubRepoVFS(string(u.Repo()), u.Rev())
+		return vfsutil.NewGitHubRepoVFS(context.Background(), string(u.Repo()), u.Rev())
 	}
 
 	return func() {

--- a/buildserver/integration_test.go
+++ b/buildserver/integration_test.go
@@ -275,7 +275,7 @@ func useGithubForVFS() func() {
 		if u.Rev() == "" {
 			return nil, errors.Errorf("rev is required in uri: %s", initializeParams.OriginalRootURI)
 		}
-		return vfsutil.NewGitHubRepoVFS(context.Background(), string(u.Repo()), u.Rev())
+		return vfsutil.NewGitHubRepoVFS(ctx, string(u.Repo()), u.Rev())
 	}
 
 	return func() {

--- a/buildserver/vfs.go
+++ b/buildserver/vfs.go
@@ -27,7 +27,7 @@ var RemoteFS = func(ctx context.Context, initializeParams lspext.InitializeParam
 		return url
 	}()
 	if zipURL != "" {
-		return vfsutil.NewZipVFS(zipURL, zipFetch.Inc, zipFetchFailed.Inc, true)
+		return vfsutil.NewZipVFS(ctx, zipURL, zipFetch.Inc, zipFetchFailed.Inc, true)
 	}
 	return nil, errors.Errorf("no zipURL was provided in the initializeOptions")
 }

--- a/vfsutil/github_archive.go
+++ b/vfsutil/github_archive.go
@@ -1,6 +1,7 @@
 package vfsutil
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 
@@ -9,13 +10,13 @@ import (
 
 // NewGitHubRepoVFS creates a new VFS backed by a GitHub downloadable
 // repository archive.
-func NewGitHubRepoVFS(repo, rev string) (*ArchiveFS, error) {
+func NewGitHubRepoVFS(ctx context.Context, repo, rev string) (*ArchiveFS, error) {
 	if !githubRepoRx.MatchString(repo) {
 		return nil, fmt.Errorf(`invalid GitHub repo %q: must be "github.com/user/repo"`, repo)
 	}
 
 	url := fmt.Sprintf("https://codeload.%s/zip/%s", repo, rev)
-	return NewZipVFS(url, ghFetch.Inc, ghFetchFailed.Inc, false)
+	return NewZipVFS(ctx, url, ghFetch.Inc, ghFetchFailed.Inc, false)
 }
 
 var githubRepoRx = regexp.MustCompile(`^github\.com/[\w.-]{1,100}/[\w.-]{1,100}$`)

--- a/vfsutil/github_archive_test.go
+++ b/vfsutil/github_archive_test.go
@@ -1,6 +1,7 @@
 package vfsutil
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -12,7 +13,7 @@ func TestGitHubRepoVFS(t *testing.T) {
 	defer cleanup()
 
 	// Any public repo will work.
-	fs, err := NewGitHubRepoVFS("github.com/gorilla/schema", "0164a00ab4cd01d814d8cd5bf63fd9fcea30e23b")
+	fs, err := NewGitHubRepoVFS(context.Background(), "github.com/gorilla/schema", "0164a00ab4cd01d814d8cd5bf63fd9fcea30e23b")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/vfsutil/zip.go
+++ b/vfsutil/zip.go
@@ -27,10 +27,10 @@ func NewZipVFS(ctx context.Context, url string, onFetchStart, onFetchFailed func
 		return nil, errors.Wrapf(err, "failed to construct a new request with URL %s", url)
 	}
 	err = setAuthFromNetrc(request)
-	response, err := ctxhttp.Do(ctx, nil, request)
 	if err != nil {
 		log.Printf("Unable to set auth from netrc: %s", err)
 	}
+	response, err := ctxhttp.Do(ctx, nil, request)
 	if err != nil {
 		return nil, err
 	}

--- a/vfsutil/zip.go
+++ b/vfsutil/zip.go
@@ -108,10 +108,7 @@ func setAuthFromNetrc(req *http.Request) error {
 		return nil
 	}
 	machine, err := netrc.FindMachine(netrcFile, host)
-	if err != nil {
-		return err
-	}
-	if machine == nil {
+	if err != nil || machine == nil {
 		return nil
 	}
 	req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", machine.Login, machine.Password))))


### PR DESCRIPTION
- Adds support for `.netrc` (for username+password basic authentication) on zip URL fetches
- Falls back to git clone when fetching from codeload.github.com 404s so that SSH auth can be attempted