### PR TITLE
Strip .git suffix from dependencies

### DIFF
--- a/buildserver/deps.go
+++ b/buildserver/deps.go
@@ -495,7 +495,13 @@ func FetchCommonDeps() {
 // Source 1 and 2 are performance optimizations over cloning the whole repo.
 var NewDepRepoVFS = func(ctx context.Context, cloneURL *url.URL, rev string, zipURLTemplate *string) (ctxvfs.FileSystem, error) {
 	if zipURLTemplate != nil {
-		zipURL := fmt.Sprintf(*zipURLTemplate, path.Join(cloneURL.Host, cloneURL.Path), rev)
+		var repoName string
+		if strings.HasSuffix(cloneURL.Path, ".git") {
+			repoName = strings.TrimSuffix(cloneURL.Path, ".git")
+		} else {
+			repoName = cloneURL.Path
+		}
+		zipURL := fmt.Sprintf(*zipURLTemplate, path.Join(cloneURL.Host, repoName), rev)
 		archive, err := vfsutil.NewZipVFS(ctx, zipURL, depZipFetch.Inc, depZipFetchFailed.Inc, false)
 		if archive != nil && err == nil {
 			return archive, nil


### PR DESCRIPTION
Some users have import paths that look like `example.com/user/repo.git` and the repository name on Sourcegraph is `example.com/user/repo` (without `.git`).

Prior to this change, go-langserver would attempt to fetch `example.com/user/repo.git` and get a 404.

After this change, go-langserver will fetch `example.com/user/repo` instead. This will break when the repository name on Sourcegraph has a `.git` suffix. @beyang Does that seem acceptable? Alternatively, go-langserver could try the original (with `.git`) and then fallback to dropping the suffix.

This worked in Sourcegraph 2.x probably because the repository contents were obtained through lsp-proxy and gitserver, rather than the raw API.