### PR TITLE
Use canonical import for log15

### DIFF
--- a/buildserver/environment.go
+++ b/buildserver/environment.go
@@ -14,7 +14,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	log15 "gopkg.in/inconshreveable/log15.v2"
+	log15 "github.com/inconshreveable/log15"
 	yaml "gopkg.in/yaml.v2"
 
 	"github.com/sourcegraph/ctxvfs"

--- a/langserver/internal/refs/refs_test.go
+++ b/langserver/internal/refs/refs_test.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"testing"
 
-	_ "gopkg.in/inconshreveable/log15.v2"
+	_ "github.com/inconshreveable/log15"
 )
 
 func testConfig(fs *token.FileSet, pkgName string, files []*ast.File) *Config {


### PR DESCRIPTION
This changes the import path for `log15`, inspired by [this PR](https://github.com/sourcegraph/sourcegraph/pull/9245).