### PR TITLE
LSP-conformant originalRootURI

### DIFF
--- a/buildserver/build_server.go
+++ b/buildserver/build_server.go
@@ -178,6 +178,19 @@ func (h *BuildHandler) Handle(ctx context.Context, conn *jsonrpc2.Conn, req *jso
 			return nil, err
 		}
 
+		// Fall back to reading the `originalRootURI` from
+		// `InitializeParams.intitializationOptions` if absent from the
+		// `InitializeParams`. This makes go-langserver more LSP-compliant so that
+		// clients don't need to go outside of the LSP specification to communicate
+		// with it.
+		if params.OriginalRootURI == "" {
+			if initializationOptions, ok := params.InitializationOptions.(map[string]interface{}); ok {
+				if originalRootURI, ok := initializationOptions["originalRootURI"].(string); ok {
+					params.OriginalRootURI = lsp.DocumentURI(originalRootURI)
+				}
+			}
+		}
+
 		if Debug {
 			var b []byte
 			if req.Params != nil {

--- a/langserver/hover.go
+++ b/langserver/hover.go
@@ -500,7 +500,7 @@ func packageForFile(pkgs map[string]*ast.Package, filename string) (string, *ast
 			}
 		}
 	}
-	return "", nil, fmt.Errorf("failed to find %q in packages %q", filename, pkgs)
+	return "", nil, fmt.Errorf("failed to find %q in packages %+v", filename, pkgs)
 }
 
 // inRange tells if x is in the range of a-b inclusive.


### PR DESCRIPTION
**Background**

Because `originalRootURI` is not part of the [LSP specification for `InitializeParams`](https://microsoft.github.io/language-server-protocol/specification#initialize), clients cannot use LSP-conformant libraries such as https://github.com/sourcegraph/lsp-client without adding a workaround specifically for communicating with go-langserver.

There is an untyped field, `InitializeParams.initializationOptions`, which can easily be used to send the `originalRootURI`.

**Details**

After this change, go-langserver will read the `originalRootURI` from `InitializeParams.initializationOptions` if it's absent from the top level `InitializeParams`. It will still be compatible with existing clients that currently put `originalRootURI` in the top level `InitializeParams`.

**One other alternative considered**

Alternatively, the `InitializeParams.rootURI` might be able to carry the current value of `originalRootURI` because it's currently set to [the informationless value of `file:///` in sourcegraph-go](https://github.com/sourcegraph/sourcegraph-go/blob/4ee437f3d2526e1c63e511be048a840e320e013b/src/lang-go.ts#L236). However, this change [seems difficult](https://docs.google.com/a/sourcegraph.com/document/d/1rFcwzKaEf2WtMJBZAc4L1LxBJqgKAduI8PMvjnNowE0/edit?disco=AAAAC_qY_8c) to make in go-langserver:

> After attempting to move originalRootURI to rootUri for ~2 hours, I'm finding that the assumption that rootUri is `file:///` pervades the LSP request handlers, utility functions, and glue code. Changing it will take longer than I had expected and I'm concerned it might introduce bugs despite the pretty good test coverage of go-langserver.

This helps integrate lsp-client into the Go extension https://github.com/sourcegraph/sourcegraph-go/issues/28