### PR TITLE
Do not include access token in cache key when fetching zip archives

### DIFF
--- a/vfsutil/zip.go
+++ b/vfsutil/zip.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -22,10 +23,10 @@ import (
 
 // NewZipVFS downloads a zip archive from a URL (or fetches from the local cache
 // on disk) and returns a new VFS backed by that zip archive.
-func NewZipVFS(ctx context.Context, url string, onFetchStart, onFetchFailed func(), evictOnClose bool) (*ArchiveFS, error) {
-	request, err := http.NewRequest("HEAD", url, nil)
+func NewZipVFS(ctx context.Context, urlString string, onFetchStart, onFetchFailed func(), evictOnClose bool) (*ArchiveFS, error) {
+	request, err := http.NewRequest("HEAD", urlString, nil)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to construct a new request with URL %s", url)
+		return nil, errors.Wrapf(err, "failed to construct a new request with URL %s", urlString)
 	}
 	setAuthFromNetrc(request)
 	response, err := ctxhttp.Do(ctx, nil, request)
@@ -33,13 +34,13 @@ func NewZipVFS(ctx context.Context, url string, onFetchStart, onFetchFailed func
 		return nil, err
 	}
 	if response.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unable to fetch zip from %s (expected HTTP response code 200, but got %d)", url, response.StatusCode)
+		return nil, fmt.Errorf("unable to fetch zip from %s (expected HTTP response code 200, but got %d)", urlString, response.StatusCode)
 	}
 
 	fetch := func(ctx context.Context) (ar *archiveReader, err error) {
 		span, ctx := opentracing.StartSpanFromContext(ctx, "zip Fetch")
 		ext.Component.Set(span, "zipvfs")
-		span.SetTag("url", url)
+		span.SetTag("url", urlString)
 		defer func() {
 			if err != nil {
 				ext.Error.Set(span, true)
@@ -54,39 +55,50 @@ func NewZipVFS(ctx context.Context, url string, onFetchStart, onFetchFailed func
 			MaxCacheSizeBytes: MaxCacheSizeBytes,
 		}
 
-		ff, err := cachedFetch(ctx, url, store, func(ctx context.Context) (io.ReadCloser, error) {
+		// Create a new URL that doesn't include the user:password (the access
+		// token) so that the same repository at a revision for a different user
+		// results in a cache hit.
+		urlStruct, err := url.Parse(urlString)
+		if err != nil {
+			return nil, err
+		}
+		urlStruct.User = nil
+		urlWithoutUser := urlStruct.String()
+
+		ff, err := cachedFetch(ctx, urlWithoutUser, store, func(ctx context.Context) (io.ReadCloser, error) {
 			onFetchStart()
-			request, err := http.NewRequest("GET", url, nil)
+			request, err := http.NewRequest("GET", urlString, nil)
 			if err != nil {
-				return nil, errors.Wrapf(err, "failed to construct a new request with URL %s", url)
+				return nil, errors.Wrapf(err, "failed to construct a new request with URL %s", urlString)
 			}
 			request.Header.Add("Accept", "application/zip")
 			setAuthFromNetrc(request)
+			fmt.Println("**** REQ ", urlString)
 			resp, err := ctxhttp.Do(ctx, nil, request)
 			if err != nil {
-				return nil, errors.Wrapf(err, "failed to fetch zip archive from %s", url)
+				return nil, errors.Wrapf(err, "failed to fetch zip archive from %s", urlString)
 			}
 			if resp.StatusCode != http.StatusOK {
 				resp.Body.Close()
-				return nil, errors.Errorf("zip URL %s returned HTTP %d", url, resp.StatusCode)
+				return nil, errors.Errorf("zip URL %s returned HTTP %d", urlString, resp.StatusCode)
 			}
 			return resp.Body, nil
 		})
 		if err != nil {
 			onFetchFailed()
-			return nil, errors.Wrapf(err, "failed to fetch/write/open zip archive from %s", url)
+			return nil, errors.Wrapf(err, "failed to fetch/write/open zip archive from %s", urlString)
 		}
 		f := ff.File
 
 		zr, err := zipNewFileReader(f)
 		if err != nil {
 			f.Close()
-			return nil, errors.Wrapf(err, "failed to read zip archive from %s", url)
+			return nil, errors.Wrapf(err, "failed to read zip archive from %s", urlString)
 		}
 
 		if len(zr.File) == 0 {
 			f.Close()
-			return nil, errors.Errorf("zip archive from %s is empty", url)
+			return nil, errors.Errorf("zip archive from %s is empty", urlString)
 		}
 
 		return &archiveReader{

--- a/vfsutil/zip.go
+++ b/vfsutil/zip.go
@@ -73,7 +73,6 @@ func NewZipVFS(ctx context.Context, urlString string, onFetchStart, onFetchFaile
 			}
 			request.Header.Add("Accept", "application/zip")
 			setAuthFromNetrc(request)
-			fmt.Println("**** REQ ", urlString)
 			resp, err := ctxhttp.Do(ctx, nil, request)
 			if err != nil {
 				return nil, errors.Wrapf(err, "failed to fetch zip archive from %s", urlString)


### PR DESCRIPTION
Prior to this change, the cache key was the full URL, including whatever username:password was set (e.g. the Sourcegraph access token).

After this change, the cache key will be the URL but with empty username:password.

This will increase the probability of a cache hit because each repo@revision will be fetched once and used by any user.

A `HEAD` request is still made for each user x repo@revision pair to make sure the user has access to the repository contents.

- Helps fix https://sourcegraph.slack.com/archives/C0C324C91/p1554154297030300
- Helps fix https://sourcegraph.slack.com/archives/C0C324C91/p1554159963034900
- Helps `fix` https://github.com/sourcegraph/sourcegraph/issues/1940

cc @beyang just FYI, no action necessary