### PR TITLE
Derive zip URL from template

### DIFF
--- a/buildserver/vfs.go
+++ b/buildserver/vfs.go
@@ -34,6 +34,9 @@ var RemoteFS = func(ctx context.Context, initializeParams lspext.InitializeParam
 			return zipURL
 		}
 		zipURLTemplate, _ := initializationOptions["zipURLTemplate"].(string)
+		if zipURLTemplate == "" {
+			return ""
+		}
 		root, err := url.Parse(string(initializeParams.OriginalRootURI))
 		if err != nil {
 			return ""

--- a/buildserver/vfs.go
+++ b/buildserver/vfs.go
@@ -2,8 +2,11 @@ package buildserver
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"io/ioutil"
+	"net/url"
+	"path"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -26,8 +29,16 @@ var RemoteFS = func(ctx context.Context, initializeParams lspext.InitializeParam
 		if !ok {
 			return ""
 		}
-		url, _ := initializationOptions["zipURL"].(string)
-		return url
+		zipURL, _ := initializationOptions["zipURL"].(string)
+		if zipURL != "" {
+			return zipURL
+		}
+		zipURLTemplate, _ := initializationOptions["zipURLTemplate"].(string)
+		root, err := url.Parse(string(initializeParams.OriginalRootURI))
+		if err != nil {
+			return ""
+		}
+		return fmt.Sprintf(zipURLTemplate, path.Join(root.Host, root.Path), root.RawQuery)
 	}()
 	if zipURL != "" {
 		vfs, err := vfsutil.NewZipVFS(ctx, zipURL, zipFetch.Inc, zipFetchFailed.Inc, true)


### PR DESCRIPTION
Passing both `zipURL` and `zipURLTemplate` is redundant. `zipURL` can be derived by instantiating the `zipURLTemplate` with `originalRootURI`.

This adds support for clients that omit `zipURL` and only provide `zipURLTemplate`. This is part of [simplifying lsp-client's communication with go-langserver](https://docs.google.com/document/d/1rFcwzKaEf2WtMJBZAc4L1LxBJqgKAduI8PMvjnNowE0/edit#heading=h.44mn607i8nf4).