### PR TITLE
Remove use of ioutil package

### DIFF
--- a/buildserver/integration_test.go
+++ b/buildserver/integration_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"strings"
@@ -281,13 +280,13 @@ func useGithubForVFS() func() {
 	gobuildserver.RemoteFS = func(ctx context.Context, initializeParams lspext.InitializeParams) (ctxvfs.FileSystem, io.Closer, error) {
 		u, err := gituri.Parse(string(initializeParams.OriginalRootURI))
 		if err != nil {
-			return nil, ioutil.NopCloser(strings.NewReader("")), errors.Wrap(err, "could not parse workspace URI for remotefs")
+			return nil, io.NopCloser(strings.NewReader("")), errors.Wrap(err, "could not parse workspace URI for remotefs")
 		}
 		if u.Rev() == "" {
-			return nil, ioutil.NopCloser(strings.NewReader("")), errors.Errorf("rev is required in uri: %s", initializeParams.OriginalRootURI)
+			return nil, io.NopCloser(strings.NewReader("")), errors.Errorf("rev is required in uri: %s", initializeParams.OriginalRootURI)
 		}
 		fs, err := vfsutil.NewGitHubRepoVFS(ctx, string(u.Repo()), u.Rev())
-		return fs, ioutil.NopCloser(strings.NewReader("")), err
+		return fs, io.NopCloser(strings.NewReader("")), err
 	}
 
 	return func() {

--- a/buildserver/proxy_test.go
+++ b/buildserver/proxy_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path"
@@ -502,7 +501,7 @@ func yza() {}
 
 				origRemoteFS := gobuildserver.RemoteFS
 				gobuildserver.RemoteFS = func(ctx context.Context, initializeParams lspext.InitializeParams) (ctxvfs.FileSystem, io.Closer, error) {
-					return mapFS(test.fs), ioutil.NopCloser(strings.NewReader("")), nil
+					return mapFS(test.fs), io.NopCloser(strings.NewReader("")), nil
 				}
 
 				defer func() {

--- a/buildserver/vfs.go
+++ b/buildserver/vfs.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"path"
 	"strings"
@@ -47,7 +46,7 @@ var RemoteFS = func(ctx context.Context, initializeParams lspext.InitializeParam
 		vfs, err := vfsutil.NewZipVFS(ctx, zipURL, zipFetch.Inc, zipFetchFailed.Inc, true)
 		return vfs, vfs, err
 	}
-	return nil, ioutil.NopCloser(strings.NewReader("")), errors.Errorf("no zipURL was provided in the initializationOptions")
+	return nil, io.NopCloser(strings.NewReader("")), errors.Errorf("no zipURL was provided in the initializationOptions")
 }
 
 var zipFetch = prometheus.NewCounter(prometheus.CounterOpts{

--- a/buildserver/xlang_test.go
+++ b/buildserver/xlang_test.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -194,7 +193,7 @@ func jsonTest(t testing.TB, gotData interface{}, testName string) {
 		t.Fatal(err)
 	}
 	wantFile := filepath.Join("testdata", "want-"+testName)
-	want, err := ioutil.ReadFile(wantFile)
+	want, err := os.ReadFile(wantFile)
 	if err != nil {
 		t.Fatal(err)
 		return
@@ -202,11 +201,11 @@ func jsonTest(t testing.TB, gotData interface{}, testName string) {
 	if strings.TrimSpace(string(got)) != strings.TrimSpace(string(want)) {
 		if *update {
 			t.Logf("updating %s", wantFile)
-			ioutil.WriteFile(wantFile, got, 0777)
+			os.WriteFile(wantFile, got, 0777)
 			return
 		}
 		gotFile := filepath.Join("testdata", "got-"+testName)
-		ioutil.WriteFile(gotFile, got, 0777)
+		os.WriteFile(gotFile, got, 0777)
 
 		cmd := exec.Command("git", "diff", "--color", "--no-index", wantFile, gotFile)
 		cmd.Dir, err = os.Getwd()

--- a/diskcache/cache.go
+++ b/diskcache/cache.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -201,7 +200,7 @@ func (s *Store) EvictMaxSize(maxCacheSizeBytes int64) (stats EvictStats, err err
 		return strings.HasSuffix(fi.Name(), ".zip")
 	}
 
-	list, err := ioutil.ReadDir(s.Dir)
+	list, err := os.ReadDir(s.Dir)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return EvictStats{

--- a/diskcache/cache_test.go
+++ b/diskcache/cache_test.go
@@ -4,13 +4,12 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"os"
 	"testing"
 )
 
 func TestOpen(t *testing.T) {
-	dir, err := ioutil.TempDir("", "diskcache_test")
+	dir, err := os.MkdirTemp("", "diskcache_test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -26,12 +25,12 @@ func TestOpen(t *testing.T) {
 		calledFetcher := false
 		f, err := store.Open(context.Background(), "key", func(ctx context.Context) (io.ReadCloser, error) {
 			calledFetcher = true
-			return ioutil.NopCloser(bytes.NewReader([]byte(want))), nil
+			return io.NopCloser(bytes.NewReader([]byte(want))), nil
 		})
 		if err != nil {
 			t.Fatal(err)
 		}
-		got, err := ioutil.ReadAll(f.File)
+		got, err := io.ReadAll(f.File)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/gosrc/import_path_test.go
+++ b/gosrc/import_path_test.go
@@ -7,7 +7,6 @@
 package gosrc
 
 import (
-	"io/ioutil"
 	"net/http"
 	"reflect"
 	"runtime"
@@ -26,7 +25,7 @@ func (t testTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 	resp := &http.Response{
 		StatusCode: statusCode,
-		Body:       ioutil.NopCloser(strings.NewReader(body)),
+		Body:       io.NopCloser(strings.NewReader(body)),
 	}
 	return resp, nil
 }

--- a/langserver/integration_test.go
+++ b/langserver/integration_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"go/build"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -434,7 +433,7 @@ func integrationTest(
 	cfg *Config,
 	fn func(context.Context, lsp.DocumentURI, *jsonrpc2.Conn, chan *jsonrpc2.Request),
 ) {
-	tmpDir, err := ioutil.TempDir("", "langserver-go-integration")
+	tmpDir, err := os.MkdirTemp("", "langserver-go-integration")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -456,7 +455,7 @@ func integrationTest(
 		if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
 			t.Fatal(err)
 		}
-		if err := ioutil.WriteFile(path, []byte(contents), 0600); err != nil {
+		if err := os.WriteFile(path, []byte(contents), 0600); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/langserver/internal/gocode/suggest/suggest.go
+++ b/langserver/internal/gocode/suggest/suggest.go
@@ -8,7 +8,6 @@ import (
 	"go/scanner"
 	"go/token"
 	"go/types"
-	"io/ioutil"
 	"path/filepath"
 	"strings"
 
@@ -188,7 +187,7 @@ func (c *Config) findOtherPackageFiles(filename, pkgName string) ([]string, erro
 	}
 
 	dir, file := filepath.Split(filename)
-	dents, err := ioutil.ReadDir(dir)
+	dents, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, fmt.Errorf("could not read dir: %v", err)
 	}

--- a/langserver/internal/godef/go/parser/interface.go
+++ b/langserver/internal/godef/go/parser/interface.go
@@ -10,7 +10,6 @@ import (
 	"bytes"
 	"errors"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -53,7 +52,7 @@ func readSource(filename string, src interface{}) ([]byte, error) {
 		}
 	}
 
-	return ioutil.ReadFile(filename)
+	return os.ReadFile(filename)
 }
 
 func (p *parser) parseEOF() error {

--- a/langserver/internal/godef/go/types/types_test.go
+++ b/langserver/internal/godef/go/types/types_test.go
@@ -3,7 +3,6 @@ package types
 import (
 	"bytes"
 	"flag"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -173,7 +172,7 @@ func TestStdLib(t *testing.T) {
 func TestCompile(t *testing.T) {
 	return // avoid usually
 	code, _ := translateSymbols(testCode)
-	err := ioutil.WriteFile("/tmp/testcode.go", code, 0666)
+	err := os.WriteFile("/tmp/testcode.go", code, 0666)
 	if err != nil {
 		t.Errorf("write file failed: %v", err)
 	}

--- a/langserver/internal/refs/refs_test.go
+++ b/langserver/internal/refs/refs_test.go
@@ -6,7 +6,6 @@ import (
 	"go/parser"
 	"go/token"
 	"go/types"
-	"io/ioutil"
 	"reflect"
 	"strconv"
 	"strings"
@@ -126,7 +125,7 @@ func TestParseFile(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.Filename, func(t *testing.T) {
-			cont, err := ioutil.ReadFile(c.Filename)
+			cont, err := os.ReadFile(c.Filename)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/langserver/langserver_test.go
+++ b/langserver/langserver_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"go/build"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -1412,7 +1411,7 @@ func lspTests(t testing.TB, ctx context.Context, h *LangHandler, c *jsonrpc2.Con
 		h.config.UseBinaryPkgCache = true
 
 		// Copy the VFS into a temp directory, which will be our $GOPATH.
-		tmpDir, err := ioutil.TempDir("", "godef-definition")
+		tmpDir, err := os.MkdirTemp("", "godef-definition")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/langserver/lint_test.go
+++ b/langserver/lint_test.go
@@ -3,7 +3,6 @@ package langserver
 import (
 	"context"
 	"go/build"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -175,7 +174,7 @@ func TestLinterGolint(t *testing.T) {
 }
 
 func linterTest(t *testing.T, files map[string]string, fn func(ctx context.Context, bctx *build.Context, rootURI lsp.DocumentURI)) {
-	tmpDir, err := ioutil.TempDir("", "langserver-go-linter")
+	tmpDir, err := os.MkdirTemp("", "langserver-go-linter")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -196,7 +195,7 @@ func linterTest(t *testing.T, files map[string]string, fn func(ctx context.Conte
 		if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
 			t.Fatal(err)
 		}
-		if err := ioutil.WriteFile(path, []byte(contents), 0600); err != nil {
+		if err := os.WriteFile(path, []byte(contents), 0600); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -173,7 +172,7 @@ func run(cfg langserver.Config) error {
 			handler := buildserver.NewHandler(cfg)
 			return jsonrpc2.AsyncHandler(jsonrpc2.HandlerWithError(handler.Handle)), handler
 		}
-		return langserver.NewHandler(cfg), ioutil.NopCloser(strings.NewReader(""))
+		return langserver.NewHandler(cfg), io.NopCloser(strings.NewReader(""))
 	}
 
 	switch *mode {

--- a/vfsutil/git_test.go
+++ b/vfsutil/git_test.go
@@ -1,7 +1,6 @@
 package vfsutil
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -46,7 +45,7 @@ func TestGitRepoVFS_subtree(t *testing.T) {
 func TestGitRepoVFS_cache(t *testing.T) {
 	// We use a different gitArchiveBasePath to ensure it is empty
 	{
-		d, err := ioutil.TempDir("", "vfsutil_test")
+		d, err := os.MkdirTemp("", "vfsutil_test")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -55,7 +54,7 @@ func TestGitRepoVFS_cache(t *testing.T) {
 		gitArchiveBasePath = d
 	}
 
-	cloneURL, err := ioutil.TempDir("", "vfsutil_test")
+	cloneURL, err := os.MkdirTemp("", "vfsutil_test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/vfsutil/github_archive_test.go
+++ b/vfsutil/github_archive_test.go
@@ -2,7 +2,6 @@ package vfsutil
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"testing"
 )
@@ -33,7 +32,7 @@ func TestGitHubRepoVFS(t *testing.T) {
 }
 
 func useEmptyArchiveCacheDir() func() {
-	d, err := ioutil.TempDir("", "vfsutil_test")
+	d, err := os.MkdirTemp("", "vfsutil_test")
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Removes usage of the deprecated ioutil package as described [here](https://golang.org/doc/go1.16#ioutil)

[_Created by Sourcegraph batch change `rslade/deprecate-ioutil`._](https://k8s.sgdev.org/users/rslade/batch-changes/deprecate-ioutil)