### PR TITLE
Fix format string

### DIFF
--- a/langserver/hover.go
+++ b/langserver/hover.go
@@ -500,7 +500,7 @@ func packageForFile(pkgs map[string]*ast.Package, filename string) (string, *ast
 			}
 		}
 	}
-	return "", nil, fmt.Errorf("failed to find %q in packages %q", filename, pkgs)
+	return "", nil, fmt.Errorf("failed to find %q in packages %+v", filename, pkgs)
 }
 
 // inRange tells if x is in the range of a-b inclusive.


### PR DESCRIPTION
CI is failing because of this https://ci.appveyor.com/project/sourcegraph/go-langserver/builds/24438368

> langserver\hover.go:503:18: Errorf format %q has arg pkgs of wrong type map[string]*go/ast.Package

I think this broke because the default Appveyor Go version was changed from 1.11 to 1.12.