### PR TITLE
Fix incorrect URI rewrite logic

### DIFF
--- a/buildserver/build_server.go
+++ b/buildserver/build_server.go
@@ -11,6 +11,7 @@ import (
 	"path"
 	pathpkg "path"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strings"
 	"sync"
@@ -497,7 +498,9 @@ func (h *BuildHandler) rewriteURIFromLangServer(uri lsp.DocumentURI) (lsp.Docume
 			h.HandlerShared.Mu.Unlock()
 			var d *gosrc.Directory
 			for _, dep := range deps {
-				if strings.HasPrefix(p, dep.ProjectRoot) {
+				pathComponents := strings.Split(p, "/")
+				depComponents := strings.Split(dep.ProjectRoot, "/")
+				if reflect.DeepEqual(pathComponents[:len(depComponents)], depComponents) {
 					d = dep
 				}
 			}


### PR DESCRIPTION
Previously, URIs would be rewritten by finding the first dep that is a prefix **by character** of the URI's path. This changes it to prefix **by path component** to avoid considering `kubernetes/api` a prefix of `kubernetes/apimachinery`.

Fixes https://github.com/sourcegraph/sourcegraph/issues/139