### PR TITLE
Fix Go import path for log15 package

### DIFF
--- a/buildserver/environment.go
+++ b/buildserver/environment.go
@@ -14,7 +14,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	log15 "gopkg.in/inconshreveable/log15.v2"
+	log15 "github.com/inconshreveable/log15"
 	yaml "gopkg.in/yaml.v2"
 
 	"github.com/sourcegraph/ctxvfs"

--- a/langserver/internal/refs/refs_test.go
+++ b/langserver/internal/refs/refs_test.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"testing"
 
-	_ "gopkg.in/inconshreveable/log15.v2"
+	_ "github.com/inconshreveable/log15"
 )
 
 func testConfig(fs *token.FileSet, pkgName string, files []*ast.File) *Config {


### PR DESCRIPTION
Rewrites Go import paths for the `log15` package from `gopkg.in/inconshreveable/log15.v2` to `github.com/inconshreveable/log15` using [Comby](https://comby.dev/)

[_Created by Sourcegraph batch change `christine/rewrite-log15-goimport`._](https://demo.sourcegraph.com/users/christine/batch-changes/rewrite-log15-goimport)